### PR TITLE
feat(providers): generic OpenAI-compatible provider + 9-preset catalog (Track F)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+### Added
+- **Generic OpenAI-compatible provider + 9-preset catalog** (#160): `engine/providers/openai_compatible.py` parameterised by `base_url`/`api_key_env`/`default_headers` replaces what would have been 9 hand-written classes. New `engine/providers/catalog.yaml` ships nvidia, openrouter, moonshot (Kimi K2), groq, together, fireworks, deepinfra, cerebras, hyperbolic — merged with `~/.agentbreeder/providers.local.yaml` overrides at load time. New CLI: `agentbreeder provider list/add/remove/test/publish`. New API route `GET /api/v1/providers/catalog`. Dashboard `/models` page lists catalog presets with a Configure stub. `model.primary: nvidia/<model>` resolves through the existing engine path.
+
 ### Fixed
 - **Integration tests / Docker builds**: removed `@agentbreeder/aps-client` npm dep (package not yet published); vendor `aps-client.ts` source directly into Node.js Docker build context so `npm install` no longer fails with 404
 - **ESLint errors**: suppressed `react-hooks/set-state-in-effect` errors in `gateway.tsx`, `incidents.tsx`, `prompt-builder.tsx`; fixed root cause in `login.tsx` by initializing `mounted=true` (removes invisible form on first render — fixes E2E login tests)

--- a/api/routes/providers.py
+++ b/api/routes/providers.py
@@ -102,6 +102,38 @@ async def detect_ollama(
     )
 
 
+@router.get("/catalog", response_model=ApiResponse[list[dict]])
+async def list_catalog_providers(
+    _user: User = Depends(get_current_user),
+) -> ApiResponse[list[dict]]:
+    """List built-in + user-local OpenAI-compatible catalog presets.
+
+    Used by the dashboard ``/models`` page to show presets with a Configure
+    button. Each entry is read-only — adding a user-local entry happens via the
+    CLI for now (``agentbreeder provider add … --type openai_compatible``).
+
+    See ``engine/providers/catalog.yaml`` for the source of truth.
+    """
+    from engine.providers.catalog import list_entries
+
+    entries = list_entries()
+    payload = [
+        {
+            "name": name,
+            "type": entry.type,
+            "base_url": str(entry.base_url),
+            "api_key_env": entry.api_key_env,
+            "default_headers": entry.default_headers,
+            "docs": str(entry.docs) if entry.docs else None,
+            "discovery": entry.discovery,
+            "notable_models": entry.notable_models,
+            "source": entry.source,
+        }
+        for name, entry in sorted(entries.items())
+    ]
+    return ApiResponse(data=payload)
+
+
 @router.get("", response_model=ApiResponse[list[ProviderResponse]])
 async def list_providers(
     provider_type: ProviderType | None = Query(None),

--- a/cli/commands/provider.py
+++ b/cli/commands/provider.py
@@ -1,18 +1,30 @@
 """agentbreeder provider — manage LLM provider connections and API keys.
 
 Subcommands:
-    agentbreeder provider list                  — list configured providers
-    agentbreeder provider add <type>            — add a new provider (interactive)
+    agentbreeder provider list                  — list catalog + configured providers
+    agentbreeder provider add <name>            — add a provider (legacy types or
+                                                  ``--type openai_compatible``)
     agentbreeder provider test <name>           — test provider connection
     agentbreeder provider models <name>         — list models from a provider
     agentbreeder provider remove <name>         — remove a provider
     agentbreeder provider disable <name>        — disable a provider without removing
     agentbreeder provider enable <name>         — re-enable a disabled provider
+    agentbreeder provider publish <name>        — promote a user-local entry to a
+                                                  PR against the upstream catalog
+
+For the OpenAI-compatible catalog (Nvidia, Groq, Together, Fireworks, …), use
+``--type openai_compatible``:
+
+    agentbreeder provider add my-vllm \\
+      --type openai_compatible \\
+      --base-url https://vllm.internal.company.com/v1 \\
+      --api-key-env COMPANY_VLLM_KEY
 """
 
 from __future__ import annotations
 
 import json
+import os
 import platform
 import sys
 import time
@@ -206,14 +218,37 @@ provider_app = typer.Typer(
 def provider_list(
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
 ) -> None:
-    """List all configured providers."""
+    """List all configured providers and catalog presets."""
+    from engine.providers.catalog import list_entries
+
     providers = _load_providers()
+    catalog_entries = list_entries()
 
     if json_output:
-        sys.stdout.write(json.dumps(list(providers.values()), indent=2) + "\n")
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "configured": list(providers.values()),
+                    "catalog": [
+                        {
+                            "name": name,
+                            "type": entry.type,
+                            "base_url": str(entry.base_url),
+                            "api_key_env": entry.api_key_env,
+                            "source": entry.source,
+                            "configured": bool(os.environ.get(entry.api_key_env)),
+                            "docs": str(entry.docs) if entry.docs else None,
+                        }
+                        for name, entry in sorted(catalog_entries.items())
+                    ],
+                },
+                indent=2,
+            )
+            + "\n"
+        )
         return
 
