### PR TITLE
fix(local-stack): wire keys, isolate LiteLLM DB, sync endpoint_url with auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+### Fixed
+- **Local stack UX**: compose now wires `GOOGLE_API_KEY`, `LITELLM_BASE_URL`, `LITELLM_MASTER_KEY`, `AGENTBREEDER_INSTALL_MODE=team` into the API container. `/playground` and `/api/v1/secrets` now work out of the box on `docker compose up`.
+- **LiteLLM trampling agentbreeder DB**: `STORE_MODEL_IN_DB: False` so LiteLLM's prisma migrations don't run against the shared database (which was wiping the `users` table). Stateless mode is fine for the playground; re-enable with a separate DB when virtual keys / DB-stored configs are needed.
+- **`gemini-2.5-flash` not in LiteLLM config**: added to `deploy/litellm_config.yaml` (also fixed `GOOGLE_AI_API_KEY` → `GOOGLE_API_KEY` typo on `gemini-2.5-pro`).
+- **Deploy → registry sync 401 (`endpoint_url` empty after deploy)**: `engine/builder.py` now attaches `AGENTBREEDER_API_TOKEN` as a Bearer header when set, so the post-deploy `PUT /api/v1/agents/{id}` succeeds and the registry record gets a real `endpoint_url` for cloud deploys.
+
 ### Added
 - **Generic OpenAI-compatible provider + 9-preset catalog** (#160): `engine/providers/openai_compatible.py` parameterised by `base_url`/`api_key_env`/`default_headers` replaces what would have been 9 hand-written classes. New `engine/providers/catalog.yaml` ships nvidia, openrouter, moonshot (Kimi K2), groq, together, fireworks, deepinfra, cerebras, hyperbolic — merged with `~/.agentbreeder/providers.local.yaml` overrides at load time. New CLI: `agentbreeder provider list/add/remove/test/publish`. New API route `GET /api/v1/providers/catalog`. Dashboard `/models` page lists catalog presets with a Configure stub. `model.primary: nvidia/<model>` resolves through the existing engine path.
 - **Sidecar — cross-cutting concerns layer** (#161): single Go binary auto-injected next to every agent that declares `guardrails:`, MCP `tools:`, or `a2a:`. Fronts the agent on `:8080` (bearer-token auth + guardrail egress checks → reverse proxy to `:8081`) and exposes `localhost:9090` helpers for A2A JSON-RPC, MCP HTTP/SSE passthrough, and cost emission. Auto-injection wired into docker-compose, GCP Cloud Run, and AWS ECS deployers. `AGENTBREEDER_SIDECAR=disabled` bypasses for local dev. New top-level `sidecar/` Go module (~89% test coverage), Dockerfile, image build target `rajits/agentbreeder-sidecar:<version>`, and docs at `website/content/docs/sidecar.mdx`.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -35,8 +35,17 @@ services:
       DATABASE_URL: postgresql+asyncpg://agentbreeder:agentbreeder@postgres:5432/agentbreeder
       REDIS_URL: redis://redis:6379
       AGENTBREEDER_ENV: development
+      AGENTBREEDER_INSTALL_MODE: team  # falls back to env backend (no keyring inside container)
       SECRET_KEY: docker-dev-secret-key-change-in-prod
       JWT_SECRET_KEY: docker-dev-jwt-key-change-in-prod
+      LITELLM_BASE_URL: http://litellm:4000
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-sk-litellm-dev}
+      # Provider keys for /playground model chat (read by LiteLLM)
+      GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-${GOOGLE_API_KEY:-}}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
     depends_on:
       postgres:
         condition: service_healthy
@@ -76,8 +85,15 @@ services:
     ports:
       - "4000:4000"
     environment:
-      DATABASE_URL: postgresql://agentbreeder:agentbreeder@postgres:5432/agentbreeder
-      STORE_MODEL_IN_DB: "True"
+      # Stateless mode — disabled DB-backed model registry to prevent LiteLLM's
+      # prisma migrations from corrupting the agentbreeder schema (they share
+      # one postgres instance). Re-enable with a separate DATABASE_URL when
+      # virtual keys / DB-stored configs are needed.
+      STORE_MODEL_IN_DB: "False"
+      GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-sk-litellm-dev}
     depends_on:
       postgres:
         condition: service_healthy

