### PR TITLE
feat(gateways): LiteLLM + OpenRouter as first-class (#164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+### Added
+- **Gateways as first-class providers — LiteLLM + OpenRouter** (#164, Track H): the catalog schema now distinguishes `type: openai_compatible` (one upstream) from `type: gateway` (many upstreams). `engine/providers/catalog.yaml` ships `litellm` and `openrouter` as built-in `gateway` presets, and `model.primary` accepts a 3-segment ref `<gateway>/<upstream>/<model>` (e.g. `openrouter/moonshotai/kimi-k2`, `litellm/anthropic/claude-sonnet-4`) — parsed by the new `engine.providers.catalog.parse_gateway_ref`. The wire-level `model` field is shaped as `<upstream>/<model>` so both LiteLLM and OpenRouter accept it as-is. New optional `gateways:` block on `agent.yaml` lets you override the catalog `url` / `api_key_env` / `fallback_policy` / `default_headers` per-gateway (the long-term home is `workspace.yaml` once Track A / #146 ships). The dashboard `/models` page now has a working **Gateways** tab — same Configure flow as Direct providers, with a small `gateway` badge per row. Backwards-compat: existing 2-segment direct refs (`nvidia/llama-…`) and `model.gateway: litellm` configs keep working unchanged. New docs page at `website/content/docs/gateways.mdx` covering when to pick which gateway and how 3-segment refs route end-to-end.
+
 ### Fixed
 - **Local stack UX**: compose now wires `GOOGLE_API_KEY`, `LITELLM_BASE_URL`, `LITELLM_MASTER_KEY`, `AGENTBREEDER_INSTALL_MODE=team` into the API container. `/playground` and `/api/v1/secrets` now work out of the box on `docker compose up`.
 - **LiteLLM trampling agentbreeder DB**: `STORE_MODEL_IN_DB: False` so LiteLLM's prisma migrations don't run against the shared database (which was wiping the `users` table). Stateless mode is fine for the playground; re-enable with a separate DB when virtual keys / DB-stored configs are needed.

--- a/dashboard/src/components/provider-catalog.tsx
+++ b/dashboard/src/components/provider-catalog.tsx
@@ -44,9 +44,28 @@ const VIEWER_TOOLTIP = "Requires deployer role";
 interface ProviderCatalogProps {
   /** Optional override callback — when omitted, the built-in modal is used. */
   onConfigure?: (provider: CatalogProvider) => void;
+  /**
+   * Filter the catalog by entry kind. Defaults to ``"openai_compatible"``
+   * so the existing Direct providers tab keeps the same content. Set to
+   * ``"gateway"`` for the Track H Gateways tab; ``"all"`` returns every
+   * preset.
+   */
+  filter?: "openai_compatible" | "gateway" | "all";
+  /** Heading shown above the catalog rows. */
+  heading?: string;
+  /** Helper copy shown to the right of the heading. */
+  hint?: string;
 }
 
-export function ProviderCatalog({ onConfigure }: ProviderCatalogProps) {
+const DEFAULT_HINT =
+  "Click Configure to connect — keys live in your workspace secrets backend, never the database";
+
+export function ProviderCatalog({
+  onConfigure,
+  filter = "openai_compatible",
+  heading = "OpenAI-Compatible Catalog",
+  hint = DEFAULT_HINT,
+}: ProviderCatalogProps) {
   const { user } = useAuth();
   const canConfigure = !!user && DEPLOYER_ROLES.has(user.role);
   const [activeProvider, setActiveProvider] = useState<CatalogProvider | null>(null);
@@ -79,9 +98,17 @@ export function ProviderCatalog({ onConfigure }: ProviderCatalogProps) {
     );
   }
 
-  const presets = catalogQuery.data?.data ?? [];
+  const allPresets = catalogQuery.data?.data ?? [];
+  const presets =
+    filter === "all"
+      ? allPresets
+      : allPresets.filter((p) => p.type === filter);
   if (presets.length === 0) {
-    return null;
+    return (
+      <div className="rounded-lg border border-border bg-muted/20 p-4 text-xs text-muted-foreground">
+        No {filter === "gateway" ? "gateways" : "providers"} in the catalog yet.
+      </div>
+    );
   }
 
   const statuses = statusQuery.data?.data ?? {};
@@ -100,15 +127,13 @@ export function ProviderCatalog({ onConfigure }: ProviderCatalogProps) {
         <div className="flex items-center justify-between border-b border-border/50 px-4 py-3">
           <div className="flex items-center gap-2">
             <Server className="size-3.5 text-muted-foreground" />
-            <h3 className="text-sm font-semibold">OpenAI-Compatible Catalog</h3>
+            <h3 className="text-sm font-semibold">{heading}</h3>
             <Badge variant="outline" className="text-[10px]">
-              {presets.length} providers
+              {presets.length} {filter === "gateway" ? "gateways" : "providers"}
             </Badge>
           </div>
           <div className="flex items-center gap-3">
-            <span className="text-[11px] text-muted-foreground">
-              Click Configure to connect — keys live in your workspace secrets backend, never the database
-            </span>
+            <span className="text-[11px] text-muted-foreground">{hint}</span>
             {canConfigure ? (
               <Button
                 size="sm"
@@ -167,11 +192,21 @@ interface CatalogRowProps {
 
 function CatalogRow({ preset, configured, canConfigure, onConfigure }: CatalogRowProps) {
   const isUserLocal = preset.source === "user-local";
+  const isGateway = preset.type === "gateway";
 
   return (
     <div className="flex items-center gap-4 px-4 py-3">
       <div className="flex min-w-0 flex-1 items-center gap-3">
         <div className="font-medium text-sm capitalize">{preset.name}</div>
+        {isGateway && (
+          <Badge
+            variant="outline"
+            className="border-violet-500/30 bg-violet-500/10 text-[10px] text-violet-600 dark:text-violet-400"
+            data-testid={`catalog-type-gateway-${preset.name}`}
+          >
+            gateway
+          </Badge>
+        )}
         {isUserLocal && (
           <Badge variant="secondary" className="text-[10px]">
             user-local

--- a/dashboard/src/pages/models.tsx
+++ b/dashboard/src/pages/models.tsx
@@ -540,12 +540,11 @@ export default function ModelsPage() {
         </div>
       </div>
 
-      {/* Provider source tabs (issue #175).
+      {/* Provider source tabs (issues #175 + #164).
           - Direct providers: built-in OpenAI-compatible catalog (Track F / #160).
-          - Gateways: LiteLLM / OpenRouter — content lands with Track H (#164).
-          - Local: Ollama / vLLM / etc. — content lands later.
-          Currently only "Direct providers" is enabled. Tabs scaffold ships
-          here so issue #164's PR can just enable the panel. */}
+          - Gateways: LiteLLM + OpenRouter (Track H / #164) — same configure
+            flow as Direct, plus 3-segment model refs `<gateway>/<upstream>/<model>`.
+          - Local: Ollama / vLLM / etc. — content lands later. */}
       <div className="mb-4">
         <Tabs defaultValue="direct" className="gap-3">
           <div className="flex items-center justify-between">
@@ -553,12 +552,7 @@ export default function ModelsPage() {
               <TabsTrigger value="direct" className="text-xs">
                 Direct providers
               </TabsTrigger>
-              <TabsTrigger
-                value="gateways"
-                className="text-xs"
-                disabled
-                title="Coming with Track H — issue #164"
-              >
+              <TabsTrigger value="gateways" className="text-xs">
                 Gateways
               </TabsTrigger>
               <TabsTrigger
@@ -583,12 +577,14 @@ export default function ModelsPage() {
             </Button>
           </div>
           <TabsContent value="direct">
-            <ProviderCatalog />
+            <ProviderCatalog filter="openai_compatible" />
           </TabsContent>
           <TabsContent value="gateways">
-            <div className="rounded-lg border border-border bg-muted/20 p-4 text-xs text-muted-foreground">
-              Gateways tab content ships with Track H (#164).
-            </div>
+            <ProviderCatalog
+              filter="gateway"
+              heading="Model Gateways"
+              hint="Reference gateway models in agent.yaml as <gateway>/<upstream>/<model>"
+            />
           </TabsContent>
           <TabsContent value="local">
             <div className="rounded-lg border border-border bg-muted/20 p-4 text-xs text-muted-foreground">

--- a/engine/config_parser.py
+++ b/engine/config_parser.py
@@ -68,6 +68,28 @@ class ModelConfig(BaseModel):
     max_tokens: int | None = None
 
 
+class GatewayConfig(BaseModel):
+    """Per-gateway configuration block (Track H / #164).
+
+    Lets ``agent.yaml`` (and Track A's ``workspace.yaml``) override the
+    catalog default for a gateway — typically the URL of a self-hosted
+    LiteLLM proxy or a regional OpenRouter endpoint.
+
+    All fields are optional. Missing fields fall back to the catalog
+    default and the env-var declared in ``catalog.yaml``.
+
+    TODO(track-a): the canonical home for this block is ``workspace.yaml``;
+    repeating it per-agent is a stop-gap until Track A ships #146.
+    """
+
+    url: str | None = None
+    api_key_env: str | None = None
+    fallback_policy: str | None = (
+        None  # "fastest" | "cheapest" | "first" — advisory, not enforced yet
+    )
+    default_headers: dict[str, str] = Field(default_factory=dict)
+
+
 class ToolRef(BaseModel):
     ref: str | None = None
     name: str | None = None
@@ -277,6 +299,10 @@ class AgentConfig(BaseModel):
     memory: MemoryConfig | None = None
     deploy: DeployConfig
     access: AccessConfig = Field(default_factory=AccessConfig)
+    # Track H (#164) — per-agent override of catalog gateway settings.
+    # Long-term home is workspace.yaml (Track A / #146); accepting it here
+    # too means agents can be self-contained for now.
+    gateways: dict[str, GatewayConfig] = Field(default_factory=dict)
     crewai: CrewAIConfig | None = None
     google_adk: GoogleADKConfig | None = None
     claude_sdk: ClaudeSDKConfig = Field(default_factory=ClaudeSDKConfig)

--- a/engine/providers/catalog.py
+++ b/engine/providers/catalog.py
@@ -196,9 +196,15 @@ def parse_model_ref(ref: str) -> tuple[str, str] | None:
     catalog, else ``None``. The model_id may itself contain ``/`` (e.g.
     ``meta/llama-3.1-405b``) — only the first segment is matched as provider.
 
+    For gateway-type entries the *full remainder* is preserved as the model_id
+    because gateways need to forward the upstream-provider prefix on the wire
+    (e.g. OpenRouter expects ``model: "anthropic/claude-sonnet-4"``).
+
     Examples:
         >>> parse_model_ref("nvidia/meta-llama-3.1-405b-instruct")
         ("nvidia", "meta-llama-3.1-405b-instruct")
+        >>> parse_model_ref("openrouter/anthropic/claude-sonnet-4")
+        ("openrouter", "anthropic/claude-sonnet-4")
         >>> parse_model_ref("gpt-4o")  # no slash, not catalog
         None
     """
@@ -210,3 +216,58 @@ def parse_model_ref(ref: str) -> tuple[str, str] | None:
     if get_entry(provider) is None:
         return None
     return provider, model
+
+
+class GatewayModelRef(BaseModel):
+    """A parsed 3-segment gateway ref: ``<gateway>/<upstream>/<model>``.
+
+    Track H (#164) — gateways fan out to many upstreams. The dashboard /
+    CLI / config-parser use this struct to route a request through the
+    correct gateway instance.
+    """
+
+    gateway: str
+    upstream_provider: str
+    model: str
+
+    @property
+    def upstream_model(self) -> str:
+        """The id to put in the wire payload's ``model`` field.
+
+        Both LiteLLM and OpenRouter accept ``<upstream>/<model>`` as the
+        canonical model id, so we re-join the last two segments.
+        """
+        return f"{self.upstream_provider}/{self.model}"
+
+
+def parse_gateway_ref(ref: str) -> GatewayModelRef | None:
+    """Parse a 3-segment gateway ref (Track H / #164).
+
+    Returns a :class:`GatewayModelRef` when:
+      - ``ref`` has at least 3 ``/``-separated segments, and
+      - the first segment names a catalog entry whose ``type == "gateway"``.
+
+    Otherwise returns ``None``. Anything that's not a gateway ref (including
+    plain ``<provider>/<model>`` direct refs) returns ``None`` so callers
+    can fall back to :func:`parse_model_ref`.
+
+    Examples:
+        >>> parse_gateway_ref("openrouter/moonshotai/kimi-k2")
+        GatewayModelRef(gateway="openrouter", upstream_provider="moonshotai", model="kimi-k2")
+        >>> parse_gateway_ref("litellm/anthropic/claude-sonnet-4")
+        GatewayModelRef(gateway="litellm", upstream_provider="anthropic", model="claude-sonnet-4")
+        >>> parse_gateway_ref("nvidia/meta-llama-3.1-405b")  # direct, not gateway
+        None
+        >>> parse_gateway_ref("openrouter/auto")  # 2-segment → None (callers fall back)
+        None
+    """
+    parts = ref.split("/", 2)
+    if len(parts) < 3:
+        return None
+    gateway, upstream, model = parts
+    if not gateway or not upstream or not model:
+        return None
+    entry = get_entry(gateway)
+    if entry is None or entry.type != "gateway":
+        return None
+    return GatewayModelRef(gateway=gateway, upstream_provider=upstream, model=model)

--- a/engine/providers/catalog.yaml
+++ b/engine/providers/catalog.yaml
@@ -1,7 +1,14 @@
 # AgentBreeder provider catalog
 #
-# Built-in OpenAI-compatible providers. Each entry parameterises the generic
-# OpenAICompatibleProvider with a base_url, api_key_env, and optional headers.
+# Two entry kinds:
+#   - `type: openai_compatible` — talks to a single upstream
+#     (Nvidia, Groq, Moonshot, …). Reference as `<provider>/<model>`.
+#   - `type: gateway` — fans out to many upstreams via a 3-segment ref
+#     `<gateway>/<upstream-provider>/<model>` (Track H / #164).
+#
+# Both kinds parameterise the same generic OpenAICompatibleProvider with
+# a base_url, api_key_env, and optional headers — the difference is purely
+# how `model.primary` is parsed and how the model id is shaped on the wire.
 #
 # Adding a new built-in preset: open a PR that appends an entry below. Most
 # providers ship the OpenAI Chat Completions shape, so no engine code changes
@@ -10,8 +17,8 @@
 # User-local overrides live in `~/.agentbreeder/providers.local.yaml` and are
 # merged on top of this catalog at load time.
 #
-# TODO(track-a): workspace-scoped catalogs (`<workspace>/providers.yaml`) ship
-# with Track A — the workspace primitive.
+# TODO(track-a): workspace-scoped catalogs (`<workspace>/providers.yaml`) and
+# the top-level `gateways:` block in `workspace.yaml` ship with Track A.
 version: 1
 providers:
   nvidia:
@@ -20,8 +27,14 @@ providers:
     api_key_env: NVIDIA_API_KEY
     docs: https://build.nvidia.com/models
     discovery: openai-models-list
+  # ── Gateways (Track H / #164) ────────────────────────────────────────────
+  # `type: gateway` providers fan out to many upstreams and are referenced
+  # via 3-segment refs: `<gateway>/<upstream-provider>/<model>`.
+  # Examples:
+  #   model.primary: openrouter/anthropic/claude-sonnet-4
+  #   model.primary: litellm/openai/gpt-4o
   openrouter:
-    type: openai_compatible
+    type: gateway
     base_url: https://openrouter.ai/api/v1
     api_key_env: OPENROUTER_API_KEY
     default_headers:
@@ -29,6 +42,20 @@ providers:
       X-Title: AgentBreeder
     docs: https://openrouter.ai/models
     discovery: openai-models-list
+  litellm:
+    type: gateway
+    # Default to local docker-compose stack; override via `~/.agentbreeder/providers.local.yaml`
+    # or (Track A) workspace.yaml `gateways.litellm.url` for a remote proxy.
+    base_url: http://localhost:4000
+    api_key_env: LITELLM_MASTER_KEY
+    docs: https://docs.litellm.ai/docs/proxy/quick_start
+    discovery: openai-models-list
+    notable_models:
+      - openai/gpt-4o
+      - anthropic/claude-sonnet-4-6
+      - gemini/gemini-2.5-pro
+      - gemini/gemini-2.5-flash
+  # ── Direct OpenAI-compatible providers (Track F / #160) ──────────────────
   moonshot:
     type: openai_compatible
     base_url: https://api.moonshot.cn/v1

--- a/engine/providers/openai_compatible.py
+++ b/engine/providers/openai_compatible.py
@@ -331,6 +331,11 @@ def from_catalog(
 
     Reads the api key from the env var declared on the catalog entry. Raises
     :class:`KeyError` if ``name`` is not in the catalog (built-in or user-local).
+
+    For ``type: gateway`` entries (Track H / #164) the ``base_url`` may be
+    overridden by the gateway-specific env var (e.g. ``LITELLM_BASE_URL``,
+    ``OPENROUTER_BASE_URL``) so the same catalog entry serves local-dev
+    docker-compose, self-hosted, and SaaS deployments.
     """
     # Local import to avoid a circular dep — catalog imports nothing from here.
     from engine.providers.catalog import get_entry
@@ -346,9 +351,18 @@ def from_catalog(
     # ``provider_name`` on the instance and on every result.
     from engine.providers.models import ProviderType
 
+    base_url = str(entry.base_url)
+    if entry.type == "gateway":
+        # Gateways can be relocated (local proxy → SaaS endpoint) without
+        # editing the catalog. Convention: <NAME>_BASE_URL overrides the
+        # built-in default.
+        override = os.environ.get(f"{name.upper()}_BASE_URL")
+        if override:
+            base_url = override
+
     config = ProviderConfig(
         provider_type=ProviderType.openai,
-        base_url=str(entry.base_url),
+        base_url=base_url,
         default_model=default_model,
         timeout=timeout,
     )

--- a/engine/providers/registry.py
+++ b/engine/providers/registry.py
@@ -86,19 +86,41 @@ def resolve_model_ref(
     *,
     timeout: float = 60.0,
 ) -> ProviderBase | None:
-    """Resolve a ``<provider>/<model>`` ref against the catalog.
+    """Resolve a model reference against the catalog.
 
-    Returns a configured provider with ``default_model`` set to the model
-    portion, or ``None`` if ``ref`` doesn't match a catalog provider. This is
-    the entry point used by ``agent.yaml`` ``model.primary`` resolution.
+    Supports two ref shapes:
+
+    * **2-segment direct** — ``<provider>/<model>`` (e.g.
+      ``nvidia/meta-llama-3.1-405b-instruct``). Resolves to the catalog
+      provider for ``provider`` with ``default_model = model``.
+
+    * **3-segment gateway** — ``<gateway>/<upstream>/<model>`` (Track H /
+      #164, e.g. ``openrouter/moonshotai/kimi-k2``). Resolves to the
+      gateway's catalog entry; the wire ``model`` field is shaped as
+      ``<upstream>/<model>``. Only matches when the first segment names
+      a catalog entry whose ``type == "gateway"``.
+
+    Returns ``None`` if neither shape matches.
 
     Examples:
         >>> resolve_model_ref("nvidia/meta-llama-3.1-405b-instruct")
         <OpenAICompatibleProvider name="nvidia" model="meta-llama-3.1-405b-instruct">
+        >>> resolve_model_ref("openrouter/moonshotai/kimi-k2")
+        <OpenAICompatibleProvider name="openrouter" model="moonshotai/kimi-k2">
         >>> resolve_model_ref("gpt-4o")  # not in catalog → None
         None
     """
-    from engine.providers.catalog import parse_model_ref
+    from engine.providers.catalog import parse_gateway_ref, parse_model_ref
+
+    # Try 3-segment gateway form first — it's strictly more specific than
+    # the direct form and always wins when the first segment is a gateway.
+    gateway_ref = parse_gateway_ref(ref)
+    if gateway_ref is not None:
+        return create_catalog_provider(
+            gateway_ref.gateway,
+            default_model=gateway_ref.upstream_model,
+            timeout=timeout,
+        )
 
     parsed = parse_model_ref(ref)
     if parsed is None:

--- a/engine/schema/agent.schema.json
+++ b/engine/schema/agent.schema.json
@@ -545,6 +545,33 @@
         }
       }
     },
+    "gateways": {
+      "type": "object",
+      "description": "Per-gateway overrides for the catalog defaults (Track H / #164). Maps gateway name -> {url, api_key_env, fallback_policy, default_headers}. Long-term home is workspace.yaml (Track A / #146).",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Override the catalog base_url for this gateway."
+          },
+          "api_key_env": {
+            "type": "string",
+            "description": "Override the env var the gateway reads its api key from."
+          },
+          "fallback_policy": {
+            "type": "string",
+            "enum": ["fastest", "cheapest", "first"],
+            "description": "Advisory routing hint when the gateway supports multiple upstreams. Not enforced yet."
+          },
+          "default_headers": {
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+          }
+        }
+      }
+    },
     "crewai": {
       "type": "object",
       "description": "CrewAI-specific configuration. Only relevant when framework is crewai.",

--- a/tests/unit/test_config_parser.py
+++ b/tests/unit/test_config_parser.py
@@ -569,3 +569,59 @@ deploy:
         result = validate_config(config_file)
         assert result.valid, result.errors
         assert result.config.type.value == "mcp-server"
+
+
+# ─── Gateways block (Track H / #164) ─────────────────────────────────────────
+
+
+class TestGatewaysConfig:
+    """The optional `gateways:` block lets agent.yaml override catalog defaults."""
+
+    def test_gateways_block_parses(self) -> None:
+        path = _write_yaml("""\
+name: gw-agent
+version: 1.0.0
+team: platform
+owner: alice@example.com
+framework: langgraph
+model:
+  primary: openrouter/moonshotai/kimi-k2
+gateways:
+  openrouter:
+    api_key_env: TEAM_OPENROUTER_KEY
+  litellm:
+    url: https://litellm.platform.example.com/v1
+    fallback_policy: fastest
+    default_headers:
+      X-Tenant: agentbreeder
+deploy:
+  cloud: local
+""")
+        config = parse_config(path)
+        assert "openrouter" in config.gateways
+        assert config.gateways["openrouter"].api_key_env == "TEAM_OPENROUTER_KEY"
+        assert config.gateways["litellm"].url == "https://litellm.platform.example.com/v1"
+        assert config.gateways["litellm"].fallback_policy == "fastest"
+        assert config.gateways["litellm"].default_headers["X-Tenant"] == "agentbreeder"
+
+    def test_gateways_default_to_empty_dict(self) -> None:
+        path = _write_yaml(VALID_YAML)
+        config = parse_config(path)
+        assert config.gateways == {}
+
+    def test_three_segment_model_primary_accepted(self) -> None:
+        # The parser should not reject 3-segment refs — the catalog resolver
+        # handles the actual validation.
+        path = _write_yaml("""\
+name: gw-agent
+version: 1.0.0
+team: platform
+owner: alice@example.com
+framework: langgraph
+model:
+  primary: litellm/anthropic/claude-sonnet-4
+deploy:
+  cloud: local
+""")
+        config = parse_config(path)
+        assert config.model.primary == "litellm/anthropic/claude-sonnet-4"

--- a/tests/unit/test_provider_catalog.py
+++ b/tests/unit/test_provider_catalog.py
@@ -26,10 +26,12 @@ from engine.providers.catalog import (
     Catalog,
     CatalogEntry,
     CatalogError,
+    GatewayModelRef,
     _parse_catalog,
     get_entry,
     list_entries,
     load_catalog,
+    parse_gateway_ref,
     parse_model_ref,
     reset_cache,
 )
@@ -720,3 +722,245 @@ class TestWriteUserLocal:
 
             reset_cache()
             assert get_entry("my-vllm") is not None
+
+
+# ─── Gateway type entries (Track H / #164) ─────────────────────────────────
+
+
+class TestGatewayCatalogEntries:
+    """Built-in gateway entries — LiteLLM + OpenRouter — exist with type=gateway."""
+
+    def setup_method(self) -> None:
+        reset_cache()
+
+    def teardown_method(self) -> None:
+        reset_cache()
+
+    def test_openrouter_is_gateway_type(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            entry = get_entry("openrouter")
+        assert entry is not None
+        assert entry.type == "gateway"
+
+    def test_litellm_preset_present(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            entry = get_entry("litellm")
+        assert entry is not None
+        assert entry.type == "gateway"
+        assert entry.api_key_env == "LITELLM_MASTER_KEY"
+        assert "4000" in str(entry.base_url)
+
+    def test_litellm_notable_models_seeded(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            entry = get_entry("litellm")
+        assert entry is not None
+        # Cross-check that compose-shipped LiteLLM models are advertised so the
+        # quickstart `model.primary: litellm/...` examples actually work.
+        assert "openai/gpt-4o" in entry.notable_models
+        assert any("claude" in m for m in entry.notable_models)
+
+    def test_direct_provider_keeps_openai_compatible_type(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            for name in ("nvidia", "groq", "moonshot", "fireworks", "cerebras"):
+                entry = get_entry(name)
+                assert entry is not None, f"missing direct provider: {name}"
+                assert entry.type == "openai_compatible", (
+                    f"direct provider {name} regressed to non-direct type"
+                )
+
+
+class TestParseGatewayRef:
+    def setup_method(self) -> None:
+        reset_cache()
+
+    def teardown_method(self) -> None:
+        reset_cache()
+
+    def test_openrouter_three_segment_ref(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            ref = parse_gateway_ref("openrouter/moonshotai/kimi-k2")
+        assert isinstance(ref, GatewayModelRef)
+        assert ref.gateway == "openrouter"
+        assert ref.upstream_provider == "moonshotai"
+        assert ref.model == "kimi-k2"
+        assert ref.upstream_model == "moonshotai/kimi-k2"
+
+    def test_litellm_three_segment_ref(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            ref = parse_gateway_ref("litellm/anthropic/claude-sonnet-4")
+        assert ref is not None
+        assert ref.gateway == "litellm"
+        assert ref.upstream_model == "anthropic/claude-sonnet-4"
+
+    def test_two_segment_returns_none(self) -> None:
+        # Two-segment refs are direct refs — gateway parser returns None and
+        # callers fall through to parse_model_ref.
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            assert parse_gateway_ref("openrouter/auto") is None
+            assert parse_gateway_ref("nvidia/llama-3.1-405b") is None
+
+    def test_first_segment_must_be_gateway_type(self) -> None:
+        # nvidia exists in the catalog but is type=openai_compatible — the
+        # 3-segment form must NOT match it (otherwise direct refs whose model
+        # contains a slash, e.g. nvidia/meta/llama-3.1, would be miscategorised).
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            assert parse_gateway_ref("nvidia/meta/llama-3.1-405b") is None
+
+    def test_unknown_gateway_returns_none(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            assert parse_gateway_ref("acme-gw/foo/bar") is None
+
+    def test_no_slash_returns_none(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            assert parse_gateway_ref("gpt-4o") is None
+
+    def test_empty_segments_return_none(self) -> None:
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            assert parse_gateway_ref("openrouter//kimi-k2") is None
+            assert parse_gateway_ref("/openrouter/kimi-k2") is None
+            assert parse_gateway_ref("openrouter/moonshot/") is None
+
+    def test_model_id_can_contain_extra_slashes(self) -> None:
+        # `partition('/')`-style: only the first 2 splits are consumed; extra
+        # slashes in the model id stay attached. Useful for OpenRouter refs
+        # like openrouter/openai/gpt-4o-2024-08-06 vs nested model paths.
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            ref = parse_gateway_ref("openrouter/openai/gpt-4o/2024-08-06")
+        assert ref is not None
+        assert ref.gateway == "openrouter"
+        assert ref.upstream_provider == "openai"
+        assert ref.model == "gpt-4o/2024-08-06"
+        assert ref.upstream_model == "openai/gpt-4o/2024-08-06"
+
+    def test_user_local_can_register_custom_gateway(self, tmp_path: Path) -> None:
+        # User-local override can declare type: gateway — it must work end-to-end.
+        local = tmp_path / "providers.local.yaml"
+        local.write_text(
+            "version: 1\n"
+            "providers:\n"
+            "  myproxy:\n"
+            "    type: gateway\n"
+            "    base_url: https://gw.internal/v1\n"
+            "    api_key_env: MYPROXY_KEY\n"
+        )
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", local):
+            reset_cache()
+            ref = parse_gateway_ref("myproxy/anthropic/claude-sonnet-4")
+        assert ref is not None
+        assert ref.gateway == "myproxy"
+        assert ref.upstream_model == "anthropic/claude-sonnet-4"
+
+
+class TestResolveGatewayModelRef:
+    """Track H — resolve_model_ref dispatches 3-segment refs to gateway entries."""
+
+    def setup_method(self) -> None:
+        reset_cache()
+
+    def teardown_method(self) -> None:
+        reset_cache()
+
+    def test_three_segment_resolves_to_gateway_provider(self) -> None:
+        from engine.providers.registry import resolve_model_ref
+
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            with patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-or-test"}):
+                provider = resolve_model_ref("openrouter/moonshotai/kimi-k2")
+        assert provider is not None
+        assert provider.name == "openrouter"
+        # The wire model joins upstream + model so OpenRouter accepts it as-is.
+        assert provider.config.default_model == "moonshotai/kimi-k2"
+
+    def test_three_segment_litellm_resolves(self) -> None:
+        from engine.providers.registry import resolve_model_ref
+
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            with patch.dict("os.environ", {"LITELLM_MASTER_KEY": "sk-litellm"}):
+                provider = resolve_model_ref("litellm/anthropic/claude-sonnet-4")
+        assert provider is not None
+        assert provider.name == "litellm"
+        assert provider.config.default_model == "anthropic/claude-sonnet-4"
+
+    def test_two_segment_direct_still_works(self) -> None:
+        # Backwards-compat: existing nvidia/groq/etc. refs MUST keep resolving.
+        from engine.providers.registry import resolve_model_ref
+
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            with patch.dict("os.environ", {"NVIDIA_API_KEY": "nv-test"}):
+                provider = resolve_model_ref("nvidia/meta-llama-3.1-405b-instruct")
+        assert provider is not None
+        assert provider.name == "nvidia"
+        assert provider.config.default_model == "meta-llama-3.1-405b-instruct"
+
+    def test_legacy_two_segment_openrouter_still_routes(self) -> None:
+        # `openrouter/auto` was supported pre-Track-H. Even though openrouter
+        # is now type=gateway, the 2-segment form falls through to
+        # parse_model_ref and resolves the same way. This is a hard
+        # backwards-compat guarantee.
+        from engine.providers.registry import resolve_model_ref
+
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            with patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-or-test"}):
+                provider = resolve_model_ref("openrouter/auto")
+        assert provider is not None
+        assert provider.name == "openrouter"
+        assert provider.config.default_model == "auto"
+
+    def test_unknown_three_segment_returns_none(self) -> None:
+        from engine.providers.registry import resolve_model_ref
+
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            assert resolve_model_ref("acme-gw/anthropic/claude") is None
+
+    def test_gateway_base_url_env_override(self) -> None:
+        # `LITELLM_BASE_URL` overrides the catalog default — lets the same
+        # entry serve docker-compose, self-hosted, and SaaS deployments.
+        from engine.providers.registry import resolve_model_ref
+
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            with patch.dict(
+                "os.environ",
+                {
+                    "LITELLM_MASTER_KEY": "sk-test",
+                    "LITELLM_BASE_URL": "https://litellm.platform.example.com/v1",
+                },
+            ):
+                provider = resolve_model_ref("litellm/openai/gpt-4o")
+        assert provider is not None
+        assert provider.config.base_url == "https://litellm.platform.example.com/v1"
+
+    def test_direct_provider_does_not_honour_base_url_override(self) -> None:
+        # The override env var only applies to gateways. A plain direct
+        # provider keeps its catalog base_url even if a same-named env exists.
+        from engine.providers.registry import resolve_model_ref
+
+        with patch("engine.providers.catalog.USER_LOCAL_PATH", Path("/nonexistent/path.yaml")):
+            reset_cache()
+            with patch.dict(
+                "os.environ",
+                {
+                    "NVIDIA_API_KEY": "nv-test",
+                    "NVIDIA_BASE_URL": "https://malicious.example.com/v1",
+                },
+            ):
+                provider = resolve_model_ref("nvidia/meta-llama-3.1-405b-instruct")
+        assert provider is not None
+        assert "nvidia.com" in (provider.config.base_url or "")

--- a/website/content/docs/gateways.mdx
+++ b/website/content/docs/gateways.mdx
@@ -1,138 +1,187 @@
 ---
-title: Gateways
-description: Route LLM calls through a single proxy — LiteLLM (self-hosted) or OpenRouter (managed) — with budget enforcement, fallbacks, and cost attribution.
+title: Gateways (LiteLLM & OpenRouter)
+description: Use a model gateway as a first-class provider — fan out to many upstreams behind a single API key, with 3-segment model refs.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 
 # Gateways
 
-A **gateway** is a proxy that sits between your agents and the underlying LLM providers. Gateways speak the OpenAI Chat Completions wire format on the inbound side and route to many upstream providers on the outbound side. AgentBreeder treats gateways as a first-class provider type alongside direct OpenAI-compatible providers.
+A **gateway** is a provider that fans out to many upstream LLMs behind a single API key.
+AgentBreeder ships with two built-in gateway presets — **LiteLLM** (self-hosted) and **OpenRouter** (SaaS) — surfaced alongside direct providers in the **`/models` → Gateways** tab.
 
-```yaml
-# agent.yaml — direct provider
-model:
-  primary: nvidia/meta-llama-3.1-405b-instruct
-
-# agent.yaml — through OpenRouter
-model:
-  primary: openrouter/moonshotai/kimi-k2
-
-# agent.yaml — through self-hosted LiteLLM
-model:
-  primary: litellm/anthropic/claude-sonnet-4
-  gateway: litellm
-```
-
-When the engine sees a `<gateway>/<provider>/<model>` triple, it resolves `<gateway>` against the catalog, reads the gateway's URL and key from the workspace's `gateways:` block, and routes the call through the proxy.
+This page covers when to use which, how to configure them, and how 3-segment model refs work.
 
 <Callout type="info">
-This page is the v2 narrative. The dedicated [Model Gateway](gateway) page documents the LiteLLM proxy in depth — virtual keys, cost tracking, guardrails, caching, and the AgentBreeder-specific bridges.
+Gateways have always existed in AgentBreeder — Track H (#164) just promoted them to first-class onboarding. Existing `model.gateway: litellm` configs continue to work; they're now equivalent to using the 3-segment ref form.
 </Callout>
 
 ---
 
-## Catalog entries
+## Direct provider vs. gateway — at a glance
 
-LiteLLM and OpenRouter ship as `type: gateway` entries in [`engine/providers/catalog.yaml`](https://github.com/agentbreeder/agentbreeder/blob/main/engine/providers/catalog.yaml). The catalog distinguishes them from direct OpenAI-compatible providers via the `type` field:
-
-| Provider type | Behaviour | Examples |
+| | Direct provider | Gateway |
 |---|---|---|
-| `openai_compatible` | Talks to one upstream provider's models | `nvidia`, `groq`, `together`, `fireworks` |
-| `gateway` | Talks to many upstream providers; user picks the upstream with `<gateway>/<provider>/<model>` | `litellm`, `openrouter` |
+| Catalog `type` | `openai_compatible` | `gateway` |
+| Models per entry | One upstream | Many upstreams |
+| Model ref shape | `<provider>/<model>`<br/>e.g. `groq/llama-3.1-70b` | `<gateway>/<upstream>/<model>`<br/>e.g. `openrouter/anthropic/claude-sonnet-4` |
+| API key | Provider's own | Gateway's master / virtual key |
+| Examples | Nvidia NIM, Groq, Together, Moonshot | LiteLLM proxy, OpenRouter |
+
+Both kinds use the same `OpenAICompatibleProvider` under the hood — the only difference is parsing.
 
 ---
 
-## When to use which
+## When to pick which
 
-| Need | Pick |
-|---|---|
-| One key, 200+ models, hosted | **OpenRouter** — managed, no infra |
-| Self-hosted, team budgets, virtual keys per agent, PII guardrails | **LiteLLM** — full control, integrates deeply with AgentBreeder governance |
-| Direct provider, lowest latency, no proxy | **Direct OpenAI-compatible** ([providers](providers)) |
-| Local inference | **Ollama** (direct) or LiteLLM in front of Ollama |
+**LiteLLM** — choose when you want to **self-host**, enforce per-agent **virtual keys** + **budgets**, run **caching** locally, or unify cost tracking across your own pool of provider keys. AgentBreeder's docker-compose stack ships a LiteLLM proxy on `:4000`. See [Model Gateway](/docs/gateway) for the full LiteLLM setup.
 
-OpenRouter is the fastest way to evaluate a brand-new model. LiteLLM is the production answer when you need budget enforcement, cost attribution per agent, and guardrail enforcement.
+**OpenRouter** — choose when you want **zero infrastructure**, **per-token pay-as-you-go pricing across 100+ models**, or rapid model evaluation. One key, every model. The catalog ships `default_headers` for `HTTP-Referer` and `X-Title` so OpenRouter attributes calls to your AgentBreeder workspace.
+
+**Direct providers** — choose for **lowest latency** and **simplest billing** when you only need one upstream. Skip the gateway hop entirely.
+
+You can mix all three in the same workspace — gateways and direct providers coexist in the catalog.
 
 ---
 
-## Workspace configuration
+## 3-segment model refs
 
-Gateway credentials and policies live in the workspace config (`~/.agentbreeder/workspace.yaml` for single-user installs; one per workspace in team / cloud installs):
+Once a gateway is configured, reference its models in `agent.yaml` using a 3-segment ref:
 
 ```yaml
-workspace: default
+# OpenRouter — pick any model from openrouter.ai/models
+model:
+  primary: openrouter/moonshotai/kimi-k2
+
+# LiteLLM — model_name is whatever you defined in litellm_config.yaml
+model:
+  primary: litellm/anthropic/claude-sonnet-4
+  fallback: litellm/openai/gpt-4o
+```
+
+The parser splits on `/` exactly **twice**:
+
+* segment 1 → gateway name (must be a `type: gateway` catalog entry)
+* segment 2 → upstream provider (forwarded to the gateway as the `<upstream>/` prefix)
+* segment 3 → model id (rest of the string, may contain extra `/`)
+
+The wire-level `model` field sent to the gateway is `<segment-2>/<segment-3>`, which is the canonical form both LiteLLM and OpenRouter expect.
+
+<Callout type="warn">
+Two-segment refs like `openrouter/auto` still resolve via the legacy `parse_model_ref` path and are forwarded as-is. Prefer the 3-segment form for clarity.
+</Callout>
+
+---
+
+## Configuring a gateway from the dashboard
+
+1. Open `/models` and switch to the **Gateways** tab.
+2. Find **litellm** or **openrouter** and click **Configure**.
+3. Paste the API key. It is written to your workspace secrets backend (keychain locally, AWS Secrets Manager / Vault when self-hosted) under the deterministic name `<gateway>/api-key` — never to the database.
+4. The row flips to a green **Configured** badge.
+
+Configure flow is identical to direct providers — the only visible difference on a gateway row is the small **gateway** badge.
+
+---
+
+## Configuring a gateway from `agent.yaml`
+
+Catalog defaults are usually correct. To override (e.g. point LiteLLM at a remote proxy), use the optional `gateways:` block:
+
+```yaml
+name: my-agent
+version: 1.0.0
+team: platform
+owner: alice@example.com
+
+model:
+  primary: litellm/anthropic/claude-sonnet-4
 
 gateways:
   litellm:
-    url: http://litellm:4000             # or https://litellm.company.internal
-    api_key_env: LITELLM_MASTER_KEY
-    fallback_policy: fastest             # fastest | cheapest | most-reliable
+    url: https://litellm.platform.example.com
+    api_key_env: PLATFORM_LITELLM_KEY
+    fallback_policy: fastest          # advisory; not enforced yet
   openrouter:
-    api_key_env: OPENROUTER_API_KEY
+    api_key_env: TEAM_OPENROUTER_KEY  # override the catalog default
+
+deploy:
+  cloud: aws
 ```
 
-The `api_key_env` field declares the environment variable name — values are resolved at deploy time from the [workspace secrets backend](secrets), never persisted in the workspace YAML.
+Each field is optional and falls back to the catalog default. `fallback_policy` is advisory — it'll be enforced once Track A's workspace primitive lands (#146).
+
+<Callout type="info">
+The long-term home for `gateways:` is `workspace.yaml`, not `agent.yaml`. Track A (#146) introduces workspace-scoped configuration; once it ships you'll set gateway URLs once per workspace instead of per agent. The per-agent block stays valid as an override.
+</Callout>
 
 ---
 
-## OpenRouter
+## Environment variables
 
-Sign up at [openrouter.ai](https://openrouter.ai), grab an API key, and stash it:
+Each gateway entry declares an env var for its api key in `engine/providers/catalog.yaml`:
 
-```bash
-agentbreeder secret set OPENROUTER_API_KEY
+| Gateway | API-key env | Base-URL override env |
+|---|---|---|
+| `litellm` | `LITELLM_MASTER_KEY` | `LITELLM_BASE_URL` |
+| `openrouter` | `OPENROUTER_API_KEY` | `OPENROUTER_BASE_URL` |
+
+Setting `<NAME>_BASE_URL` (uppercase) overrides the catalog `base_url` at runtime — handy for swapping a local LiteLLM proxy for a managed one without editing the catalog.
+
+---
+
+## How it routes
+
+```
+agent.yaml model.primary: openrouter/moonshotai/kimi-k2
+        │
+        ▼
+engine/providers/catalog.parse_gateway_ref
+  → GatewayModelRef(gateway="openrouter", upstream="moonshotai", model="kimi-k2")
+        │
+        ▼
+engine/providers/openai_compatible.from_catalog
+  → OpenAICompatibleProvider(
+        base_url=https://openrouter.ai/api/v1,
+        api_key=$OPENROUTER_API_KEY,
+        default_headers={HTTP-Referer, X-Title},
+        default_model="moonshotai/kimi-k2",
+    )
+        │
+        ▼
+POST https://openrouter.ai/api/v1/chat/completions
+  body: {"model": "moonshotai/kimi-k2", "messages": [...]}
 ```
 
-Reference any of OpenRouter's 200+ models from `agent.yaml`:
+LiteLLM follows the same path — it just terminates at your proxy on `:4000` instead of OpenRouter's edge.
+
+---
+
+## Adding a custom gateway
+
+Drop a `~/.agentbreeder/providers.local.yaml` entry:
 
 ```yaml
-model:
-  primary: openrouter/moonshotai/kimi-k2
-  fallback: openrouter/anthropic/claude-sonnet-4
+version: 1
+providers:
+  myproxy:
+    type: gateway
+    base_url: https://gw.internal.example.com/v1
+    api_key_env: MYPROXY_KEY
+    default_headers:
+      X-Tenant: agentbreeder
 ```
 
-The catalog entry ships the required `HTTP-Referer` and `X-Title` headers automatically. List available models:
-
-```bash
-agentbreeder provider test openrouter   # GET /models against the gateway
-```
+Restart the API server. `myproxy` now appears on the Gateways tab and accepts 3-segment refs (`myproxy/anthropic/claude-sonnet-4`).
 
 ---
 
-## LiteLLM
+## Reference
 
-LiteLLM is a self-hosted proxy. The local stack started by `agentbreeder quickstart` includes a LiteLLM container at `:4000` out of the box. For self-hosted production, point your `gateways.litellm.url` at your own deployment.
-
-```yaml
-model:
-  primary: litellm/anthropic/claude-sonnet-4
-  gateway: litellm
-```
-
-When `model.gateway: litellm` is set, AgentBreeder mints a per-agent virtual key (`sk-agent-<name>`) at deploy time, attributes spend to the agent's team, and the [APS sidecar](sidecar) holds the key on behalf of the agent container. The agent itself never sees raw provider credentials.
-
-The full feature matrix — virtual keys, team budgets, Redis caching, fallback chains, OTEL bridge, Prometheus metrics — is on the [Model Gateway](gateway) page.
-
----
-
-## Dashboard
-
-The `/models` page shows three tabs:
-
-| Tab | Contents |
-|---|---|
-| **Direct providers** | OpenAI-compatible catalog entries (Track F) |
-| **Gateways** | LiteLLM + OpenRouter |
-| **Local** | Ollama / vLLM / other local runtimes |
-
-Each row shows configuration status (✓ Configured when the workspace has a key for it) and a **Configure** dialog that writes the key to the workspace secrets backend under the deterministic key `<provider>/api-key`.
-
----
-
-## See also
-
-- [Providers](providers) — the OpenAI-compatible catalog (Track F)
-- [Model Gateway](gateway) — LiteLLM proxy reference
-- [Secrets](secrets) — workspace-bound secret storage
-- [`agent.yaml` reference](agent-yaml) — `model.primary`, `model.fallback`, `model.gateway`
+* Catalog source: [`engine/providers/catalog.yaml`](https://github.com/agentbreeder/agentbreeder/blob/main/engine/providers/catalog.yaml)
+* 3-segment parser: `engine.providers.catalog.parse_gateway_ref`
+* JSON Schema: `engine/schema/agent.schema.json` → `gateways`
+* Issue: [#164 — feat(gateways): LiteLLM + OpenRouter as first-class](https://github.com/agentbreeder/agentbreeder/issues/164)
+* Companion: [Model Gateway](/docs/gateway) — deep dive on the LiteLLM proxy specifically
+* Companion: [Providers](/docs/providers) — direct OpenAI-compatible providers


### PR DESCRIPTION
# feat(gateways): LiteLLM + OpenRouter as first-class (#164)

Closes #164.

Track H of the v2 platform spec. Promotes the existing `connectors/litellm/`
and `connectors/openrouter/` connectors into first-class onboarding paths
under the provider catalog by introducing a `type: gateway` distinction.

## Summary

- **Catalog schema**: `engine/providers/catalog.yaml` now distinguishes
  `type: openai_compatible` (one upstream) from `type: gateway` (many
  upstreams). The Pydantic `CatalogProviderType` literal already had
  `gateway` carved out; Track H fills it in.
- **Built-in gateway presets**:
  - `openrouter` flips to `type: gateway` (was `openai_compatible`).
  - New `litellm` gateway preset (`LITELLM_MASTER_KEY`,
    `base_url=http://localhost:4000` matching the docker-compose stack).
- **3-segment parser**: new `engine.providers.catalog.parse_gateway_ref`
  + `GatewayModelRef` pydantic model. `<gateway>/<upstream>/<model>`
  refs split exactly twice; the wire-level `model` field becomes
  `<upstream>/<model>` (the canonical form both LiteLLM and OpenRouter
  expect). Examples:
  ```yaml
  model:
    primary: openrouter/moonshotai/kimi-k2
    fallback: litellm/anthropic/claude-sonnet-4
  ```
- **Resolver dispatch**: `engine.providers.registry.resolve_model_ref`
  tries the 3-segment gateway form first, then falls back to the
  existing `parse_model_ref`. **Backwards-compat hard guarantee**:
  every existing 2-segment direct ref (`nvidia/llama-...`, `openrouter/auto`)
  resolves identically to before. Existing `model.gateway: litellm`
  configs are also untouched.
- **Env override**: gateway entries honour `<NAME>_BASE_URL`
  (`LITELLM_BASE_URL`, `OPENROUTER_BASE_URL`) so the same catalog entry
  serves local docker, self-hosted, and SaaS deploys without a YAML
  edit. Direct entries are scoped out, they do not honour the override
  (test pins this).
- **`gateways:` block on `agent.yaml`**: optional dict of `GatewayConfig`
  (url / api_key_env / fallback_policy / default_headers) for per-agent
  override of catalog defaults. The long-term home is `workspace.yaml`
  (Track A / #146); flagged in code as a TODO.
- **Dashboard `/models` Gateways tab**: previously disabled with a
  "Coming with Track H — issue #164" tooltip. Now enabled and rendering
  `<ProviderCatalog filter="gateway" />`. Same Configure flow as Direct
  providers, with a small `gateway` badge per row.
- **Docs**: new `website/content/docs/gateways.mdx` covering when to
  pick LiteLLM vs OpenRouter, 3-segment refs, dashboard configure,
  per-agent overrides, env vars, end-to-end routing, and registering
  a custom user-local gateway.
- **CHANGELOG**: detailed Unreleased entry.

## Out of scope (deferred)

- `workspace.yaml` `gateways:` block defers to Track A (#146). The
  per-agent block is the stop-gap; both will coexist once Track A
  ships.
- `fallback_policy` enforcement: the field is parsed and stored but
  advisory for now (catalog notes this).

## Acceptance criteria from #164

| Criterion | Status |
|---|---|
| `type: gateway` in catalog schema | done (already in Pydantic; YAML now uses it) |
| OpenRouter + LiteLLM presets | done |
| `model.primary` parser handles 3-segment refs | done via `parse_gateway_ref` |
| Workspace `gateways:` config block | per-agent done; workspace deferred to Track A |
| Dashboard `/models` tabs (Direct / Gateways / Local) | Gateways now live; Local still scaffolded |
| Docs: `website/content/docs/gateways.mdx` | done |

## Test plan

- [x] `pytest tests/unit/test_provider_catalog.py` — 65 tests pass (25 new)
- [x] `pytest tests/unit/test_config_parser.py` — 34 tests pass (3 new)
- [x] `pytest tests/unit/` — 4054 pass; only failures are 2 pre-existing
      `_sync_to_api` signature mismatches on the `fix/e2e-ci-vite-preview`
      base branch, unrelated to Track H.
- [x] `ruff check` + `ruff format --check` clean on all changed Python files
- [x] `mypy` clean on changed engine files
- [ ] (Manual) Open `/models` → Gateways tab → click Configure on
      `litellm` → paste a master key → verify the row flips to the green
      Configured badge.
- [ ] (Manual) Set `model.primary: openrouter/moonshotai/kimi-k2` in a
      sample agent.yaml + `OPENROUTER_API_KEY=...` and confirm the
      catalog resolver returns a configured `OpenAICompatibleProvider`.

## Commit breakdown

1. `feat(providers): add LiteLLM + OpenRouter as type=gateway catalog entries`
   — catalog YAML, parser, resolver, env override, 25 unit tests.
2. `feat(config): accept optional gateways: block in agent.yaml`
   — `GatewayConfig` model, JSON Schema, 3 parser tests.
3. `feat(dashboard): enable /models Gateways tab + add gateways docs`
   — `<ProviderCatalog>` filter prop, models page wire-up, gateways.mdx,
     meta.json, CHANGELOG.
