### PR TITLE
fix(tests): release-blocking test failures from Track G + #174

### DIFF
--- a/tests/unit/test_api_routes_coverage_boost.py
+++ b/tests/unit/test_api_routes_coverage_boost.py
@@ -2641,6 +2641,11 @@ class TestRegistryModels:
         m.capabilities = ["chat"]
         m.created_at = _NOW
         m.updated_at = _NOW
+        # Track G lifecycle fields default to None
+        m.discovered_at = None
+        m.last_seen_at = None
+        m.deprecated_at = None
+        m.deprecation_replacement_id = None
         mock_reg.return_value = m
         resp = client.post(
             "/api/v1/registry/models",
@@ -2671,6 +2676,11 @@ class TestRegistryModels:
         m.capabilities = []
         m.created_at = _NOW
         m.updated_at = _NOW
+        # Track G lifecycle fields default to None
+        m.discovered_at = None
+        m.last_seen_at = None
+        m.deprecated_at = None
+        m.deprecation_replacement_id = None
         mock_get.return_value = m
         resp = client.get(f"/api/v1/registry/models/{m.id}")
         assert resp.status_code == 200

--- a/tests/unit/test_deploy_engine.py
+++ b/tests/unit/test_deploy_engine.py
@@ -383,7 +383,9 @@ class TestSyncToApiBestEffort:
         with patch.object(engine, "_sync_to_api") as mock_sync:
             engine._register(config, "http://agent:8080")
 
-        mock_sync.assert_called_once_with(config, "http://agent:8080", "http://custom-api:9999")
+        mock_sync.assert_called_once_with(
+            config, "http://agent:8080", "http://custom-api:9999", ""
+        )
 
     def test_default_api_base_is_localhost_8000(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """When env var is absent, api_base should default to http://localhost:8000."""
@@ -394,4 +396,4 @@ class TestSyncToApiBestEffort:
         with patch.object(engine, "_sync_to_api") as mock_sync:
             engine._register(config, "http://agent:8080")
 
-        mock_sync.assert_called_once_with(config, "http://agent:8080", "http://localhost:8000")
+        mock_sync.assert_called_once_with(config, "http://agent:8080", "http://localhost:8000", "")

--- a/tests/unit/test_final_coverage.py
+++ b/tests/unit/test_final_coverage.py
@@ -70,6 +70,12 @@ def _mock_user(**kwargs):
 
 def _mock_obj(**kwargs):
     m = MagicMock()
+    # Track G ModelResponse lifecycle fields are typed UUID|None / datetime|None,
+    # so MagicMock auto-attrs would fail pydantic validation. Default to None.
+    m.discovered_at = None
+    m.last_seen_at = None
+    m.deprecated_at = None
+    m.deprecation_replacement_id = None
     for k, v in kwargs.items():
         setattr(m, k, v)
     return m


### PR DESCRIPTION
Pre-release CI for v2.0.0 caught 5 test regressions. Mechanical fixes: 4th-arg `api_token` on _sync_to_api assertions, plus None defaults for Track G's 4 new ModelResponse lifecycle fields in MagicMock fixtures.