### PR TITLE
fix(e2e): raise expect timeout to 15s; seed auth token via addInitScript

### DIFF
--- a/dashboard/playwright.config.ts
+++ b/dashboard/playwright.config.ts
@@ -4,6 +4,10 @@ export default defineConfig({
   testDir: "./tests/e2e",
   timeout: 30_000,
   retries: 0,
+  expect: {
+    // CI Ubuntu runners are slower; auth+data render cycles can exceed 5s default.
+    timeout: 15_000,
+  },
   use: {
     baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL ?? "http://localhost:3001",
     headless: true,

--- a/dashboard/tests/e2e/fixtures.ts
+++ b/dashboard/tests/e2e/fixtures.ts
@@ -2,6 +2,12 @@ import { test as base, type Page } from "@playwright/test";
 
 /** Seed localStorage with a fake token and mock /me endpoint so route guards pass. */
 async function setupAuth(page: Page) {
+  // Inject the token before the first navigation so RequireAuth never sees an
+  // unauthenticated state — avoids a /login round-trip per test.
+  await page.addInitScript(() => {
+    window.localStorage.setItem("ag-token", "test-token");
+  });
+
   // Mock /me to return a valid user
   await page.route("**/api/v1/auth/me", (route) =>
     route.fulfill({
@@ -37,10 +43,6 @@ async function setupAuth(page: Page) {
       }),
     }),
   );
-
-  // Set token before navigating
-  await page.goto("/login");
-  await page.evaluate(() => localStorage.setItem("ag-token", "test-token"));
 }
 
 /** Extended test fixture that pre-authenticates every test. */


### PR DESCRIPTION
## Summary
- After `@tanstack/react-query` bumped 5.90→5.99, the auth+data render cycle on slow Ubuntu CI runners started consistently exceeding Playwright's default 5-second assertion timeout, causing ~124/143 mocked E2E tests to fail with "element not found"
- Raises `expect.timeout` to 15 000ms in `playwright.config.ts` to give CI headroom for two async render cycles (auth fetch → RequireAuth re-render → data fetch → content render)
- Replaces `page.goto("/login") + page.evaluate(setItem)` in `setupAuth` with `page.addInitScript()` — token injected before the first navigation, removing one full page-load per test

## Changes
- `dashboard/playwright.config.ts` — add `expect: { timeout: 15_000 }`
- `dashboard/tests/e2e/fixtures.ts` — replace goto/evaluate auth setup with `addInitScript`

## Test plan
- [x] All 143 mocked E2E tests pass locally after this change (2 runs confirmed)
- [ ] Verify CI E2E Tests (Mocked) job goes green after merge

## Related issues
Fixes E2E failures in https://github.com/agentbreeder/agentbreeder/actions/runs/24965956645
