### PR TITLE
fix(docs): escape <1 in deployment.mdx — unblocks Vercel build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 ## [Unreleased]
 
 ### Fixed
+- **MDX deployment-doc parser failure**: escape `<1 sec` in `website/content/docs/deployment.mdx` (Turbopack/MDX parses `<1` as start of a JSX tag). Was blocking Vercel preview builds on every PR.
+- **E2E API smoke `.local` TLD rejected**: switch test email to `@example.com` (RFC 2606); pydantic `email-validator` now rejects `.local` as a special-use TLD, breaking the Docker E2E smoke on every PR.
 - **Integration tests / Docker builds**: removed `@agentbreeder/aps-client` npm dep (package not yet published); vendor `aps-client.ts` source directly into Node.js Docker build context so `npm install` no longer fails with 404
 - **ESLint errors**: suppressed `react-hooks/set-state-in-effect` errors in `gateway.tsx`, `incidents.tsx`, `prompt-builder.tsx`; fixed root cause in `login.tsx` by initializing `mounted=true` (removes invisible form on first render — fixes E2E login tests)
 - **CI gate**: integration tests (`tests/integration/`) now run alongside unit tests in the `test-python` CI job

--- a/dashboard/tests/e2e-docker/api_smoke.sh
+++ b/dashboard/tests/e2e-docker/api_smoke.sh
@@ -32,7 +32,7 @@ curl -sf "$API/health" >/dev/null \
 
 echo
 echo "════ Auth flow ════"
-EMAIL="e2e-$(date +%s%N | head -c12)@test.local"
+EMAIL="e2e-$(date +%s%N | head -c12)@example.com"
 PASSWORD="Test1234!"
 
 REG_BODY=$(printf '{"email":"%s","password":"%s","name":"E2E"}' "$EMAIL" "$PASSWORD")

--- a/website/content/docs/deployment.mdx
+++ b/website/content/docs/deployment.mdx
@@ -32,8 +32,8 @@ CLI, the secrets backend, and the IAM model.
 | Stage | Command | Time |
 |---|---|---|
 | 1. Enable APIs | `gcloud services enable run + artifactregistry + cloudbuild + secretmanager` | ~5 sec (first run only) |
-| 2. Ensure Artifact Registry repo | `gcloud artifacts repositories create` (idempotent) | <1 sec |
-| 3. Push secrets to Secret Manager | `gcloud secrets create / versions add` | <1 sec |
+| 2. Ensure Artifact Registry repo | `gcloud artifacts repositories create` (idempotent) | &lt;1 sec |
+| 3. Push secrets to Secret Manager | `gcloud secrets create / versions add` | &lt;1 sec |
 | 4. Build + push image | `gcloud builds submit . --config <generated cloudbuild.yaml>` | ~3 min (first build) |
 | 5. Deploy to Cloud Run | `gcloud run deploy --update-secrets ...` | ~1 min |
 


### PR DESCRIPTION
## Summary

`website/content/docs/deployment.mdx` has `<1 sec` on lines 35-36. MDX/Turbopack parses `<1` as the start of a JSX tag and fails because `1` isn't a valid tag-name start char. This is currently failing the Vercel build on **every** PR (already saw it on #168, #169, #170). Pre-existing on main since the comprehensive docs update earlier today.

Fix: escape as `&lt;1 sec`. Renders identically.

## Test plan

- [x] `grep '<[0-9]' website/content/docs/*.mdx` — no remaining cases
- [ ] Vercel preview build passes on this PR (will confirm once CI runs)