--- a/deploy/litellm_config.yaml
+++ b/deploy/litellm_config.yaml
@@ -10,7 +10,11 @@ model_list:
   - model_name: gemini-2.5-pro
     litellm_params:
       model: gemini/gemini-2.5-pro
-      api_key: os.environ/GOOGLE_AI_API_KEY
+      api_key: os.environ/GOOGLE_API_KEY
+  - model_name: gemini-2.5-flash
+    litellm_params:
+      model: gemini/gemini-2.5-flash
+      api_key: os.environ/GOOGLE_API_KEY
 
 general_settings:
   master_key: os.environ/LITELLM_MASTER_KEY

--- a/engine/builder.py
+++ b/engine/builder.py
@@ -276,9 +276,12 @@ class DeployEngine:
 
         # ── Step 2: dashboard API upsert (best-effort) ────────────────────────
         api_base = os.environ.get("AGENTBREEDER_API_URL", "http://localhost:8000")
-        self._sync_to_api(config, endpoint_url, api_base)
+        api_token = os.environ.get("AGENTBREEDER_API_TOKEN", "")
+        self._sync_to_api(config, endpoint_url, api_base, api_token)
 
-    def _sync_to_api(self, config: AgentConfig, endpoint_url: str, api_base: str) -> None:
+    def _sync_to_api(
+        self, config: AgentConfig, endpoint_url: str, api_base: str, api_token: str = ""
+    ) -> None:
         """Upsert the deployed agent into the dashboard API.
 
         Uses a search-first strategy:
@@ -286,11 +289,16 @@ class DeployEngine:
           PUT  /api/v1/agents/{id}             — update if found
           POST /api/v1/agents                  — create if not found
 
+        Auth: if ``AGENTBREEDER_API_TOKEN`` is set in the env, attach it as a
+        Bearer token. Without it the dashboard's auth gate (all 247 routes are
+        gated) returns 401 and the sync is best-effort/skipped.
+
         All errors are caught so the deploy is never blocked.
         """
         base = api_base.rstrip("/")
+        headers = {"Authorization": f"Bearer {api_token}"} if api_token else {}
         try:
-            with httpx.Client(timeout=5.0) as client:
+            with httpx.Client(timeout=5.0, headers=headers) as client:
                 # Search for an existing agent with the exact name
                 search_resp = client.get(
                     f"{base}/api/v1/agents/search",


### PR DESCRIPTION
## Summary

Fixes the rough spots that surfaced during a manual UI tour of the freshly-merged v2 stack.

- **`/playground` "no model available"** → API container missing `GOOGLE_API_KEY`, `LITELLM_BASE_URL`, `LITELLM_MASTER_KEY` in compose
- **`/api/v1/secrets` 500 NoKeyringError** → API defaulted to OS keychain inside Docker; set `AGENTBREEDER_INSTALL_MODE=team` so the factory falls back to env
- **LiteLLM corrupting the agentbreeder DB** → its prisma migrations ran against the shared database on every compose up, wiping the `users` table. Set `STORE_MODEL_IN_DB: False` (stateless mode is fine for playground)
- **`gemini-2.5-flash` missing from gateway** + `GOOGLE_AI_API_KEY` typo on `gemini-2.5-pro` in `deploy/litellm_config.yaml`
- **Deploy → registry sync 401** → `engine/builder._sync_to_api` had no auth header, so cloud-deployed agents had empty `endpoint_url` in the registry. Now reads `AGENTBREEDER_API_TOKEN` and attaches as Bearer.

## Test plan

- [x] `docker compose -f deploy/docker-compose.yml up -d` then smoke `/playground` — returns real Gemini response (~1s)
- [x] `GET /api/v1/secrets` returns `{data:[],…}` (no NoKeyringError)
- [x] `docker compose down && up` no longer wipes the demo user
- [x] `gemini-2.5-flash` resolves through LiteLLM gateway at `:4000`
- [ ] Cloud deploy with `AGENTBREEDER_API_TOKEN` set → registry record has live `endpoint_url` (manually verified by patching record; deploy-side verification deferred)

## Out of scope

- /models page UX gaps (Add provider RBAC, Configure button stub, Scan, LiteLLM not shown) — tracked separately
- Bearer token auto-fill on `/agents/{id}?tab=invoke` — tracked separately
- Playground talking to deployed agents instead of just models — tracked separately
