### PR TITLE
fix(ci): skip changelog check for dependabot; fix search-agent.yaml schema

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -9,6 +9,7 @@ jobs:
   changelog-check:
     name: Changelog Updated
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/examples/quickstart/search-agent.yaml
+++ b/examples/quickstart/search-agent.yaml
@@ -12,8 +12,6 @@ model:
 
 framework: langgraph
 
-entrypoint: agent.py
-
 tools:
   - ref: tools/mcp-filesystem
   - ref: tools/mcp-memory


### PR DESCRIPTION
## Summary

- **docs-check.yml**: Add `if: github.actor != 'dependabot[bot]'` to the `changelog-check` job — Dependabot PRs that bump `package.json` were triggering the CHANGELOG requirement even though dependency bumps don't warrant changelog entries
- **examples/quickstart/search-agent.yaml**: Remove `entrypoint` field — the agent schema has `additionalProperties: false` and `entrypoint` is not a defined property, causing the Validate YAML Examples CI job to fail on every PR

## Test plan
- [ ] Verify Validate YAML Examples passes (search-agent.yaml no longer has unknown field)
- [ ] Verify Changelog Updated is skipped (not failed) on Dependabot PRs
- [ ] Verify Changelog Updated still fires for normal contributor PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)