-    if not providers:
+    if not providers and not catalog_entries:
         console.print()
         console.print(
             Panel(
@@ -229,29 +264,50 @@ def provider_list(
         console.print()
         return
 
-    table = Table(title="Configured Providers")
-    table.add_column("Name", style="cyan")
-    table.add_column("Type", style="yellow")
-    table.add_column("Status", style="green")
-    table.add_column("Models")
-    table.add_column("API Key", style="dim")
-    table.add_column("Base URL", style="dim")
+    if providers:
+        table = Table(title="Configured Providers")
+        table.add_column("Name", style="cyan")
+        table.add_column("Type", style="yellow")
+        table.add_column("Status", style="green")
+        table.add_column("Models")
+        table.add_column("API Key", style="dim")
+        table.add_column("Base URL", style="dim")
 
-    for p in providers.values():
-        status = p.get("status", "active")
-        status_style = {"active": "green", "disabled": "yellow", "error": "red"}.get(status, "dim")
+        for p in providers.values():
+            status = p.get("status", "active")
+            status_style = {"active": "green", "disabled": "yellow", "error": "red"}.get(
+                status, "dim"
+            )
+            table.add_row(
+                p.get("name", ""),
+                p.get("provider_type", ""),
+                f"[{status_style}]{status}[/{status_style}]",
+                str(p.get("model_count", 0)),
+                p.get("masked_key", "—"),
+                p.get("base_url", "") or "—",
+            )
+        console.print()
+        console.print(table)
 
-        table.add_row(
-            p.get("name", ""),
-            p.get("provider_type", ""),
-            f"[{status_style}]{status}[/{status_style}]",
-            str(p.get("model_count", 0)),
-            p.get("masked_key", "—"),
-            p.get("base_url", "") or "—",
-        )
+    if catalog_entries:
+        catalog_table = Table(title="OpenAI-Compatible Catalog")
+        catalog_table.add_column("Name", style="cyan")
+        catalog_table.add_column("Source", style="yellow")
+        catalog_table.add_column("Configured", style="green")
+        catalog_table.add_column("API Key Env", style="dim")
+        catalog_table.add_column("Base URL", style="dim")
 
-    console.print()
-    console.print(table)
+        for name, entry in sorted(catalog_entries.items()):
+            configured = bool(os.environ.get(entry.api_key_env))
+            catalog_table.add_row(
+                name,
+                entry.source,
+                "[green]yes[/green]" if configured else "[dim]no[/dim]",
+                entry.api_key_env,
+                str(entry.base_url),
+            )
+        console.print()
+        console.print(catalog_table)
     console.print()
 
 
@@ -259,13 +315,45 @@ def provider_list(
 def provider_add(
     provider_type: str = typer.Argument(
         ...,
-        help="Provider type: openai, anthropic, google, ollama, litellm, openrouter",
+        help=(
+            "Either a built-in type (openai, anthropic, google, ollama, "
+            "litellm, openrouter) or a catalog name (with --type openai_compatible)"
+        ),
     ),
     api_key: str | None = typer.Option(None, "--api-key", help="API key (non-interactive)"),
     base_url: str | None = typer.Option(None, "--base-url", help="Custom base URL"),
+    api_key_env: str | None = typer.Option(
+        None,
+        "--api-key-env",
+        help="Env var name for the API key (used with --type openai_compatible)",
+    ),
+    type_: str | None = typer.Option(
+        None,
+        "--type",
+        help="Set to 'openai_compatible' to add a generic OpenAI-compatible provider",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
 ) -> None:
-    """Add and configure a new LLM provider."""
+    """Add and configure a new LLM provider.
+
+    Two modes:
+
+    1. **Built-in type** — ``provider add openai`` runs the interactive wizard
+       for one of the hand-written providers.
+    2. **Catalog (OpenAI-compatible)** — ``provider add my-vllm
+       --type openai_compatible --base-url URL --api-key-env ENV`` writes a new
+       entry to ``~/.agentbreeder/providers.local.yaml`` so it can be referenced
+       in ``agent.yaml`` as ``my-vllm/<model>``.
+    """
+    if type_ == "openai_compatible":
+        _add_openai_compatible(
+            name=provider_type,
+            base_url=base_url,
+            api_key_env=api_key_env,
+            json_output=json_output,
+        )
+        return
+
     provider_type = provider_type.lower()
 
     if provider_type not in PROVIDER_TYPES:
@@ -453,10 +541,33 @@ def provider_add(
 
 @provider_app.command(name="test")
 def provider_test(
-    name: str = typer.Argument(..., help="Provider to test: openai, anthropic, etc."),
+    name: str = typer.Argument(..., help="Provider to test"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
 ) -> None:
-    """Test a provider connection and verify the API key works."""
+    """Test a provider connection and verify the API key works.
+
+    For catalog providers (Nvidia, Groq, …) this hits ``GET /models`` against
+    the configured ``base_url`` using the API key from the entry's
+    ``api_key_env``. For legacy interactive providers it falls back to the
+    simulated check.
+    """
+    from engine.providers.catalog import get_entry
+
+    catalog_entry = get_entry(name)
+    if catalog_entry is not None:
+        result = _test_catalog_provider(name, catalog_entry, json_output)
+        if json_output:
+            sys.stdout.write(json.dumps(result, indent=2) + "\n")
+            return
+        if result["success"]:
+            console.print(f"  [green]✓[/green] {name} is healthy")
+            console.print(f"    Models discovered: {result['model_count']}")
+        else:
+            console.print(f"  [red]✗[/red] {name}: {result['error']}")
+            raise typer.Exit(code=1)
+        console.print()
+        return
+
     name = name.lower()
     providers = _load_providers()
 
@@ -534,7 +645,39 @@ def provider_remove(
     name: str = typer.Argument(..., help="Provider to remove"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
 ) -> None:
-    """Remove a provider and its API key."""
+    """Remove a provider and its API key.
+
+    Looks first in the user-local catalog (added via
+    ``provider add ... --type openai_compatible``); falls back to the legacy
+    interactive provider registry for built-in types.
+    """
+    # Catalog-style user-local entry takes precedence
+    from engine.providers.catalog import (
+        load_user_local,
+        reset_cache,
+        write_user_local,
+    )
+
+    user_catalog = load_user_local()
+    if name in user_catalog.providers:
+        if not json_output:
+            confirm = (
+                console.input(f"  [bold]Remove user-local catalog entry '{name}'? (y/N): [/bold]")
+                .strip()
+                .lower()
+            )
+            if confirm != "y":
+                console.print("  [dim]Cancelled.[/dim]")
+                raise typer.Exit(code=0)
+        del user_catalog.providers[name]
+        write_user_local(user_catalog)
+        reset_cache()
+        if json_output:
+            sys.stdout.write(json.dumps({"removed": name, "source": "user-local"}) + "\n")
+            return
+        console.print(f"  [green]✓[/green] Removed user-local entry '{name}'\n")
+        return
+
     name = name.lower()
     providers = _load_providers()
 
@@ -622,3 +765,206 @@ def provider_enable(
 
     console.print(f"  [green]✓[/green] {providers[name]['name']} re-enabled")
     console.print()
+
+
+# ─── OpenAI-compatible catalog helpers ─────────────────────────────────────
+
+
+def _add_openai_compatible(
+    *,
+    name: str,
+    base_url: str | None,
+    api_key_env: str | None,
+    json_output: bool,
+) -> None:
+    """Add a user-local OpenAI-compatible catalog entry."""
+    from engine.providers.catalog import (
+        CatalogEntry,
+        CatalogError,
+        load_user_local,
+        write_user_local,
+    )
+
+    if not base_url:
+        console.print("[red]--base-url is required for --type openai_compatible[/red]")
+        raise typer.Exit(code=1)
+    if not api_key_env:
+        console.print("[red]--api-key-env is required for --type openai_compatible[/red]")
+        raise typer.Exit(code=1)
+
+    try:
+        entry = CatalogEntry(
+            type="openai_compatible",
+            base_url=base_url,
+            api_key_env=api_key_env,
+            source="user-local",
+        )
+    except Exception as exc:  # pydantic ValidationError
+        console.print(f"[red]Invalid catalog entry: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+    try:
+        catalog = load_user_local()
+    except CatalogError as exc:
+        console.print(f"[red]Could not load user-local catalog: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+    catalog.providers[name] = entry
+    path = write_user_local(catalog)
+
+    if json_output:
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "name": name,
+                    "type": "openai_compatible",
+                    "base_url": str(entry.base_url),
+                    "api_key_env": api_key_env,
+                    "source": "user-local",
+                    "file": str(path),
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        return
+
+    console.print()
+    console.print(
+        Panel(
+            f"  [green]✓[/green] Added user-local provider [cyan]{name}[/cyan]\n\n"
+            f"  Base URL:    [dim]{entry.base_url}[/dim]\n"
+            f"  API key env: [dim]{api_key_env}[/dim]\n"
+            f"  File:        [dim]{path}[/dim]\n\n"
+            f"  Use in agent.yaml:\n"
+            f"    [dim]model:\n"
+            f"      primary: {name}/<model-id>[/dim]\n\n"
+            f"  Test with: [bold cyan]agentbreeder provider test {name}[/bold cyan]\n"
+            f"  Promote to upstream catalog: "
+            f"[bold cyan]agentbreeder provider publish {name}[/bold cyan]",
+            border_style="green",
+            padding=(1, 2),
+        )
+    )
+    console.print()
+
+
+def _test_catalog_provider(
+    name: str,
+    entry: object,  # CatalogEntry — typed loosely to avoid import at module load
+    json_output: bool,
+) -> dict[str, object]:
+    """Run ``GET /models`` against a catalog provider and report results.
+
+    Mocks of ``httpx.AsyncClient`` are honoured — see tests.
+    """
+    import asyncio
+
+    from engine.providers.base import (
+        AuthenticationError,
+        ProviderError,
+    )
+    from engine.providers.openai_compatible import from_catalog
+
+    if not json_output:
+        console.print(f"\n  [dim]Testing {name}...[/dim]")
+
+    api_key_env = getattr(entry, "api_key_env", "")
+    if api_key_env and not os.environ.get(api_key_env):
+        return {
+            "success": False,
+            "model_count": 0,
+            "error": f"{api_key_env} not set in environment",
+        }
+
+    async def _run() -> dict[str, object]:
+        try:
+            provider = from_catalog(name)
+        except (KeyError, AuthenticationError) as exc:
+            return {"success": False, "model_count": 0, "error": str(exc)}
+        try:
+            models = await provider.list_models()
+            return {"success": True, "model_count": len(models), "error": None}
+        except ProviderError as exc:
+            return {"success": False, "model_count": 0, "error": str(exc)}
+        finally:
+            await provider.close()
+
+    return asyncio.run(_run())
+
+
+@provider_app.command(name="publish")
+def provider_publish(
+    name: str = typer.Argument(..., help="User-local catalog name to promote"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+) -> None:
+    """Promote a user-local provider entry to a PR against the upstream catalog.
+
+    Currently this prints the equivalent ``catalog.yaml`` patch and exits
+    non-zero — actual PR opening will land alongside ``cli/commands/git.py``
+    integration. Until then, copy the printed YAML into a PR by hand.
+    """
+    from engine.providers.catalog import load_user_local
+
+    catalog = load_user_local()
+    entry = catalog.providers.get(name)
+    if entry is None:
+        console.print(
+            f"[red]No user-local provider named '{name}'.[/red] "
+            f"Add one first with [bold]agentbreeder provider add[/bold]."
+        )
+        raise typer.Exit(code=1)
+
+    payload = {
+        name: {
+            "type": entry.type,
+            "base_url": str(entry.base_url),
+            "api_key_env": entry.api_key_env,
+        }
+    }
+    if entry.default_headers:
+        payload[name]["default_headers"] = entry.default_headers  # type: ignore[assignment]
+    if entry.docs:
+        payload[name]["docs"] = str(entry.docs)
+    if entry.notable_models:
+        payload[name]["notable_models"] = entry.notable_models  # type: ignore[assignment]
+
+    import yaml
+
+    snippet = yaml.safe_dump({"providers": payload}, sort_keys=False)
+
+    if json_output:
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "status": "not_implemented",
+                    "name": name,
+                    "snippet": snippet,
+                    "next_steps": [
+                        "Append snippet to engine/providers/catalog.yaml",
+                        "Open a PR against agentbreeder/agentbreeder",
+                    ],
+                },
+                indent=2,
+            )
+            + "\n"
+        )
+        raise typer.Exit(code=2)
+
+    console.print()
+    console.print(
+        Panel(
+            "[yellow]provider publish[/yellow] would open a PR against "
+            "[cyan]engine/providers/catalog.yaml[/cyan].\n\n"
+            "  [dim]Automatic PR opening is not yet implemented "
+            "(TODO: integrate with cli/commands/git.py).[/dim]\n\n"
+            "  [bold]Patch to apply manually:[/bold]\n\n"
+            f"[dim]{snippet}[/dim]\n"
+            "  Then submit a PR to [cyan]https://github.com/agentbreeder/agentbreeder[/cyan].",
+            title=f"Promote '{name}' to upstream",
+            border_style="yellow",
+            padding=(1, 2),
+        )
+    )
+    console.print()
+    raise typer.Exit(code=2)

--- a/dashboard/src/components/provider-catalog.tsx
+++ b/dashboard/src/components/provider-catalog.tsx
@@ -1,0 +1,129 @@
+/**
+ * Provider catalog — surfaces the OpenAI-compatible presets shipped in
+ * `engine/providers/catalog.yaml` (Nvidia, Groq, Together, OpenRouter, …) so
+ * users can connect a provider with a single click.
+ *
+ * Backed by `GET /api/v1/providers/catalog` (Track F / issue #160). The
+ * "Configure" button currently surfaces the env-var that needs to be set —
+ * wiring it to a secrets-entry modal lands with Track K.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { ExternalLink, Plug, Server } from "lucide-react";
+
+import { api, type CatalogProvider } from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+interface ProviderCatalogProps {
+  onConfigure?: (provider: CatalogProvider) => void;
+}
+
+export function ProviderCatalog({ onConfigure }: ProviderCatalogProps) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["providers", "catalog"],
+    queryFn: () => api.providers.catalog(),
+    staleTime: 60_000,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="rounded-lg border border-border bg-muted/20 p-4 text-xs text-muted-foreground">
+        Loading provider catalog...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-xs text-destructive">
+        Failed to load catalog: {(error as Error).message}
+      </div>
+    );
+  }
+
+  const presets = data?.data ?? [];
+  if (presets.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-card">
+      <div className="flex items-center justify-between border-b border-border/50 px-4 py-3">
+        <div className="flex items-center gap-2">
+          <Server className="size-3.5 text-muted-foreground" />
+          <h3 className="text-sm font-semibold">OpenAI-Compatible Catalog</h3>
+          <Badge variant="outline" className="text-[10px]">
+            {presets.length} providers
+          </Badge>
+        </div>
+        <span className="text-[11px] text-muted-foreground">
+          Click Configure to connect — keys live in your environment, never the database
+        </span>
+      </div>
+
+      <div className="divide-y divide-border/50">
+        {presets.map((preset) => (
+          <CatalogRow
+            key={preset.name}
+            preset={preset}
+            onConfigure={onConfigure}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CatalogRow({
+  preset,
+  onConfigure,
+}: {
+  preset: CatalogProvider;
+  onConfigure?: (preset: CatalogProvider) => void;
+}) {
+  const isUserLocal = preset.source === "user-local";
+
+  return (
+    <div className="flex items-center gap-4 px-4 py-3">
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <div className="font-medium text-sm capitalize">{preset.name}</div>
+        {isUserLocal && (
+          <Badge variant="secondary" className="text-[10px]">
+            user-local
+          </Badge>
+        )}
+        <span className="truncate text-[11px] text-muted-foreground">
+          {preset.base_url}
+        </span>
+      </div>
+
+      <code className="rounded bg-muted/50 px-2 py-0.5 text-[10px] text-muted-foreground">
+        {preset.api_key_env}
+      </code>
+
+      {preset.docs && (
+        <a
+          href={preset.docs}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground"
+        >
+          Docs
+          <ExternalLink className="size-3" />
+        </a>
+      )}
+
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={() => onConfigure?.(preset)}
+        className="h-7 text-xs"
+        data-testid={`catalog-configure-${preset.name}`}
+      >
+        <Plug className="mr-1 size-3" />
+        Configure
+      </Button>
+    </div>
+  );
+}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -253,6 +253,25 @@ export interface Provider {
   updated_at: string;
 }
 
+/**
+ * A preset entry in the OpenAI-compatible provider catalog (Track F / issue #160).
+ *
+ * These are read from `engine/providers/catalog.yaml` plus user-local overrides
+ * at `~/.agentbreeder/providers.local.yaml`. The dashboard surfaces them as a
+ * "Configure" list so users can connect a provider in one click.
+ */
+export interface CatalogProvider {
+  name: string;
+  type: "openai_compatible" | "gateway";
+  base_url: string;
+  api_key_env: string;
+  default_headers: Record<string, string>;
+  docs: string | null;
+  discovery: string | null;
+  notable_models: string[];
+  source: "builtin" | "user-local" | "workspace";
+}
+
 export interface ProviderTestResult {
   success: boolean;
   latency_ms: number | null;
@@ -1279,6 +1298,7 @@ export const api = {
       request<ProviderDiscoverResult>(`/providers/${id}/discover`, {
         method: "POST",
       }),
+    catalog: () => request<CatalogProvider[]>("/providers/catalog"),
   },
   mcpServers: {
     list: (params?: { page?: number; per_page?: number }) => {

--- a/dashboard/src/pages/models.tsx
+++ b/dashboard/src/pages/models.tsx
@@ -35,6 +35,7 @@ import { SortableColumnHeader } from "@/components/ui/sortable-header";
 import { SkeletonTableRows } from "@/components/ui/skeleton-table";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ColumnToggle, type ColumnDefinition } from "@/components/ui/column-toggle";
+import { ProviderCatalog } from "@/components/provider-catalog";
 
 const PROVIDER_COLORS: Record<string, string> = {
   anthropic: "bg-orange-500/10 text-orange-600 dark:text-orange-400 border-orange-500/20",
@@ -535,6 +536,13 @@ export default function ModelsPage() {
           />
           <CreateModelDialog />
         </div>
+      </div>
+
+      {/* OpenAI-compatible provider catalog (Track F / issue #160).
+          Shows the built-in presets shipped in `engine/providers/catalog.yaml`
+          plus any user-local entries from `~/.agentbreeder/providers.local.yaml`. */}
+      <div className="mb-4">
+        <ProviderCatalog />
       </div>
 
       {/* Provider filter tabs */}

--- a/dashboard/tests/e2e-docker/api_smoke.sh
+++ b/dashboard/tests/e2e-docker/api_smoke.sh
@@ -32,7 +32,7 @@ curl -sf "$API/health" >/dev/null \
 
 echo
 echo "════ Auth flow ════"
-EMAIL="e2e-$(date +%s%N | head -c12)@test.local"
+EMAIL="e2e-$(date +%s%N | head -c12)@example.com"
 PASSWORD="Test1234!"
 
 REG_BODY=$(printf '{"email":"%s","password":"%s","name":"E2E"}' "$EMAIL" "$PASSWORD")

--- a/engine/providers/catalog.py
+++ b/engine/providers/catalog.py
@@ -1,0 +1,212 @@
+"""Provider catalog — load and merge OpenAI-compatible provider presets.
+
+The catalog has two layers:
+
+1. **Built-in presets** — shipped in ``engine/providers/catalog.yaml``. Curated
+   list of public OpenAI-compatible providers (Nvidia, Groq, OpenRouter, …).
+2. **User-local overrides** — ``~/.agentbreeder/providers.local.yaml``. Lets a
+   developer register private/internal providers (self-hosted vLLM, etc.)
+   without modifying the package.
+
+User-local entries take precedence over built-in ones with the same name. This
+mirrors the way ``kubeconfig`` merges contexts.
+
+TODO(track-a): workspace-scoped catalogs (``<workspace>/providers.yaml``) will
+land with Track A. The merge order will then be: built-in < user-local <
+workspace.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import cache
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, Field, HttpUrl, ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+# ─── Paths ─────────────────────────────────────────────────────────────────
+
+CATALOG_PATH = Path(__file__).parent / "catalog.yaml"
+USER_LOCAL_PATH = Path.home() / ".agentbreeder" / "providers.local.yaml"
+
+
+# ─── Schema ────────────────────────────────────────────────────────────────
+
+
+CatalogProviderType = Literal["openai_compatible", "gateway"]
+
+
+class CatalogEntry(BaseModel):
+    """A single provider entry in the catalog.
+
+    All built-in entries must declare ``type``, ``base_url``, and ``api_key_env``.
+    Anything else (``docs``, ``default_headers``, ``notable_models``) is optional
+    metadata used by the dashboard, CLI ``provider list``, and discovery.
+    """
+
+    type: CatalogProviderType = "openai_compatible"
+    base_url: HttpUrl
+    api_key_env: str = Field(min_length=1)
+    default_headers: dict[str, str] = Field(default_factory=dict)
+    docs: HttpUrl | None = None
+    discovery: str | None = None
+    notable_models: list[str] = Field(default_factory=list)
+    # Source — set by loader, not read from YAML
+    source: Literal["builtin", "user-local", "workspace"] = "builtin"
+
+
+class Catalog(BaseModel):
+    """Top-level catalog document."""
+
+    version: int = 1
+    providers: dict[str, CatalogEntry] = Field(default_factory=dict)
+
+
+class CatalogError(Exception):
+    """Raised when the catalog YAML is malformed."""
+
+
+# ─── Loader ────────────────────────────────────────────────────────────────
+
+
+def _load_yaml(path: Path) -> dict[str, object]:
+    """Read a YAML file and return its top-level dict, or {} if absent."""
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    except yaml.YAMLError as exc:
+        msg = f"Failed to parse catalog YAML at {path}: {exc}"
+        raise CatalogError(msg) from exc
+    if not isinstance(data, dict):
+        msg = f"Catalog at {path} must be a YAML mapping, got {type(data).__name__}"
+        raise CatalogError(msg)
+    return data
+
+
+def _parse_catalog(data: dict[str, object], source: str) -> Catalog:
+    """Parse a raw catalog dict and stamp each entry with its source."""
+    try:
+        catalog = Catalog.model_validate(data)
+    except ValidationError as exc:
+        msg = f"Invalid catalog ({source}): {exc}"
+        raise CatalogError(msg) from exc
+    # Stamp source on every entry
+    for entry in catalog.providers.values():
+        entry.source = source  # type: ignore[assignment]
+    return catalog
+
+
+@cache
+def load_catalog() -> Catalog:
+    """Load + merge the built-in catalog with the user-local overrides.
+
+    The result is cached for the process lifetime. Tests should call
+    :func:`reset_cache` between assertions if they mutate paths.
+    """
+    builtin = _parse_catalog(_load_yaml(CATALOG_PATH), source="builtin")
+
+    if USER_LOCAL_PATH.exists():
+        try:
+            user_local = _parse_catalog(_load_yaml(USER_LOCAL_PATH), source="user-local")
+        except CatalogError:
+            logger.exception(
+                "Skipping user-local catalog at %s due to validation errors",
+                USER_LOCAL_PATH,
+            )
+            user_local = Catalog()
+    else:
+        user_local = Catalog()
+
+    merged = Catalog(version=builtin.version, providers=dict(builtin.providers))
+    for name, entry in user_local.providers.items():
+        merged.providers[name] = entry  # user-local wins on name collision
+    return merged
+
+
+def reset_cache() -> None:
+    """Clear the catalog cache. Used by tests."""
+    load_catalog.cache_clear()
+
+
+# ─── User-local mutations ──────────────────────────────────────────────────
+
+
+def write_user_local(catalog: Catalog) -> Path:
+    """Persist a catalog to the user-local override file.
+
+    The file is created with ``0600`` permissions (best-effort — Windows ignores).
+    """
+    USER_LOCAL_PATH.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": catalog.version,
+        "providers": {
+            name: {
+                "type": entry.type,
+                "base_url": str(entry.base_url),
+                "api_key_env": entry.api_key_env,
+                **({"default_headers": entry.default_headers} if entry.default_headers else {}),
+                **({"docs": str(entry.docs)} if entry.docs else {}),
+                **({"discovery": entry.discovery} if entry.discovery else {}),
+                **({"notable_models": entry.notable_models} if entry.notable_models else {}),
+            }
+            for name, entry in catalog.providers.items()
+            if entry.source == "user-local"
+        },
+    }
+    with USER_LOCAL_PATH.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(payload, fh, sort_keys=False)
+    try:
+        USER_LOCAL_PATH.chmod(0o600)
+    except OSError:
+        # Windows or unusual filesystems — ignore.
+        logger.debug("Could not chmod %s to 0600", USER_LOCAL_PATH)
+    reset_cache()
+    return USER_LOCAL_PATH
+
+
+def load_user_local() -> Catalog:
+    """Load just the user-local overrides (does not merge with built-in)."""
+    return _parse_catalog(_load_yaml(USER_LOCAL_PATH), source="user-local")
+
+
+# ─── Public lookup helpers ─────────────────────────────────────────────────
+
+
+def get_entry(name: str) -> CatalogEntry | None:
+    """Return the catalog entry for a provider name, or None if unknown."""
+    return load_catalog().providers.get(name)
+
+
+def list_entries() -> dict[str, CatalogEntry]:
+    """Return all catalog entries (built-in + user-local merged)."""
+    return dict(load_catalog().providers)
+
+
+def parse_model_ref(ref: str) -> tuple[str, str] | None:
+    """Parse a ``<provider>/<model>`` reference against the catalog.
+
+    Returns ``(provider_name, model_id)`` if ``provider_name`` is in the
+    catalog, else ``None``. The model_id may itself contain ``/`` (e.g.
+    ``meta/llama-3.1-405b``) — only the first segment is matched as provider.
+
+    Examples:
+        >>> parse_model_ref("nvidia/meta-llama-3.1-405b-instruct")
+        ("nvidia", "meta-llama-3.1-405b-instruct")
+        >>> parse_model_ref("gpt-4o")  # no slash, not catalog
+        None
+    """
+    if "/" not in ref:
+        return None
+    provider, _, model = ref.partition("/")
+    if not provider or not model:
+        return None
+    if get_entry(provider) is None:
+        return None
+    return provider, model

--- a/engine/providers/catalog.yaml
+++ b/engine/providers/catalog.yaml
@@ -1,0 +1,62 @@
+# AgentBreeder provider catalog
+#
+# Built-in OpenAI-compatible providers. Each entry parameterises the generic
+# OpenAICompatibleProvider with a base_url, api_key_env, and optional headers.
+#
+# Adding a new built-in preset: open a PR that appends an entry below. Most
+# providers ship the OpenAI Chat Completions shape, so no engine code changes
+# are needed.
+#
+# User-local overrides live in `~/.agentbreeder/providers.local.yaml` and are
+# merged on top of this catalog at load time.
+#
+# TODO(track-a): workspace-scoped catalogs (`<workspace>/providers.yaml`) ship
+# with Track A — the workspace primitive.
+version: 1
+providers:
+  nvidia:
+    type: openai_compatible
+    base_url: https://integrate.api.nvidia.com/v1
+    api_key_env: NVIDIA_API_KEY
+    docs: https://build.nvidia.com/models
+    discovery: openai-models-list
+  openrouter:
+    type: openai_compatible
+    base_url: https://openrouter.ai/api/v1
+    api_key_env: OPENROUTER_API_KEY
+    default_headers:
+      HTTP-Referer: https://agentbreeder.io
+      X-Title: AgentBreeder
+    docs: https://openrouter.ai/models
+    discovery: openai-models-list
+  moonshot:
+    type: openai_compatible
+    base_url: https://api.moonshot.cn/v1
+    api_key_env: MOONSHOT_API_KEY
+    notable_models:
+      - moonshot-v1-128k
+      - kimi-k2-instruct
+  groq:
+    type: openai_compatible
+    base_url: https://api.groq.com/openai/v1
+    api_key_env: GROQ_API_KEY
+  together:
+    type: openai_compatible
+    base_url: https://api.together.xyz/v1
+    api_key_env: TOGETHER_API_KEY
+  fireworks:
+    type: openai_compatible
+    base_url: https://api.fireworks.ai/inference/v1
+    api_key_env: FIREWORKS_API_KEY
+  deepinfra:
+    type: openai_compatible
+    base_url: https://api.deepinfra.com/v1/openai
+    api_key_env: DEEPINFRA_API_KEY
+  cerebras:
+    type: openai_compatible
+    base_url: https://api.cerebras.ai/v1
+    api_key_env: CEREBRAS_API_KEY
+  hyperbolic:
+    type: openai_compatible
+    base_url: https://api.hyperbolic.xyz/v1
+    api_key_env: HYPERBOLIC_API_KEY

--- a/engine/providers/openai_compatible.py
+++ b/engine/providers/openai_compatible.py
@@ -1,0 +1,360 @@
+"""Generic OpenAI-compatible provider.
+
+Most "new" LLM providers (Nvidia NIM, Groq, Together, Fireworks, DeepInfra,
+Cerebras, Hyperbolic, Moonshot/Kimi, OpenRouter, …) speak the **OpenAI Chat
+Completions** wire format. The only real differences are:
+
+- ``base_url`` (e.g. ``https://api.groq.com/openai/v1``)
+- ``api_key_env`` (e.g. ``GROQ_API_KEY``)
+- ``default_headers`` (OpenRouter wants ``HTTP-Referer`` + ``X-Title``)
+
+This class is parameterised by those three things and reuses the same wire
+logic as :class:`engine.providers.openai_provider.OpenAIProvider` — so adding a
+new provider is a YAML edit to ``catalog.yaml``, not a new Python class.
+
+The hand-written ``OpenAIProvider`` stays in place because it's the canonical
+default for ``provider_type=openai`` and serves as the implementation
+reference. This class is *additive*.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+
+from engine.providers.base import (
+    AuthenticationError,
+    ModelNotFoundError,
+    ProviderBase,
+    ProviderError,
+    RateLimitError,
+)
+from engine.providers.models import (
+    GenerateResult,
+    ModelInfo,
+    ProviderConfig,
+    StreamChunk,
+    ToolCall,
+    ToolDefinition,
+    UsageInfo,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAICompatibleProvider(ProviderBase):
+    """Provider for any OpenAI-compatible chat completions endpoint.
+
+    Construct via :class:`engine.providers.models.ProviderConfig` plus three
+    catalog-derived fields surfaced as kwargs:
+
+    Args:
+        config: Standard provider config — must set ``base_url``.
+        provider_name: Catalog name (e.g. ``"nvidia"``). Stamped on results.
+        api_key_env: Env var name to read the API key from when
+            ``config.api_key`` is unset (e.g. ``"NVIDIA_API_KEY"``).
+        default_headers: Extra headers to send on every request (e.g.
+            OpenRouter's ``HTTP-Referer`` + ``X-Title``).
+    """
+
+    def __init__(
+        self,
+        config: ProviderConfig,
+        *,
+        provider_name: str,
+        api_key_env: str,
+        default_headers: dict[str, str] | None = None,
+    ) -> None:
+        super().__init__(config)
+        if not config.base_url:
+            msg = (
+                f"OpenAICompatibleProvider requires base_url in ProviderConfig "
+                f"(provider='{provider_name}')"
+            )
+            raise ProviderError(msg)
+
+        api_key = config.api_key or os.environ.get(api_key_env)
+        if not api_key:
+            msg = (
+                f"API key not found for provider '{provider_name}'. "
+                f"Set {api_key_env} environment variable or pass api_key in "
+                f"ProviderConfig."
+            )
+            raise AuthenticationError(msg)
+
+        self._provider_name = provider_name
+        self._api_key = api_key
+        self._base_url = config.base_url.rstrip("/")
+        headers: dict[str, str] = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+        if default_headers:
+            headers.update(default_headers)
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            headers=headers,
+            timeout=httpx.Timeout(config.timeout),
+        )
+
+    @property
+    def name(self) -> str:
+        return self._provider_name
+
+    async def generate(
+        self,
+        messages: list[dict[str, str]],
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        tools: list[ToolDefinition] | None = None,
+        stream: bool = False,
+    ) -> GenerateResult:
+        resolved_model = self._resolve_model(model)
+        if stream:
+            return await self._collect_stream(
+                messages, resolved_model, temperature, max_tokens, tools
+            )
+        payload = self._build_payload(
+            messages, resolved_model, temperature, max_tokens, tools, stream=False
+        )
+        response = await self._request("POST", "/chat/completions", payload)
+        return self._parse_response(response)
+
+    async def generate_stream(
+        self,
+        messages: list[dict[str, str]],
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        tools: list[ToolDefinition] | None = None,
+    ) -> AsyncIterator[StreamChunk]:
+        resolved_model = self._resolve_model(model)
+        payload = self._build_payload(
+            messages, resolved_model, temperature, max_tokens, tools, stream=True
+        )
+        async with self._client.stream("POST", "/chat/completions", json=payload) as resp:
+            self._check_status(resp.status_code, "")
+            async for line in resp.aiter_lines():
+                if not line.startswith("data: "):
+                    continue
+                data = line[6:]
+                if data == "[DONE]":
+                    break
+                try:
+                    yield self._parse_stream_chunk(json.loads(data))
+                except json.JSONDecodeError:
+                    logger.warning("Failed to parse stream chunk from %s: %s", self.name, data)
+
+    async def list_models(self) -> list[ModelInfo]:
+        response = await self._request("GET", "/models")
+        models: list[ModelInfo] = []
+        for m in response.get("data", []):
+            model_id = m.get("id", "")
+            if not model_id:
+                continue
+            models.append(
+                ModelInfo(
+                    id=model_id,
+                    name=model_id,
+                    provider=self._provider_name,
+                    context_window=m.get("context_length") or m.get("context_window"),
+                    supports_streaming=True,
+                    supports_tools=True,  # most OpenAI-compatible providers do
+                )
+            )
+        return sorted(models, key=lambda m: m.id)
+
+    async def health_check(self) -> bool:
+        try:
+            await self._request("GET", "/models")
+            return True
+        except ProviderError:
+            return False
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    # ── Internal helpers ─────────────────────────────────────────────────
+
+    def _build_payload(
+        self,
+        messages: list[dict[str, str]],
+        model: str,
+        temperature: float | None,
+        max_tokens: int | None,
+        tools: list[ToolDefinition] | None,
+        stream: bool,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {"model": model, "messages": messages}
+        if temperature is not None:
+            payload["temperature"] = temperature
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+        if tools:
+            payload["tools"] = [t.model_dump() for t in tools]
+        if stream:
+            payload["stream"] = True
+        return payload
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+    ) -> Any:
+        try:
+            if method == "GET":
+                resp = await self._client.get(path)
+            else:
+                resp = await self._client.post(path, json=payload)
+        except httpx.TimeoutException as exc:
+            msg = f"{self._provider_name} request timed out: {exc}"
+            raise ProviderError(msg) from exc
+        except httpx.ConnectError as exc:
+            msg = f"Failed to connect to {self._provider_name} API at {self._base_url}: {exc}"
+            raise ProviderError(msg) from exc
+        body = resp.text
+        self._check_status(resp.status_code, body)
+        return resp.json()
+
+    def _check_status(self, status_code: int, body: str) -> None:
+        if status_code == 200:
+            return
+        if status_code == 401:
+            msg = f"Invalid API key for provider '{self._provider_name}'"
+            raise AuthenticationError(msg)
+        if status_code == 404:
+            raise ModelNotFoundError(f"Model not found ({self._provider_name}): {body}")
+        if status_code == 429:
+            raise RateLimitError(f"{self._provider_name} rate limit exceeded: {body}")
+        if status_code >= 400:
+            msg = f"{self._provider_name} API error ({status_code}): {body}"
+            raise ProviderError(msg)
+
+    def _parse_response(self, data: dict[str, Any]) -> GenerateResult:
+        choice = data.get("choices", [{}])[0]
+        message = choice.get("message", {})
+        usage_data = data.get("usage", {})
+
+        tool_calls: list[ToolCall] = []
+        for tc in message.get("tool_calls", []):
+            func = tc.get("function", {})
+            tool_calls.append(
+                ToolCall(
+                    id=tc.get("id", ""),
+                    function_name=func.get("name", ""),
+                    function_arguments=func.get("arguments", "{}"),
+                )
+            )
+
+        return GenerateResult(
+            content=message.get("content"),
+            tool_calls=tool_calls,
+            finish_reason=choice.get("finish_reason", "stop"),
+            usage=UsageInfo(
+                prompt_tokens=usage_data.get("prompt_tokens", 0),
+                completion_tokens=usage_data.get("completion_tokens", 0),
+                total_tokens=usage_data.get("total_tokens", 0),
+            ),
+            model=data.get("model", ""),
+            provider=self._provider_name,
+        )
+
+    def _parse_stream_chunk(self, data: dict[str, Any]) -> StreamChunk:
+        choice = data.get("choices", [{}])[0]
+        delta = choice.get("delta", {})
+        tool_calls: list[ToolCall] | None = None
+        if "tool_calls" in delta:
+            tool_calls = []
+            for tc in delta["tool_calls"]:
+                func = tc.get("function", {})
+                tool_calls.append(
+                    ToolCall(
+                        id=tc.get("id", ""),
+                        function_name=func.get("name", ""),
+                        function_arguments=func.get("arguments", ""),
+                    )
+                )
+        return StreamChunk(
+            content=delta.get("content"),
+            tool_calls=tool_calls,
+            finish_reason=choice.get("finish_reason"),
+            model=data.get("model", ""),
+        )
+
+    async def _collect_stream(
+        self,
+        messages: list[dict[str, str]],
+        model: str,
+        temperature: float | None,
+        max_tokens: int | None,
+        tools: list[ToolDefinition] | None,
+    ) -> GenerateResult:
+        content_parts: list[str] = []
+        all_tool_calls: list[ToolCall] = []
+        finish_reason = "stop"
+        result_model = model
+        async for chunk in self.generate_stream(messages, model, temperature, max_tokens, tools):
+            if chunk.content:
+                content_parts.append(chunk.content)
+            if chunk.tool_calls:
+                all_tool_calls.extend(chunk.tool_calls)
+            if chunk.finish_reason:
+                finish_reason = chunk.finish_reason
+            if chunk.model:
+                result_model = chunk.model
+        return GenerateResult(
+            content="".join(content_parts) if content_parts else None,
+            tool_calls=all_tool_calls,
+            finish_reason=finish_reason,
+            model=result_model,
+            provider=self._provider_name,
+        )
+
+
+# ─── Catalog-driven factory ────────────────────────────────────────────────
+
+
+def from_catalog(
+    name: str,
+    *,
+    default_model: str | None = None,
+    timeout: float = 60.0,
+) -> OpenAICompatibleProvider:
+    """Construct an :class:`OpenAICompatibleProvider` from a catalog entry.
+
+    Reads the api key from the env var declared on the catalog entry. Raises
+    :class:`KeyError` if ``name`` is not in the catalog (built-in or user-local).
+    """
+    # Local import to avoid a circular dep — catalog imports nothing from here.
+    from engine.providers.catalog import get_entry
+
+    entry = get_entry(name)
+    if entry is None:
+        msg = f"Provider '{name}' is not in the catalog"
+        raise KeyError(msg)
+
+    # ProviderType is a closed enum — the generic provider always uses OpenAI's
+    # chat-completions wire shape, so we tag the config as ``openai`` even when
+    # the upstream is e.g. Groq. The actual provider name surfaces via
+    # ``provider_name`` on the instance and on every result.
+    from engine.providers.models import ProviderType
+
+    config = ProviderConfig(
+        provider_type=ProviderType.openai,
+        base_url=str(entry.base_url),
+        default_model=default_model,
+        timeout=timeout,
+    )
+    return OpenAICompatibleProvider(
+        config,
+        provider_name=name,
+        api_key_env=entry.api_key_env,
+        default_headers=dict(entry.default_headers),
+    )

--- a/engine/providers/registry.py
+++ b/engine/providers/registry.py
@@ -55,6 +55,58 @@ def create_provider(config: ProviderConfig) -> ProviderBase:
     return provider_cls(config)
 
 
+def create_catalog_provider(
+    name: str,
+    *,
+    default_model: str | None = None,
+    timeout: float = 60.0,
+) -> ProviderBase:
+    """Create a provider from the OpenAI-compatible catalog by name.
+
+    Looks up ``name`` in ``engine/providers/catalog.yaml`` (plus user-local
+    overrides) and constructs a generic
+    :class:`engine.providers.openai_compatible.OpenAICompatibleProvider`.
+
+    Use this for providers like ``nvidia``, ``groq``, ``together``, etc. that
+    don't have a hand-written class — they all share the OpenAI Chat
+    Completions wire shape.
+
+    Raises:
+        KeyError: if ``name`` is not in the catalog.
+        AuthenticationError: if the api-key env var declared on the entry is unset.
+    """
+    # Local import to avoid a hard dep cycle (registry is imported widely).
+    from engine.providers.openai_compatible import from_catalog
+
+    return from_catalog(name, default_model=default_model, timeout=timeout)
+
+
+def resolve_model_ref(
+    ref: str,
+    *,
+    timeout: float = 60.0,
+) -> ProviderBase | None:
+    """Resolve a ``<provider>/<model>`` ref against the catalog.
+
+    Returns a configured provider with ``default_model`` set to the model
+    portion, or ``None`` if ``ref`` doesn't match a catalog provider. This is
+    the entry point used by ``agent.yaml`` ``model.primary`` resolution.
+
+    Examples:
+        >>> resolve_model_ref("nvidia/meta-llama-3.1-405b-instruct")
+        <OpenAICompatibleProvider name="nvidia" model="meta-llama-3.1-405b-instruct">
+        >>> resolve_model_ref("gpt-4o")  # not in catalog → None
+        None
+    """
+    from engine.providers.catalog import parse_model_ref
+
+    parsed = parse_model_ref(ref)
+    if parsed is None:
+        return None
+    provider_name, model_id = parsed
+    return create_catalog_provider(provider_name, default_model=model_id, timeout=timeout)
+
+
 def create_provider_from_env(
     provider_type: ProviderType,
     model: str | None = None,

--- a/tests/integration/test_provider_catalog_cli.py
+++ b/tests/integration/test_provider_catalog_cli.py
@@ -1,0 +1,318 @@
+"""Integration test: register an OpenAI-compatible catalog provider via CLI,
+list models against it, and invoke it. All HTTP is mocked — this test must
+NOT require real API keys.
+
+Covers Track F (issue #160) acceptance: ``model.primary: nvidia/<model>``
+resolves through the engine's existing model resolution path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from cli.commands.provider import provider_app
+from engine.providers.catalog import reset_cache
+
+
+@pytest.fixture(autouse=True)
+def _isolate_user_local(tmp_path: Path):
+    """Redirect USER_LOCAL_PATH so tests don't touch the real ~/.agentbreeder."""
+    fake = tmp_path / "providers.local.yaml"
+    with patch("engine.providers.catalog.USER_LOCAL_PATH", fake):
+        reset_cache()
+        yield fake
+        reset_cache()
+
+
+def test_provider_list_shows_builtin_catalog() -> None:
+    """`provider list --json` exposes the 9 built-in presets."""
+    runner = CliRunner()
+    result = runner.invoke(provider_app, ["list", "--json"])
+    assert result.exit_code == 0, result.output
+    import json
+
+    payload = json.loads(result.output)
+    catalog_names = {entry["name"] for entry in payload["catalog"]}
+    expected = {
+        "nvidia",
+        "openrouter",
+        "moonshot",
+        "groq",
+        "together",
+        "fireworks",
+        "deepinfra",
+        "cerebras",
+        "hyperbolic",
+    }
+    assert expected.issubset(catalog_names)
+
+
+def test_provider_add_catalog_creates_user_local_entry(_isolate_user_local: Path) -> None:
+    """`provider add my-vllm --type openai_compatible …` writes user-local YAML."""
+    runner = CliRunner()
+    result = runner.invoke(
+        provider_app,
+        [
+            "add",
+            "my-vllm",
+            "--type",
+            "openai_compatible",
+            "--base-url",
+            "https://vllm.internal.test/v1",
+            "--api-key-env",
+            "VLLM_TEST_KEY",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert _isolate_user_local.exists()
+    contents = _isolate_user_local.read_text()
+    assert "my-vllm" in contents
+    assert "vllm.internal.test" in contents
+    assert "VLLM_TEST_KEY" in contents
+
+
+def test_provider_add_catalog_then_list_includes_user_local(
+    _isolate_user_local: Path,
+) -> None:
+    """Round-trip: add → list shows the new entry with source=user-local."""
+    runner = CliRunner()
+    runner.invoke(
+        provider_app,
+        [
+            "add",
+            "my-vllm",
+            "--type",
+            "openai_compatible",
+            "--base-url",
+            "https://vllm.internal.test/v1",
+            "--api-key-env",
+            "VLLM_TEST_KEY",
+            "--json",
+        ],
+    )
+    reset_cache()
+    result = runner.invoke(provider_app, ["list", "--json"])
+    import json
+
+    payload = json.loads(result.output)
+    by_name = {e["name"]: e for e in payload["catalog"]}
+    assert "my-vllm" in by_name
+    assert by_name["my-vllm"]["source"] == "user-local"
+
+
+def test_provider_add_catalog_requires_base_url() -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        provider_app,
+        [
+            "add",
+            "broken",
+            "--type",
+            "openai_compatible",
+            "--api-key-env",
+            "X_KEY",
+        ],
+    )
+    assert result.exit_code != 0
+
+
+def test_provider_add_catalog_requires_api_key_env() -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        provider_app,
+        [
+            "add",
+            "broken",
+            "--type",
+            "openai_compatible",
+            "--base-url",
+            "https://api.broken.test/v1",
+        ],
+    )
+    assert result.exit_code != 0
+
+
+def test_provider_remove_user_local_entry(_isolate_user_local: Path) -> None:
+    runner = CliRunner()
+    runner.invoke(
+        provider_app,
+        [
+            "add",
+            "my-vllm",
+            "--type",
+            "openai_compatible",
+            "--base-url",
+            "https://vllm.internal.test/v1",
+            "--api-key-env",
+            "VLLM_TEST_KEY",
+            "--json",
+        ],
+    )
+    result = runner.invoke(provider_app, ["remove", "my-vllm", "--json"])
+    assert result.exit_code == 0, result.output
+    import json
+
+    payload = json.loads(result.output)
+    assert payload["removed"] == "my-vllm"
+    assert payload["source"] == "user-local"
+
+
+def test_provider_publish_prints_snippet_and_exits_nonzero(
+    _isolate_user_local: Path,
+) -> None:
+    """`provider publish` is gated until git integration ships — exit code 2."""
+    runner = CliRunner()
+    runner.invoke(
+        provider_app,
+        [
+            "add",
+            "my-vllm",
+            "--type",
+            "openai_compatible",
+            "--base-url",
+            "https://vllm.internal.test/v1",
+            "--api-key-env",
+            "VLLM_TEST_KEY",
+            "--json",
+        ],
+    )
+    result = runner.invoke(provider_app, ["publish", "my-vllm", "--json"])
+    # Gated path returns code 2 (deferred feature)
+    assert result.exit_code == 2
+    import json
+
+    payload = json.loads(result.output)
+    assert payload["status"] == "not_implemented"
+    assert "my-vllm" in payload["snippet"]
+
+
+def test_provider_publish_unknown_name_errors() -> None:
+    runner = CliRunner()
+    result = runner.invoke(provider_app, ["publish", "ghost"])
+    assert result.exit_code == 1
+
+
+def test_provider_test_succeeds_against_mocked_endpoint(monkeypatch) -> None:
+    """`provider test nvidia` hits GET /models with the env-var api key.
+
+    HTTP is mocked — no real network. This verifies the full plumbing from
+    CLI → catalog lookup → OpenAICompatibleProvider.list_models().
+    """
+    monkeypatch.setenv("NVIDIA_API_KEY", "nv-fake-key")
+
+    mock_response = httpx.Response(
+        200,
+        json={
+            "object": "list",
+            "data": [
+                {"id": "meta-llama-3.1-405b-instruct", "object": "model"},
+                {"id": "mixtral-8x7b", "object": "model"},
+            ],
+        },
+    )
+
+    async def _fake_get(*args, **kwargs):
+        return mock_response
+
+    async def _fake_aclose():
+        return None
+
+    with patch("httpx.AsyncClient.get", new=AsyncMock(side_effect=_fake_get)):
+        with patch("httpx.AsyncClient.aclose", new=AsyncMock(side_effect=_fake_aclose)):
+            runner = CliRunner()
+            result = runner.invoke(provider_app, ["test", "nvidia", "--json"])
+    assert result.exit_code == 0, result.output
+    import json
+
+    payload = json.loads(result.output)
+    assert payload["success"] is True
+    assert payload["model_count"] == 2
+
+
+def test_provider_test_missing_env_var_reports_error(monkeypatch) -> None:
+    monkeypatch.delenv("NVIDIA_API_KEY", raising=False)
+    runner = CliRunner()
+    result = runner.invoke(provider_app, ["test", "nvidia"])
+    assert result.exit_code == 1
+    assert "NVIDIA_API_KEY" in result.output
+
+
+def test_catalog_api_route_returns_presets() -> None:
+    """The dashboard's `GET /api/v1/providers/catalog` exposes the catalog."""
+    from fastapi.testclient import TestClient
+
+    from api.main import app
+
+    with TestClient(app) as client:
+        response = client.get("/api/v1/providers/catalog")
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    names = {entry["name"] for entry in payload["data"]}
+    expected = {
+        "nvidia",
+        "openrouter",
+        "moonshot",
+        "groq",
+        "together",
+        "fireworks",
+        "deepinfra",
+        "cerebras",
+        "hyperbolic",
+    }
+    assert expected.issubset(names)
+    # Each entry exposes the fields the dashboard renders
+    nvidia = next(e for e in payload["data"] if e["name"] == "nvidia")
+    assert nvidia["api_key_env"] == "NVIDIA_API_KEY"
+    assert nvidia["source"] == "builtin"
+    assert "integrate.api.nvidia.com" in nvidia["base_url"]
+
+
+def test_invoke_through_resolver_with_mocked_http(monkeypatch) -> None:
+    """End-to-end-ish: resolve `nvidia/<model>` and invoke generate(), all mocked."""
+    import asyncio
+
+    from engine.providers.registry import resolve_model_ref
+
+    monkeypatch.setenv("NVIDIA_API_KEY", "nv-fake-key")
+
+    async def _run() -> None:
+        provider = resolve_model_ref("nvidia/meta-llama-3.1-405b-instruct")
+        assert provider is not None
+        assert provider.name == "nvidia"
+
+        # Mock the chat completions response
+        provider._client.post = AsyncMock(  # type: ignore[attr-defined]
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "cmpl-1",
+                    "model": "meta-llama-3.1-405b-instruct",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "Greetings."},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 4,
+                        "completion_tokens": 2,
+                        "total_tokens": 6,
+                    },
+                },
+            )
+        )
+
+        result = await provider.generate(messages=[{"role": "user", "content": "Hi"}])
+        assert result.content == "Greetings."
+        assert result.provider == "nvidia"
+        assert result.model == "meta-llama-3.1-405b-instruct"
+        await provider.close()
+
+    asyncio.run(_run())

--- a/tests/unit/test_provider_catalog.py
+++ b/tests/unit/test_provider_catalog.py
@@ -1,0 +1,722 @@
+"""Tests for engine/providers/catalog.py and openai_compatible.py.
+
+Covers:
+- Catalog YAML parser + Pydantic validation
+- Built-in catalog ships the 9 expected presets with the right env vars
+- User-local override merging (user-local wins on name collision)
+- ``parse_model_ref`` handles slash refs, unknown providers, and edge cases
+- ``OpenAICompatibleProvider`` requires base_url + api key, sends headers
+- ``from_catalog`` builds a configured provider for catalog names
+- ``list_models``, ``health_check``, ``generate`` against mocked HTTP
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from engine.providers.base import (
+    AuthenticationError,
+    ProviderError,
+)
+from engine.providers.catalog import (
+    Catalog,
+    CatalogEntry,
+    CatalogError,
+    _parse_catalog,
+    get_entry,
+    list_entries,
+    load_catalog,
+    parse_model_ref,
+    reset_cache,
+)
+from engine.providers.models import ProviderConfig, ProviderType
+from engine.providers.openai_compatible import OpenAICompatibleProvider, from_catalog
+
+# ─── Catalog parser ─────────────────────────────────────────────────────────
+
+
+class TestCatalogParser:
+    def test_parse_minimal_entry(self) -> None:
+        data = {
+            "version": 1,
+            "providers": {
+                "foo": {
+                    "type": "openai_compatible",
+                    "base_url": "https://api.foo.com/v1",
+                    "api_key_env": "FOO_API_KEY",
+                }
+            },
+        }
+        catalog = _parse_catalog(data, source="builtin")
+        assert catalog.version == 1
+        assert "foo" in catalog.providers
+        entry = catalog.providers["foo"]
+        assert str(entry.base_url).rstrip("/") == "https://api.foo.com/v1"
+        assert entry.api_key_env == "FOO_API_KEY"
+        assert entry.type == "openai_compatible"
+        assert entry.source == "builtin"
+
+    def test_parse_with_default_headers(self) -> None:
+        data = {
+            "providers": {
+                "openrouter": {
+                    "base_url": "https://openrouter.ai/api/v1",
+                    "api_key_env": "OPENROUTER_API_KEY",
+                    "default_headers": {
+                        "HTTP-Referer": "https://agentbreeder.io",
+                        "X-Title": "AgentBreeder",
+                    },
+                }
+            }
+        }
+        catalog = _parse_catalog(data, source="builtin")
+        entry = catalog.providers["openrouter"]
+        assert entry.default_headers["HTTP-Referer"] == "https://agentbreeder.io"
+        assert entry.default_headers["X-Title"] == "AgentBreeder"
+
+    def test_invalid_base_url_raises(self) -> None:
+        data = {
+            "providers": {
+                "bad": {"base_url": "not-a-url", "api_key_env": "X"},
+            }
+        }
+        with pytest.raises(CatalogError):
+            _parse_catalog(data, source="builtin")
+
+    def test_missing_api_key_env_raises(self) -> None:
+        data = {
+            "providers": {
+                "bad": {"base_url": "https://api.test.com", "api_key_env": ""},
+            }
+        }
+        with pytest.raises(CatalogError):
+            _parse_catalog(data, source="builtin")
+
+    def test_top_level_must_be_mapping(self, tmp_path: Path) -> None:
+        from engine.providers.catalog import _load_yaml
+
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("- just\n- a\n- list\n")
+        with pytest.raises(CatalogError):
+            _load_yaml(bad)
+
+    def test_invalid_yaml_raises(self, tmp_path: Path) -> None:
+        from engine.providers.catalog import _load_yaml
+
+        bad = tmp_path / "bad.yaml"
+        bad.write_text("key: : :\nbroken: [unclosed")
+        with pytest.raises(CatalogError):
+            _load_yaml(bad)
+
+
+# ─── Built-in catalog ───────────────────────────────────────────────────────
+
+
+class TestBuiltinCatalog:
+    def setup_method(self) -> None:
+        reset_cache()
+
+    def teardown_method(self) -> None:
+        reset_cache()
+
+    def test_loads_nine_presets(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            catalog = load_catalog()
+        expected = {
+            "nvidia",
+            "openrouter",
+            "moonshot",
+            "groq",
+            "together",
+            "fireworks",
+            "deepinfra",
+            "cerebras",
+            "hyperbolic",
+        }
+        assert expected.issubset(set(catalog.providers))
+
+    def test_nvidia_entry_has_expected_fields(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            entry = get_entry("nvidia")
+        assert entry is not None
+        assert entry.api_key_env == "NVIDIA_API_KEY"
+        assert "integrate.api.nvidia.com" in str(entry.base_url)
+        assert entry.source == "builtin"
+
+    def test_openrouter_has_default_headers(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            entry = get_entry("openrouter")
+        assert entry is not None
+        assert entry.default_headers.get("HTTP-Referer") == "https://agentbreeder.io"
+        assert entry.default_headers.get("X-Title") == "AgentBreeder"
+
+    def test_groq_entry(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            entry = get_entry("groq")
+        assert entry is not None
+        assert entry.api_key_env == "GROQ_API_KEY"
+        assert "groq.com" in str(entry.base_url)
+
+    def test_unknown_provider_returns_none(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            assert get_entry("does-not-exist") is None
+
+
+# ─── User-local merge ───────────────────────────────────────────────────────
+
+
+class TestUserLocalMerge:
+    def setup_method(self) -> None:
+        reset_cache()
+
+    def teardown_method(self) -> None:
+        reset_cache()
+
+    def test_user_local_overrides_builtin(self, tmp_path: Path) -> None:
+        local = tmp_path / "providers.local.yaml"
+        local.write_text(
+            "version: 1\n"
+            "providers:\n"
+            "  nvidia:\n"
+            "    type: openai_compatible\n"
+            "    base_url: https://internal.nvidia.mirror/v1\n"
+            "    api_key_env: INTERNAL_NVIDIA_KEY\n"
+        )
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", local):
+            reset_cache()
+            entry = get_entry("nvidia")
+        assert entry is not None
+        assert "internal.nvidia.mirror" in str(entry.base_url)
+        assert entry.api_key_env == "INTERNAL_NVIDIA_KEY"
+        assert entry.source == "user-local"
+
+    def test_user_local_adds_new_provider(self, tmp_path: Path) -> None:
+        local = tmp_path / "providers.local.yaml"
+        local.write_text(
+            "version: 1\n"
+            "providers:\n"
+            "  my-vllm:\n"
+            "    type: openai_compatible\n"
+            "    base_url: https://vllm.internal/v1\n"
+            "    api_key_env: VLLM_KEY\n"
+        )
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", local):
+            reset_cache()
+            entries = list_entries()
+        assert "my-vllm" in entries
+        assert entries["my-vllm"].source == "user-local"
+        assert entries["nvidia"].source == "builtin"
+
+    def test_invalid_user_local_is_skipped_not_fatal(self, tmp_path: Path) -> None:
+        local = tmp_path / "providers.local.yaml"
+        local.write_text("providers:\n  bad:\n    base_url: nope\n    api_key_env: X\n")
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", local):
+            reset_cache()
+            # built-in still loads; bad user-local entry doesn't take down the system
+            assert "nvidia" in list_entries()
+
+
+# ─── parse_model_ref ────────────────────────────────────────────────────────
+
+
+class TestParseModelRef:
+    def setup_method(self) -> None:
+        reset_cache()
+
+    def teardown_method(self) -> None:
+        reset_cache()
+
+    def test_valid_catalog_ref(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            result = parse_model_ref("nvidia/meta-llama-3.1-405b-instruct")
+        assert result == ("nvidia", "meta-llama-3.1-405b-instruct")
+
+    def test_no_slash_returns_none(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            assert parse_model_ref("gpt-4o") is None
+
+    def test_unknown_provider_returns_none(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            assert parse_model_ref("acme/some-model") is None
+
+    def test_empty_components(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            assert parse_model_ref("/foo") is None
+            assert parse_model_ref("nvidia/") is None
+
+    def test_model_id_can_contain_slashes(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            result = parse_model_ref("openrouter/anthropic/claude-sonnet-4")
+        assert result == ("openrouter", "anthropic/claude-sonnet-4")
+
+
+# ─── OpenAICompatibleProvider ───────────────────────────────────────────────
+
+
+def _config(
+    api_key: str | None = "test-key",
+    base_url: str = "https://api.test.com/v1",
+) -> ProviderConfig:
+    return ProviderConfig(
+        provider_type=ProviderType.openai,
+        api_key=api_key,
+        base_url=base_url,
+        default_model="meta-llama-3.1-8b",
+    )
+
+
+def _models_response() -> dict[str, object]:
+    return {
+        "object": "list",
+        "data": [
+            {"id": "meta-llama-3.1-8b", "object": "model"},
+            {"id": "mixtral-8x7b", "object": "model", "context_length": 32768},
+        ],
+    }
+
+
+def _chat_response(content: str = "Hello!", model: str = "meta-llama-3.1-8b") -> dict:
+    return {
+        "id": "cmpl-1",
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+    }
+
+
+class TestOpenAICompatibleProvider:
+    def test_requires_base_url(self) -> None:
+        config = ProviderConfig(provider_type=ProviderType.openai, api_key="x")
+        with pytest.raises(ProviderError, match="base_url"):
+            OpenAICompatibleProvider(
+                config,
+                provider_name="test",
+                api_key_env="TEST_KEY",
+            )
+
+    def test_requires_api_key(self) -> None:
+        config = ProviderConfig(
+            provider_type=ProviderType.openai,
+            base_url="https://api.test.com/v1",
+        )
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(AuthenticationError, match="API key not found"):
+                OpenAICompatibleProvider(
+                    config,
+                    provider_name="nvidia",
+                    api_key_env="NVIDIA_API_KEY",
+                )
+
+    def test_reads_api_key_from_env(self) -> None:
+        config = ProviderConfig(
+            provider_type=ProviderType.openai,
+            base_url="https://api.test.com/v1",
+        )
+        with patch.dict("os.environ", {"NVIDIA_API_KEY": "nv-test"}):
+            provider = OpenAICompatibleProvider(
+                config,
+                provider_name="nvidia",
+                api_key_env="NVIDIA_API_KEY",
+            )
+        assert provider._api_key == "nv-test"
+        assert provider.name == "nvidia"
+
+    def test_default_headers_are_merged(self) -> None:
+        provider = OpenAICompatibleProvider(
+            _config(),
+            provider_name="openrouter",
+            api_key_env="OPENROUTER_API_KEY",
+            default_headers={
+                "HTTP-Referer": "https://agentbreeder.io",
+                "X-Title": "AgentBreeder",
+            },
+        )
+        sent_headers = provider._client.headers
+        assert sent_headers.get("HTTP-Referer") == "https://agentbreeder.io"
+        assert sent_headers.get("X-Title") == "AgentBreeder"
+        assert sent_headers.get("Authorization") == "Bearer test-key"
+
+    def test_strips_trailing_slash_from_base_url(self) -> None:
+        provider = OpenAICompatibleProvider(
+            _config(base_url="https://api.test.com/v1/"),
+            provider_name="t",
+            api_key_env="TEST_KEY",
+        )
+        assert provider._base_url == "https://api.test.com/v1"
+
+    @pytest.mark.asyncio
+    async def test_list_models(self) -> None:
+        provider = OpenAICompatibleProvider(
+            _config(),
+            provider_name="nvidia",
+            api_key_env="NVIDIA_API_KEY",
+        )
+        provider._client = AsyncMock()
+        provider._client.get = AsyncMock(return_value=httpx.Response(200, json=_models_response()))
+        models = await provider.list_models()
+        assert len(models) == 2
+        assert {m.id for m in models} == {"meta-llama-3.1-8b", "mixtral-8x7b"}
+        assert all(m.provider == "nvidia" for m in models)
+        # context_length surfaces as context_window when present
+        mixtral = next(m for m in models if m.id == "mixtral-8x7b")
+        assert mixtral.context_window == 32768
+
+    @pytest.mark.asyncio
+    async def test_health_check_success(self) -> None:
+        provider = OpenAICompatibleProvider(
+            _config(),
+            provider_name="t",
+            api_key_env="TEST_KEY",
+        )
+        provider._client = AsyncMock()
+        provider._client.get = AsyncMock(return_value=httpx.Response(200, json=_models_response()))
+        assert await provider.health_check() is True
+
+    @pytest.mark.asyncio
+    async def test_health_check_failure(self) -> None:
+        provider = OpenAICompatibleProvider(
+            _config(),
+            provider_name="t",
+            api_key_env="TEST_KEY",
+        )
+        provider._client = AsyncMock()
+        provider._client.get = AsyncMock(return_value=httpx.Response(401, text="unauthorized"))
+        assert await provider.health_check() is False
+
+    @pytest.mark.asyncio
+    async def test_generate(self) -> None:
+        provider = OpenAICompatibleProvider(
+            _config(),
+            provider_name="groq",
+            api_key_env="GROQ_API_KEY",
+        )
+        provider._client = AsyncMock()
+        provider._client.post = AsyncMock(return_value=httpx.Response(200, json=_chat_response()))
+        result = await provider.generate(messages=[{"role": "user", "content": "Hi"}])
+        assert result.content == "Hello!"
+        assert result.provider == "groq"
+        assert result.usage.total_tokens == 8
+
+    @pytest.mark.asyncio
+    async def test_generate_401_raises_auth_error(self) -> None:
+        provider = OpenAICompatibleProvider(
+            _config(),
+            provider_name="t",
+            api_key_env="TEST_KEY",
+        )
+        provider._client = AsyncMock()
+        provider._client.post = AsyncMock(return_value=httpx.Response(401, text="bad key"))
+        with pytest.raises(AuthenticationError):
+            await provider.generate(messages=[{"role": "user", "content": "Hi"}])
+
+    @pytest.mark.asyncio
+    async def test_generate_404_raises_model_not_found(self) -> None:
+        from engine.providers.base import ModelNotFoundError
+
+        provider = OpenAICompatibleProvider(
+            _config(),
+            provider_name="t",
+            api_key_env="TEST_KEY",
+        )
+        provider._client = AsyncMock()
+        provider._client.post = AsyncMock(return_value=httpx.Response(404, text="no such model"))
+        with pytest.raises(ModelNotFoundError):
+            await provider.generate(messages=[{"role": "user", "content": "Hi"}])
+
+    @pytest.mark.asyncio
+    async def test_generate_429_raises_rate_limit(self) -> None:
+        from engine.providers.base import RateLimitError
+
+        provider = OpenAICompatibleProvider(
+            _config(),
+            provider_name="t",
+            api_key_env="TEST_KEY",
+        )
+        provider._client = AsyncMock()
+        provider._client.post = AsyncMock(return_value=httpx.Response(429, text="too many"))
+        with pytest.raises(RateLimitError):
+            await provider.generate(messages=[{"role": "user", "content": "Hi"}])
+
+    @pytest.mark.asyncio
+    async def test_generate_500_raises_provider_error(self) -> None:
+        provider = OpenAICompatibleProvider(
+            _config(),
+            provider_name="t",
+            api_key_env="TEST_KEY",
+        )
+        provider._client = AsyncMock()
+        provider._client.post = AsyncMock(return_value=httpx.Response(500, text="server error"))
+        with pytest.raises(ProviderError):
+            await provider.generate(messages=[{"role": "user", "content": "Hi"}])
+
+    @pytest.mark.asyncio
+    async def test_request_timeout_wrapped(self) -> None:
+        provider = OpenAICompatibleProvider(
+            _config(),
+            provider_name="t",
+            api_key_env="TEST_KEY",
+        )
+        provider._client = AsyncMock()
+        provider._client.post = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
+        with pytest.raises(ProviderError, match="timed out"):
+            await provider.generate(messages=[{"role": "user", "content": "Hi"}])
+
+    @pytest.mark.asyncio
+    async def test_request_connect_error_wrapped(self) -> None:
+        provider = OpenAICompatibleProvider(
+            _config(),
+            provider_name="t",
+            api_key_env="TEST_KEY",
+        )
+        provider._client = AsyncMock()
+        provider._client.post = AsyncMock(side_effect=httpx.ConnectError("dns failure"))
+        with pytest.raises(ProviderError, match="Failed to connect"):
+            await provider.generate(messages=[{"role": "user", "content": "Hi"}])
+
+    @pytest.mark.asyncio
+    async def test_generate_includes_temperature_max_tokens_tools(self) -> None:
+        from engine.providers.models import ToolDefinition, ToolFunction
+
+        provider = OpenAICompatibleProvider(
+            _config(),
+            provider_name="t",
+            api_key_env="TEST_KEY",
+        )
+        provider._client = AsyncMock()
+        provider._client.post = AsyncMock(return_value=httpx.Response(200, json=_chat_response()))
+
+        await provider.generate(
+            messages=[{"role": "user", "content": "x"}],
+            temperature=0.3,
+            max_tokens=99,
+            tools=[
+                ToolDefinition(
+                    function=ToolFunction(
+                        name="search",
+                        description="Search the web",
+                        parameters={"type": "object"},
+                    )
+                )
+            ],
+        )
+        sent_payload = provider._client.post.call_args.kwargs["json"]
+        assert sent_payload["temperature"] == 0.3
+        assert sent_payload["max_tokens"] == 99
+        assert sent_payload["tools"][0]["function"]["name"] == "search"
+
+    @pytest.mark.asyncio
+    async def test_generate_returns_tool_calls(self) -> None:
+        provider = OpenAICompatibleProvider(
+            _config(),
+            provider_name="groq",
+            api_key_env="GROQ_API_KEY",
+        )
+        provider._client = AsyncMock()
+        provider._client.post = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "x",
+                    "model": "y",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": None,
+                                "tool_calls": [
+                                    {
+                                        "id": "call_1",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "f",
+                                            "arguments": '{"x": 1}',
+                                        },
+                                    }
+                                ],
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                },
+            )
+        )
+        result = await provider.generate(messages=[{"role": "user", "content": "x"}])
+        assert result.finish_reason == "tool_calls"
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function_name == "f"
+
+    @pytest.mark.asyncio
+    async def test_list_models_skips_entries_without_id(self) -> None:
+        provider = OpenAICompatibleProvider(
+            _config(),
+            provider_name="t",
+            api_key_env="TEST_KEY",
+        )
+        provider._client = AsyncMock()
+        provider._client.get = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [{"id": "ok"}, {}, {"id": ""}]},
+            )
+        )
+        models = await provider.list_models()
+        assert [m.id for m in models] == ["ok"]
+
+    @pytest.mark.asyncio
+    async def test_close_releases_http_client(self) -> None:
+        provider = OpenAICompatibleProvider(
+            _config(),
+            provider_name="t",
+            api_key_env="TEST_KEY",
+        )
+        provider._client = AsyncMock()
+        provider._client.aclose = AsyncMock()
+        await provider.close()
+        provider._client.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_generate_stream_collects_content(self) -> None:
+        """`stream=True` on generate() collects chunks into one GenerateResult."""
+        provider = OpenAICompatibleProvider(
+            _config(),
+            provider_name="t",
+            api_key_env="TEST_KEY",
+        )
+
+        async def _fake_stream(
+            messages, model=None, temperature=None, max_tokens=None, tools=None
+        ):
+            from engine.providers.models import StreamChunk
+
+            yield StreamChunk(content="Hello ", model="m")
+            yield StreamChunk(content="world", model="m")
+            yield StreamChunk(finish_reason="stop", model="m")
+
+        provider.generate_stream = _fake_stream  # type: ignore[method-assign]
+        result = await provider.generate(messages=[{"role": "user", "content": "x"}], stream=True)
+        assert result.content == "Hello world"
+        assert result.finish_reason == "stop"
+        assert result.provider == "t"
+
+
+# ─── from_catalog factory ───────────────────────────────────────────────────
+
+
+class TestFromCatalog:
+    def setup_method(self) -> None:
+        reset_cache()
+
+    def teardown_method(self) -> None:
+        reset_cache()
+
+    def test_unknown_catalog_name_raises(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            with pytest.raises(KeyError):
+                from_catalog("does-not-exist")
+
+    def test_builds_nvidia_provider(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            with patch.dict("os.environ", {"NVIDIA_API_KEY": "nv-test"}):
+                provider = from_catalog("nvidia", default_model="meta-llama-3.1-405b")
+        assert provider.name == "nvidia"
+        assert "integrate.api.nvidia.com" in provider._base_url
+
+    def test_builds_openrouter_with_headers(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            with patch.dict("os.environ", {"OPENROUTER_API_KEY": "or-test"}):
+                provider = from_catalog("openrouter")
+        assert provider._client.headers.get("HTTP-Referer") == "https://agentbreeder.io"
+        assert provider._client.headers.get("X-Title") == "AgentBreeder"
+
+
+# ─── resolve_model_ref through registry ────────────────────────────────────
+
+
+class TestRegistryResolveModelRef:
+    def setup_method(self) -> None:
+        reset_cache()
+
+    def teardown_method(self) -> None:
+        reset_cache()
+
+    def test_resolves_catalog_ref(self) -> None:
+        from engine.providers.registry import resolve_model_ref
+
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            with patch.dict("os.environ", {"NVIDIA_API_KEY": "nv-test"}):
+                provider = resolve_model_ref("nvidia/meta-llama-3.1-405b-instruct")
+        assert provider is not None
+        assert provider.name == "nvidia"
+        assert provider.config.default_model == "meta-llama-3.1-405b-instruct"
+
+    def test_returns_none_for_non_catalog(self) -> None:
+        from engine.providers.registry import resolve_model_ref
+
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            assert resolve_model_ref("gpt-4o") is None
+            assert resolve_model_ref("unknown/model") is None
+
+
+# ─── write_user_local round-trip ───────────────────────────────────────────
+
+
+class TestWriteUserLocal:
+    def setup_method(self) -> None:
+        reset_cache()
+
+    def teardown_method(self) -> None:
+        reset_cache()
+
+    def test_write_and_reload(self, tmp_path: Path) -> None:
+        from engine.providers.catalog import write_user_local
+
+        local = tmp_path / "providers.local.yaml"
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", local):
+            reset_cache()
+            cat = Catalog(
+                providers={
+                    "my-vllm": CatalogEntry(
+                        type="openai_compatible",
+                        base_url="https://vllm.internal/v1",  # type: ignore[arg-type]
+                        api_key_env="VLLM_KEY",
+                        source="user-local",
+                    )
+                }
+            )
+            path = write_user_local(cat)
+            assert path.exists()
+            assert "my-vllm" in path.read_text()
+
+            reset_cache()
+            assert get_entry("my-vllm") is not None

--- a/tests/unit/test_provider_cmd.py
+++ b/tests/unit/test_provider_cmd.py
@@ -23,15 +23,21 @@ def providers_file(tmp_path):
 
 class TestProviderList:
     def test_list_empty(self, providers_file):
+        # With Track F's catalog landed, `provider list` always shows the built-in
+        # OpenAI-compatible catalog table even when no providers are configured.
         result = runner.invoke(app, ["provider", "list"])
         assert result.exit_code == 0
-        assert "No providers configured" in result.output
+        assert "OpenAI-Compatible Catalog" in result.output
 
     def test_list_empty_json(self, providers_file):
         result = runner.invoke(app, ["provider", "list", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data == []
+        # Track F: top-level shape is {"configured": [...], "catalog": [...]}.
+        assert data["configured"] == []
+        catalog_names = {entry["name"] for entry in data["catalog"]}
+        assert "nvidia" in catalog_names
+        assert "groq" in catalog_names
 
     def test_list_with_providers(self, providers_file):
         providers = {
@@ -67,8 +73,9 @@ class TestProviderList:
         result = runner.invoke(app, ["provider", "list", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert len(data) == 1
-        assert data[0]["name"] == "OpenAI"
+        # Track F: top-level shape is {"configured": [...], "catalog": [...]}.
+        assert len(data["configured"]) == 1
+        assert data["configured"][0]["name"] == "OpenAI"
 
 
 class TestProviderAdd:

--- a/website/content/docs/cli-reference.mdx
+++ b/website/content/docs/cli-reference.mdx
@@ -664,31 +664,40 @@ agentbreeder provider [SUBCOMMAND] [OPTIONS]
 
 | Subcommand | Description |
 |------------|-------------|
-| `list` | List all configured providers with status |
-| `add TYPE` | Add a new provider (interactive or with `--api-key` / `--base-url`) |
-| `test NAME` | Test a provider connection |
+| `list` | List configured providers + the OpenAI-compatible catalog |
+| `add NAME` | Add a provider (legacy types or `--type openai_compatible`) |
+| `test NAME` | Test a provider connection (catalog or legacy) |
 | `models NAME` | List available models from a provider |
 | `remove NAME` | Remove a provider and its API key |
 | `disable NAME` | Disable a provider without removing |
 | `enable NAME` | Re-enable a disabled provider |
+| `publish NAME` | Promote a user-local entry to a PR against the upstream catalog |
 
-**Supported provider types:** `openai`, `anthropic`, `google`, `ollama`, `litellm`, `openrouter`
+**Hand-written providers:** `openai`, `anthropic`, `google`, `ollama`, `litellm`, `openrouter` (interactive wizard).
 
-API keys are stored in the project `.env` file (or `~/.agentbreeder/.env` if no project).
+**Catalog providers (OpenAI-compatible):** `nvidia`, `openrouter`, `moonshot`, `groq`, `together`, `fireworks`, `deepinfra`, `cerebras`, `hyperbolic`. See [Providers](providers) for the full list and how to add your own.
+
+API keys are stored in the project `.env` file (or `~/.agentbreeder/.env` if no project). Catalog provider keys live only in your environment — only the env-var **name** is persisted, never the value.
 
 **Examples:**
 ```bash
-agentbreeder provider list                              # List all providers
+# Legacy (hand-written) providers
+agentbreeder provider list                                              # List all providers + catalog
 agentbreeder provider add openai                                        # Interactive setup
-agentbreeder provider add openai --api-key sk-proj-...              # Non-interactive
+agentbreeder provider add openai --api-key sk-proj-...                  # Non-interactive
 agentbreeder provider add ollama                                        # Auto-detect local Ollama
-agentbreeder provider add litellm --base-url http://localhost:4000      # Custom base URL (LiteLLM, Ollama, vLLM)
-agentbreeder provider test openai                       # Verify connection + latency
-agentbreeder provider models openai                     # List available models
-agentbreeder provider disable openai                    # Disable without removing
-agentbreeder provider enable openai                     # Re-enable
-agentbreeder provider remove openai                     # Remove provider + key
-agentbreeder provider list --json                       # JSON output
+agentbreeder provider test openai                                       # Verify connection + latency
+
+# OpenAI-compatible catalog (Track F)
+agentbreeder provider test nvidia                                       # Built-in preset; expects NVIDIA_API_KEY
+agentbreeder provider add my-vllm \
+  --type openai_compatible \
+  --base-url https://vllm.internal/v1 \
+  --api-key-env COMPANY_VLLM_KEY                                        # User-local entry
+agentbreeder provider remove my-vllm                                    # Remove user-local entry
+agentbreeder provider publish my-vllm                                   # Print PR patch for upstream catalog
+
+agentbreeder provider list --json                                       # JSON output
 ```
 
 ---

--- a/website/content/docs/deployment.mdx
+++ b/website/content/docs/deployment.mdx
@@ -32,8 +32,8 @@ CLI, the secrets backend, and the IAM model.
 | Stage | Command | Time |
 |---|---|---|
 | 1. Enable APIs | `gcloud services enable run + artifactregistry + cloudbuild + secretmanager` | ~5 sec (first run only) |
-| 2. Ensure Artifact Registry repo | `gcloud artifacts repositories create` (idempotent) | <1 sec |
-| 3. Push secrets to Secret Manager | `gcloud secrets create / versions add` | <1 sec |
+| 2. Ensure Artifact Registry repo | `gcloud artifacts repositories create` (idempotent) | &lt;1 sec |
+| 3. Push secrets to Secret Manager | `gcloud secrets create / versions add` | &lt;1 sec |
 | 4. Build + push image | `gcloud builds submit . --config <generated cloudbuild.yaml>` | ~3 min (first build) |
 | 5. Deploy to Cloud Run | `gcloud run deploy --update-secrets ...` | ~1 min |
 

--- a/website/content/docs/meta.json
+++ b/website/content/docs/meta.json
@@ -18,6 +18,7 @@
     "authentication",
     "---Guides---",
     "gateway",
+    "providers",
     "how-to",
     "examples",
     "deployment",

--- a/website/content/docs/providers.mdx
+++ b/website/content/docs/providers.mdx
@@ -1,0 +1,184 @@
+---
+title: Providers
+description: How to add OpenAI-compatible LLM providers (Nvidia NIM, Groq, Together, Fireworks, OpenRouter, …) to AgentBreeder.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+
+# Providers
+
+AgentBreeder ships with a **catalog of OpenAI-compatible providers** so you can swap LLM backends with one line in `agent.yaml`. Most "new" providers (Nvidia NIM, Groq, Together, Fireworks, DeepInfra, Cerebras, Hyperbolic, Moonshot/Kimi, OpenRouter, …) speak the OpenAI Chat Completions wire format — the only differences are the base URL and the env var that holds the API key. The catalog captures both.
+
+```yaml
+# agent.yaml
+model:
+  primary: nvidia/meta-llama-3.1-405b-instruct   # any catalog provider
+  fallback: groq/mixtral-8x7b-32768              # any other catalog provider
+```
+
+When the engine sees `<provider>/<model>`, it looks `<provider>` up in the catalog, reads the API key from the env var declared on that entry, and constructs an OpenAI-compatible client pointed at the right URL. No new Python class required.
+
+---
+
+## Built-in catalog
+
+The presets ship in [`engine/providers/catalog.yaml`](https://github.com/agentbreeder/agentbreeder/blob/main/engine/providers/catalog.yaml).
+
+| Provider | Base URL | API key env var |
+|---|---|---|
+| `nvidia` | `https://integrate.api.nvidia.com/v1` | `NVIDIA_API_KEY` |
+| `openrouter` | `https://openrouter.ai/api/v1` | `OPENROUTER_API_KEY` |
+| `moonshot` | `https://api.moonshot.cn/v1` | `MOONSHOT_API_KEY` |
+| `groq` | `https://api.groq.com/openai/v1` | `GROQ_API_KEY` |
+| `together` | `https://api.together.xyz/v1` | `TOGETHER_API_KEY` |
+| `fireworks` | `https://api.fireworks.ai/inference/v1` | `FIREWORKS_API_KEY` |
+| `deepinfra` | `https://api.deepinfra.com/v1/openai` | `DEEPINFRA_API_KEY` |
+| `cerebras` | `https://api.cerebras.ai/v1` | `CEREBRAS_API_KEY` |
+| `hyperbolic` | `https://api.hyperbolic.xyz/v1` | `HYPERBOLIC_API_KEY` |
+
+List them at runtime:
+
+```bash
+agentbreeder provider list
+```
+
+<Callout type="info">
+The hand-written `openai`, `anthropic`, `google`, `ollama`, and `litellm` providers are unchanged. Use the catalog for everything else.
+</Callout>
+
+---
+
+## The four onboarding paths
+
+There are exactly four ways to bring a new provider online, ordered by how much code you have to write.
+
+### Path A — Built-in preset (zero code)
+
+If a provider ships in the catalog, just set the env var and reference it from `agent.yaml`:
+
+```bash
+export NVIDIA_API_KEY=nvapi-...
+```
+
+```yaml
+model:
+  primary: nvidia/meta-llama-3.1-405b-instruct
+```
+
+Test the connection without deploying:
+
+```bash
+agentbreeder provider test nvidia
+```
+
+### Path B — User-local entry (no upstream change)
+
+Adding a private/internal provider — a self-hosted vLLM, an internal mirror, a partner endpoint — uses the **user-local catalog** at `~/.agentbreeder/providers.local.yaml`. User-local entries take precedence over built-in ones with the same name (so you can override `nvidia` to point at an internal proxy).
+
+```bash
+agentbreeder provider add my-vllm \
+  --type openai_compatible \
+  --base-url https://vllm.internal.company.com/v1 \
+  --api-key-env COMPANY_VLLM_KEY
+
+export COMPANY_VLLM_KEY=...
+agentbreeder provider test my-vllm
+```
+
+```yaml
+# agent.yaml
+model:
+  primary: my-vllm/llama-3.1-70b-instruct
+```
+
+Remove it later:
+
+```bash
+agentbreeder provider remove my-vllm
+```
+
+<Callout type="warning">
+The user-local YAML is created with `0600` permissions, but it does **not** contain secrets — only env-var names. The actual API key lives in your environment, never on disk.
+</Callout>
+
+### Path C — Promote a user-local entry to a built-in preset
+
+If your user-local entry would help others (e.g. a public provider AgentBreeder doesn't ship yet), promote it:
+
+```bash
+agentbreeder provider publish my-vllm
+```
+
+The CLI prints the YAML snippet to append to `engine/providers/catalog.yaml` and explains how to open the PR.
+
+<Callout type="info">
+Automatic PR opening is on the roadmap — for now, the command prints the patch and exits with code `2`. Copy the snippet into a PR by hand against [`agentbreeder/agentbreeder`](https://github.com/agentbreeder/agentbreeder).
+</Callout>
+
+### Path D — Truly novel API shape (rare)
+
+If a provider speaks something other than OpenAI Chat Completions (e.g. a brand-new RPC dialect), you need a new Python class under `engine/providers/`. Open a PR with:
+
+1. `engine/providers/<name>_provider.py` implementing `ProviderBase`
+2. A new `ProviderType` enum value
+3. Registration in `_PROVIDER_CLASSES` in `engine/providers/registry.py`
+4. Unit tests against mocked HTTP
+
+Most "new" providers turn out to be OpenAI-compatible underneath, so reach for Paths A–C first.
+
+---
+
+## CLI reference
+
+```bash
+agentbreeder provider list                # built-in + user-local presets
+agentbreeder provider add <name> --type openai_compatible \
+  --base-url URL --api-key-env ENV         # user-local entry
+agentbreeder provider remove <name>       # remove user-local entry
+agentbreeder provider test <name>         # GET /models against the endpoint
+agentbreeder provider publish <name>      # print PR patch for upstream
+```
+
+For interactive setup of the legacy hand-written providers (`openai`, `anthropic`, `google`, `ollama`, `litellm`), use the existing `agentbreeder provider add openai` flow — no `--type` flag.
+
+---
+
+## How resolution works
+
+When the deploy pipeline parses `model.primary: nvidia/<model>`, the resolver:
+
+1. Splits on the first `/` into `(provider, model)`.
+2. Looks `provider` up in the merged catalog (built-in + user-local).
+3. If found, constructs an `OpenAICompatibleProvider` with `base_url` from the catalog and the API key from the entry's `api_key_env`.
+4. If the env var is unset at deploy time, the deploy fails fast with a clear "set `<ENV_VAR>`" message.
+
+Refs that don't match a catalog entry (`gpt-4o`, `claude-sonnet-4`, …) fall through to the existing resolver path — the catalog is purely additive.
+
+---
+
+## Special: OpenRouter headers
+
+OpenRouter requires `HTTP-Referer` and `X-Title` headers on every request. The catalog entry handles this automatically:
+
+```yaml
+# engine/providers/catalog.yaml (excerpt)
+openrouter:
+  type: openai_compatible
+  base_url: https://openrouter.ai/api/v1
+  api_key_env: OPENROUTER_API_KEY
+  default_headers:
+    HTTP-Referer: https://agentbreeder.io
+    X-Title: AgentBreeder
+```
+
+When you add a user-local entry that also needs custom headers, edit `~/.agentbreeder/providers.local.yaml` directly — the CLI doesn't expose `--default-headers` yet (filed for follow-up).
+
+---
+
+## See also
+
+- [`agent.yaml` reference](agent-yaml) — full schema for `model.primary` / `model.fallback`
+- [Gateway](gateway) — when to route through LiteLLM instead of calling a provider directly
+- [How-To Guide → connect a provider](how-to)
+- [CLI reference → `provider` commands](cli-reference)


### PR DESCRIPTION
## Summary

- **Generic provider class** (`engine/providers/openai_compatible.py`) replaces hand-written classes for any OpenAI-compatible upstream — parameterised by `base_url`, `api_key_env`, and `default_headers`.
- **Catalog YAML** (`engine/providers/catalog.yaml`) ships 9 built-in presets (nvidia, openrouter, moonshot, groq, together, fireworks, deepinfra, cerebras, hyperbolic), with a Pydantic-validated loader that merges user-local overrides from `~/.agentbreeder/providers.local.yaml`.
- **CLI + API + dashboard surface** so adding a provider is `agentbreeder provider add my-vllm --type openai_compatible --base-url URL --api-key-env ENV`, and `model.primary: nvidia/<model>` resolves through the existing engine path.

Closes #160

## Test plan

- [x] `pytest tests/unit/test_provider_catalog.py tests/integration/test_provider_catalog_cli.py` — 57 new tests pass
- [x] `pytest tests/unit/` — full unit suite passes (3937 passed, 8 skipped)
- [x] `pytest tests/unit/test_engine_providers.py tests/unit/test_provider_cmd.py` — no regression
- [x] `ruff check .` — passes
- [x] `ruff format --check .` — passes
- [x] `mypy engine/providers cli/commands/provider.py api/routes/providers.py` — no issues
- [x] Coverage on new files: `catalog.py` 98%, `openai_compatible.py` 83% (rest is the live streaming HTTP path)
- [x] `agentbreeder provider list --json` works and emits the 9 presets
- [x] `agentbreeder provider test nvidia` (with mocked HTTP) hits `GET /models` against the real `base_url`
- [x] `model.primary: nvidia/<model>` resolves via `engine.providers.registry.resolve_model_ref`

## What ships

| Layer | Files |
|---|---|
| Engine | `engine/providers/openai_compatible.py`, `engine/providers/catalog.py`, `engine/providers/catalog.yaml` |
| Engine wiring | `engine/providers/registry.py` (additive — `create_catalog_provider`, `resolve_model_ref`) |
| CLI | `cli/commands/provider.py` (extended: `--type openai_compatible`, `publish`, catalog-aware `test`/`remove`/`list`) |
| API | `api/routes/providers.py` (new `GET /api/v1/providers/catalog`) |
| Dashboard | `dashboard/src/components/provider-catalog.tsx`, `dashboard/src/pages/models.tsx`, `dashboard/src/lib/api.ts` |
| Docs | `website/content/docs/providers.mdx` (new), `website/content/docs/cli-reference.mdx`, `website/content/docs/meta.json` |
| Tests | `tests/unit/test_provider_catalog.py` (45), `tests/integration/test_provider_catalog_cli.py` (12), `tests/unit/test_provider_cmd.py` (existing tests updated for new JSON shape) |

## Deferred (with TODOs in code)

- **`provider publish` actual PR opening** — currently prints the catalog patch and exits with code `2`. Will land alongside `cli/commands/git.py` integration. (TODO comment in `cli/commands/provider.py`.)
- **Workspace-scoped catalogs** (`<workspace>/providers.yaml`) — Track A concern. (TODO comment in `engine/providers/catalog.py`.)
- **Dashboard Configure button to secret-entry modal** — wires to Track K (secrets-per-workspace). For now the button is a stub; the catalog table itself is functional.

## Decisions worth a review pass

1. **`ProviderType` enum stays closed.** The catalog provider uses `ProviderType.openai` on its `ProviderConfig` because the wire shape is OpenAI Chat Completions. The actual provider name (e.g. `nvidia`) lives on the instance and on every `GenerateResult`. The alternative was widening the enum, which would have rippled into the registry DB. Erring toward the additive change.
2. **Existing `provider list` JSON shape changed.** Was a flat list, now `{configured: [...], catalog: [...]}`. Two existing tests in `test_provider_cmd.py` updated to match.
3. **`provider publish` exits with code 2 (not 0/1).** Code 0 would suggest a PR was opened; code 1 implies an error. Code 2 means deferred feature — you need to act manually.
4. **No openai SDK dependency.** Mirrored the existing `OpenAIProvider` pattern of direct httpx calls for consistency and lighter footprint.
