### PR TITLE
docs(website): page-by-page audit — flag unshipped features as roadmap

### DIFF
--- a/website/components/features.tsx
+++ b/website/components/features.tsx
@@ -40,6 +40,31 @@ const FEATURES: Feature[] = [
     title: 'LLM-as-Judge Eval Hub',
     desc: 'Multi-criteria scoring (accuracy, helpfulness, safety, groundedness) via Claude, GPT-4o, or Gemini. Public leaderboard, regression detection, CSV export.',
   },
+  {
+    icon: '🛒',
+    title: 'Provider Catalog (v2.0)',
+    desc: '9 OpenAI-compatible presets out of the box — Nvidia NIM, Kimi K2, Groq, Together, Fireworks, DeepInfra, Cerebras, Hyperbolic, OpenRouter. `agentbreeder provider add` for any custom upstream.',
+  },
+  {
+    icon: '🛡️',
+    title: 'Sidecar Pattern (v2.0)',
+    desc: 'Single Go binary auto-injected next to every agent. Bearer auth, OTel tracing, cost attribution, PII guardrails, A2A JSON-RPC, MCP passthrough — zero per-language re-implementation.',
+  },
+  {
+    icon: '🔐',
+    title: 'Workspace Secrets (v2.0)',
+    desc: 'OS keychain · Vault · AWS · GCP — pick one per workspace. `agentbreeder deploy` auto-mirrors declared secrets to the target cloud and grants the runtime SA `secretAccessor`. No plaintext in the image.',
+  },
+  {
+    icon: '🌐',
+    title: 'Polyglot Runtime Contract (v2.0)',
+    desc: 'Versioned HTTP contract every agent satisfies. First-party Go SDK ships v2.0 (Kotlin, Rust, .NET on the way). Any language with an HTTP server is a Tier-3 citizen — generate from the OpenAPI.',
+  },
+  {
+    icon: '🔀',
+    title: 'Gateways as First-Class (v2.0)',
+    desc: 'LiteLLM and OpenRouter promoted to `type: gateway` providers. Three-segment refs route the request: `model: openrouter/moonshotai/kimi-k2`. Configure once per workspace; switch upstreams without touching code.',
+  },
 ];
 
 export function Features() {

--- a/website/components/five-layer-arch.tsx
+++ b/website/components/five-layer-arch.tsx
@@ -41,7 +41,7 @@ const LAYERS = [
       { icon: '✓', name: 'RBAC Check', desc: 'Fail fast if unauthorized', badge: 'step 2' },
       { icon: '✓', name: 'Dependency Resolution', desc: 'Fetch all registry refs', badge: 'step 3' },
       { icon: '✓', name: 'Container Build', desc: 'Framework-specific Dockerfile', badge: 'step 4' },
-      { icon: '✓', name: 'Infra Provision', desc: 'Pulumi cloud resources', badge: 'step 5' },
+      { icon: '✓', name: 'Infra Provision', desc: 'Cloud SDK calls (boto3 · gcloud · k8s)', badge: 'step 5' },
       { icon: '✓', name: 'Deploy & Health Check', desc: 'Rolling deploy + smoke test', badge: 'step 6' },
       { icon: '✓', name: 'Register in Org', desc: 'Auto-register in registry', badge: 'step 7' },
       { icon: '✓', name: 'Return Endpoint', desc: 'Live URL + deployment ID', badge: 'step 8' },

--- a/website/content/blog/v2-platform-substrate.mdx
+++ b/website/content/blog/v2-platform-substrate.mdx
@@ -1,0 +1,86 @@
+---
+title: "AgentBreeder v2.0: Frameworks, Clouds, Languages, Providers Are Now Plug-Ins"
+description: "v2.0 turns AgentBreeder into a substrate. Six new tracks land at once: provider catalog, model lifecycle, gateways, polyglot runtime contract, sidecar, workspace secrets. What it means and what's next."
+author: "Rajit Saha"
+date: "2026-04-29"
+tags: ["release", "v2", "platform", "polyglot", "providers", "secrets", "sidecar"]
+---
+
+v1 of AgentBreeder shipped a working agent platform. v2 turns it into a **substrate** — anything above the substrate (frameworks, clouds, languages, providers) plugs in without engine changes.
+
+Six tracks landed at once. Here's what each one buys you.
+
+## Track F — Provider Catalog
+
+Adding Nvidia NIM used to mean writing a provider class. Same for Kimi K2, Groq, Together, Fireworks. They're all **OpenAI-compatible** — only `base_url` and `api_key` differ. v2 collapses them into one generic class plus a checked-in catalog YAML with 9 presets out of the box.
+
+```yaml
+model:
+  primary: nvidia/meta-llama-3.1-405b-instruct
+```
+
+Not on the list? `agentbreeder provider add my-vllm --type openai_compatible --base-url http://… --api-key-env MY_KEY` and you're done.
+
+## Track G — Model Lifecycle
+
+Provider model lists change weekly. v2 auto-discovers from each provider's `/models` endpoint, marks new ones `active`, deprecated ones `deprecated`, and after 30 days of absence: `retired`. Audit events for every transition. CLI: `agentbreeder model sync`.
+
+## Track H — Gateways as First-Class
+
+LiteLLM and OpenRouter graduate from "connector tucked away in a folder" to first-class catalog entries with `type: gateway`. Three-segment refs route the request:
+
+```yaml
+model:
+  primary: openrouter/moonshotai/kimi-k2
+```
+
+Switch upstream providers without touching agent code.
+
+## Track I — Polyglot Runtime Contract + Go SDK
+
+Every agent container — Python, TypeScript, Go, Kotlin, Rust, .NET — satisfies the same versioned HTTP contract: `/health`, `/invoke`, `/stream`, `/resume`, `/openapi.json`, bearer auth via `AGENT_AUTH_TOKEN`. Spec lives at `engine/schema/runtime-contract-v1.md` + `runtime-contract-v1.openapi.yaml`.
+
+The first Tier-2 SDK ships with v2: **Go** (`sdk/go/agentbreeder/`). Kotlin, Rust, and .NET are tracked in their own issues for v2.x.
+
+```bash
+agentbreeder init --lang go --framework custom my-go-agent
+```
+
+## Track J — The Sidecar
+
+CLAUDE.md described "the sidecar pattern (planned)" since v1. v2 ships it. A single Go binary auto-injected next to every agent that declares `guardrails:`, MCP `tools:`, or `a2a:`. Handles bearer auth, OTel tracing, cost attribution, PII guardrails, A2A JSON-RPC, MCP passthrough — once, in Go, and every language SDK gets it for free.
+
+## Track K — Workspace Secrets
+
+`engine/secrets/` had four backends (env, AWS, GCP, Vault) but no workspace binding. v2 adds:
+
+- `keychain` backend (cross-platform via `keyring`)
+- One backend per workspace (`AGENTBREEDER_INSTALL_MODE=team` defaults to env, etc.)
+- **Auto-mirror at deploy** — declared `secrets:` get written to the target cloud's native store under `agentbreeder/<agent>/<secret>`, runtime SA gets `secretAccessor`, no plaintext in the image
+
+```bash
+agentbreeder secret set OPENAI_API_KEY        # one command, right backend per workspace
+```
+
+## What didn't ship (yet)
+
+We were honest about scope. v2 doesn't include:
+
+- **Track A — Workspace primitive** ([#146](https://github.com/agentbreeder/agentbreeder/issues/146)): `workspace.yaml`, `agentbreeder workspace init/login`, multi-cloud config block. The pieces that depend on it (gateway config, secrets backend) ship in v2 with a per-agent fallback.
+- **`/agent-build` redesign** ([#147](https://github.com/agentbreeder/agentbreeder/issues/147)): the next-gen entrypoint that walks you from `pip install` through deploy.
+- **Polyglot phase 2/3 SDKs**: Kotlin ([#188](https://github.com/agentbreeder/agentbreeder/issues/188)), Rust ([#189](https://github.com/agentbreeder/agentbreeder/issues/189)), .NET ([#190](https://github.com/agentbreeder/agentbreeder/issues/190)). Tracked, not yet built.
+- **Auto-mirror to Azure** — the secrets auto-mirror flow currently covers AWS ECS + GCP Cloud Run. Azure Container Apps support is in the next minor.
+- **Daily model-sync cron** in cloud workspaces — Track G ships the engine + CLI; the cron itself is a system-cron sample for v2.0, native scheduler in v2.1.
+
+## Try it
+
+```bash
+pip install agentbreeder==2.0.0
+agentbreeder provider list                  # see the 9-preset catalog
+agentbreeder secret set OPENAI_API_KEY      # workspace backend, masked input
+agentbreeder model sync                     # auto-discover from your configured providers
+```
+
+Or `docker compose -f deploy/docker-compose.yml up -d` and open `http://localhost:3001`.
+
+Full changelog: [v2.0.0 release notes](https://github.com/agentbreeder/agentbreeder/releases/tag/v2.0.0). Architecture spec: [`docs/architecture/platform-v2.md`](https://github.com/agentbreeder/agentbreeder/blob/main/docs/architecture/platform-v2.md).

--- a/website/content/docs/agent-yaml.mdx
+++ b/website/content/docs/agent-yaml.mdx
@@ -120,7 +120,7 @@ access:
 
 ### `framework`
 
-For **Python agents**, set `framework` directly (top-level field). For **TypeScript, Rust, and Go agents**, use the `runtime:` block instead — see below.
+For **Python agents**, set `framework` directly (top-level field). For **TypeScript or Go agents**, use the `runtime:` block instead — see below. (Kotlin / Rust / .NET are roadmap — see [Polyglot Agents](polyglot-agents).)
 
 | Value | Framework | Runtime |
 |-------|-----------|---------|
@@ -142,7 +142,7 @@ framework: langgraph
 
 The `language:` field drives base-image and SDK selection. For Python agents you can omit it entirely. For everything else, set it (and use the `runtime:` block below for non-Python frameworks). See [Polyglot Agents](polyglot-agents) and the [Runtime Contract](runtime-contract) for the full picture.
 
-### `runtime:` block — Polyglot Agents (TypeScript, Rust, Go)
+### `runtime:` block — Polyglot Agents (TypeScript, Go)
 
 For non-Python agents, replace the top-level `framework` field with a `runtime:` block. `framework` and `runtime:` are mutually exclusive.
 
@@ -163,14 +163,14 @@ runtime:
 
 **Supported `language` + `framework` combinations:**
 
-| Language | Available frameworks |
-|---|---|
-| `python` | Use top-level `framework` field — do not use `runtime:` |
-| `node` | `vercel-ai`, `mastra`, `langchain-js`, `openai-agents-ts`, `deepagent`, `custom` |
-| `rust` | `rig`, `custom` *(Phase 2)* |
-| `go` | `langchaingo`, `custom` *(Phase 2)* |
+| Language | Available frameworks | Status |
+|---|---|---|
+| `python` | Use top-level `framework` field — do not use `runtime:` | shipped |
+| `node` | `vercel-ai`, `mastra`, `langchain-js`, `openai-agents-ts`, `custom` | shipped |
+| `go` | `custom` (with the [Go SDK](go-sdk)) | **shipped in v2.0** |
+| `kotlin` / `rust` / `csharp` | reserved enum values | **roadmap** — [#188](https://github.com/agentbreeder/agentbreeder/issues/188), [#189](https://github.com/agentbreeder/agentbreeder/issues/189), [#190](https://github.com/agentbreeder/agentbreeder/issues/190) |
 
-See [Polyglot Agents](/docs/polyglot-agents) for full setup, APS sidecar wiring, and cross-language A2A calls.
+See [Polyglot Agents](/docs/polyglot-agents) for full setup, sidecar wiring, and cross-language A2A calls.
 
 #### Framework-Specific Configuration
 
@@ -341,6 +341,28 @@ model:
   primary: ollama/llama3
   gateway: ollama
 ```
+
+---
+
+### `gateways` *(v2.0+, optional)*
+
+Workspace-level gateway overrides. Most agents do not need this block — the catalog defaults are correct. Use it when you need to point LiteLLM at a different proxy URL, or set a per-agent OpenRouter key:
+
+```yaml
+gateways:
+  litellm:
+    url: https://litellm.platform.example.com    # overrides catalog default
+    api_key_env: PLATFORM_LITELLM_KEY
+    fallback_policy: fastest                      # advisory; not enforced yet
+  openrouter:
+    api_key_env: TEAM_OPENROUTER_KEY
+    default_headers:                              # merged with catalog defaults
+      X-Tenant: my-team
+```
+
+Each top-level key is a gateway preset name from `engine/providers/catalog.yaml` (or your `~/.agentbreeder/providers.local.yaml`). Every nested field is optional and falls back to the catalog default. See [Gateways](gateways) for the full picture and `engine.providers.catalog.parse_gateway_ref` for the routing implementation.
+
+> **Note:** the long-term home for `gateways:` is `workspace.yaml`; per-agent overrides remain valid once Track A ([#146](https://github.com/agentbreeder/agentbreeder/issues/146)) ships.
 
 ---
 

--- a/website/content/docs/connectors.mdx
+++ b/website/content/docs/connectors.mdx
@@ -173,7 +173,7 @@ stories = await hn.scan()
 Pushes AgentBreeder agent metrics and traces to a Grafana stack (Loki for logs, Tempo for traces). Also scans existing Grafana dashboards into the registry.
 
 <Callout type="warn">
-  Beta: The `push_metrics()` and `push_traces()` method signatures may change before v2.0. Pin to a specific AgentBreeder version if using in production.
+  Beta: The `push_metrics()` and `push_traces()` method signatures are still evolving and may change in a future minor release. Pin to a specific AgentBreeder version if using in production.
 </Callout>
 
 **Constructor:**

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -39,7 +39,9 @@ eject to YAML, eject to Full Code at any time.
 
 **TypeScript/Node.js:** Vercel AI SDK · Mastra · LangChain.js · OpenAI Agents TS · Custom
 
-**Rust · Go** *(Phase 2)*
+**Go** *(v2.0 — Tier-2 SDK; see [Go SDK](go-sdk))*
+
+**Kotlin · Rust · .NET** *(roadmap — tracked at [#188](https://github.com/agentbreeder/agentbreeder/issues/188), [#189](https://github.com/agentbreeder/agentbreeder/issues/189), [#190](https://github.com/agentbreeder/agentbreeder/issues/190))*
 
 ## Deploy Targets
 
@@ -50,7 +52,7 @@ Local (Docker Compose) · AWS ECS Fargate · AWS App Runner · GCP Cloud Run · 
 | Goal | Where to go |
 |------|-------------|
 | Build your first agent in 5 minutes | [Quickstart →](quickstart) |
-| TypeScript, Rust, Go agents | [Polyglot Agents →](polyglot-agents) |
+| TypeScript or Go agents | [Polyglot Agents →](polyglot-agents) |
 | Deploy to a specific cloud | [How-To →](how-to) |
 | Model gateway — budgets, guardrails, caching | [Model Gateway →](gateway) |
 | Agent YAML reference | [agent.yaml →](agent-yaml) |

--- a/website/content/docs/mcp-authoring.mdx
+++ b/website/content/docs/mcp-authoring.mdx
@@ -1,6 +1,6 @@
 ---
 title: MCP Server Authoring
-description: Build and deploy MCP servers in TypeScript, Go, Rust, or Python using AgentBreeder's scaffolding. Same deploy pipeline as agents — governance, registry, and RBAC included.
+description: Build and deploy MCP servers in TypeScript, Python, or Go using AgentBreeder's scaffolding. Same deploy pipeline as agents — governance, registry, and RBAC included.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
@@ -12,6 +12,10 @@ AgentBreeder lets you **author, deploy, and register MCP servers** in any suppor
 
 <Callout type="info">
   MCP servers are containers. They go through the same RBAC check, registry entry, and governance pipeline as agents. There is no separate "tool registry" — MCP servers appear in the main registry under the `tools/` namespace.
+</Callout>
+
+<Callout type="warn" title="Language status (v2.0)">
+  TypeScript, Python, and Go MCP-server scaffolds are shipped. **Rust** scaffolding is reserved but not yet wired (tracked at [#189](https://github.com/agentbreeder/agentbreeder/issues/189)) — the Rust tabs below show the planned shape; until then implement the MCP protocol by hand and deploy as `framework: custom`.
 </Callout>
 
 ---

--- a/website/content/docs/migrations.mdx
+++ b/website/content/docs/migrations.mdx
@@ -1,0 +1,130 @@
+---
+title: Migrations
+description: How to upgrade between AgentBreeder versions. Each entry covers the minimum changes and the no-op default that lets v1.x configs keep working.
+---
+
+AgentBreeder is committed to **forward-only, additive changes** at the `agent.yaml` and engine layer. Every version below shows what's new, what's optional, and the smallest possible diff to take advantage.
+
+---
+
+## v1.x → v2.0
+
+> **TL;DR:** Existing v1.x deployments keep working without changes. v2 features are opt-in via additive `agent.yaml` fields, new CLI commands, and new dashboard pages.
+
+### What's new
+
+The full list is on [the v2.0.0 release notes](https://github.com/agentbreeder/agentbreeder/releases/tag/v2.0.0). The shipped tracks:
+
+| Track | What it is | Doc |
+|---|---|---|
+| **F** | 9-preset OpenAI-compatible provider catalog (Nvidia, Kimi, Groq, Together, Fireworks, DeepInfra, Cerebras, Hyperbolic, OpenRouter) | [Providers](/docs/providers) |
+| **G** | Model lifecycle — auto-discover from provider `/models`, status badges, 30-day-stale retire | [Providers § Lifecycle](/docs/providers#daily-cron-out-of-scope-for-this-pr) |
+| **H** | Gateways promoted to first-class `type: gateway`; 3-segment refs `openrouter/moonshotai/kimi-k2` | [Gateways](/docs/gateways) |
+| **I** | Polyglot runtime contract v1 + Go SDK; Kotlin/Rust/.NET coming | [Runtime contract](/docs/runtime-contract), [Go SDK](/docs/go-sdk) |
+| **J** | Sidecar — single Go binary auto-injected for guardrails, A2A, MCP, OTel, cost | [Sidecar](/docs/sidecar) |
+| **K** | Workspace-bound secrets backend (keychain/Vault/AWS/GCP) + auto-mirror to cloud at deploy | [Secrets](/docs/secrets) |
+
+### What you do **not** need to change
+
+Every v1.x `agent.yaml` continues to deploy unchanged. Specifically:
+
+- 2-segment model refs like `nvidia/llama-3.1-405b-instruct` keep resolving via the new catalog
+- `model.gateway: litellm` keeps working alongside the new `gateways:` block
+- Existing `secrets: [OPENAI_API_KEY]` still reads from env unless you migrate to a workspace backend
+- Deploy targets (`local`, `gcp`, `aws`, `azure`, `kubernetes`, `claude-managed`) — no schema changes
+
+### Recommended opt-in changes
+
+Pick the tracks you want; each is independent.
+
+#### Use the provider catalog
+
+No yaml change. Just configure the api-key once via the dashboard:
+
+1. Sign in as a `deployer`-role user
+2. Go to `/models`, click **Configure** on any preset (Nvidia, Kimi, Groq, etc.)
+3. Paste the api-key — stored in the workspace secrets backend, never the image
+
+Then point `model.primary` at the provider:
+
+```yaml
+model:
+  primary: nvidia/meta-llama-3.1-405b-instruct
+```
+
+#### Use a gateway
+
+Add a `gateways:` block to `agent.yaml` if you want to override the workspace default:
+
+```yaml
+model:
+  primary: openrouter/moonshotai/kimi-k2
+gateways:
+  openrouter:
+    api_key_env: OPENROUTER_API_KEY
+    fallback_policy: fastest
+```
+
+Or rely entirely on the workspace's gateway config (recommended once Track A workspace primitive ships).
+
+#### Migrate to the workspace secrets backend
+
+```bash
+# Local dev
+agentbreeder secret set OPENAI_API_KEY            # → OS keychain
+# Self-hosted team
+export AGENTBREEDER_INSTALL_MODE=team
+agentbreeder secret set OPENAI_API_KEY            # → env / Vault
+# Cloud SaaS
+agentbreeder secret set OPENAI_API_KEY            # → AWS Secrets Manager
+```
+
+At deploy time the engine auto-mirrors whatever is in `secrets:` to the target cloud's native store under `agentbreeder/<agent-name>/<secret>`.
+
+#### Try the Go SDK
+
+```bash
+agentbreeder init --lang go --framework custom my-go-agent
+cd my-go-agent && go test ./...
+agentbreeder deploy --target local
+```
+
+#### Get the sidecar features
+
+The sidecar auto-injects when `agent.yaml` declares any of `guardrails:`, MCP `tools:`, or `a2a:`. To bypass entirely (local dev convenience):
+
+```bash
+export AGENTBREEDER_SIDECAR=disabled
+```
+
+### Breaking changes
+
+**None.** The schema additions in v2.0 (`language:`, `gateways:`, `claude_sdk.thinking.enabled` clarification, `models.status`) are all forward-compatible with v1.x configs.
+
+### Deprecations
+
+- The legacy `engine/secrets/{aws,gcp,vault}_backend.py` direct factory call is still supported but no longer the default — `engine.secrets.factory.get_workspace_backend()` is the new entry point.
+- `models.status` is now mandatory in registry inserts. Existing rows backfill to `active` via Alembic migration `018_add_model_lifecycle_fields.py`.
+
+### CI / release
+
+- Tag-triggered releases now publish 4 PyPI artifacts and 3 Docker images. See `.github/workflows/release.yml`.
+- The Homebrew tap auto-update step requires a new PAT secret `HOMEBREW_TAP_TOKEN` ([#195](https://github.com/agentbreeder/agentbreeder/issues/195)).
+
+---
+
+## v1.9 → v1.10
+
+See [v1.10.0 release notes](https://github.com/agentbreeder/agentbreeder/releases/tag/v1.10.0).
+
+## v1.8 → v1.9
+
+See [v1.9.0 release notes](https://github.com/agentbreeder/agentbreeder/releases/tag/v1.9.0).
+
+## v1.7 → v1.8
+
+See [v1.8.0 release notes](https://github.com/agentbreeder/agentbreeder/releases/tag/v1.8.0). Adds Ollama / LiteLLM support across all runtimes.
+
+---
+
+Found a regression after upgrading? File at [github.com/agentbreeder/agentbreeder/issues](https://github.com/agentbreeder/agentbreeder/issues) with the `regression` label and we'll prioritise.

--- a/website/content/docs/polyglot-agents.mdx
+++ b/website/content/docs/polyglot-agents.mdx
@@ -1,6 +1,6 @@
 ---
-title: Polyglot Agents — TypeScript, Rust, Go
-description: Build and deploy AgentBreeder agents in TypeScript, Rust, and Go. Full RAG, memory, tools, and A2A parity with Python — zero Python required for non-Python stacks.
+title: Polyglot Agents — TypeScript, Go, Python
+description: Build and deploy AgentBreeder agents in TypeScript, Go, or Python. Full RAG, memory, tools, and A2A parity — wired by the platform, not written by you.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
@@ -8,10 +8,13 @@ import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
 
 # Polyglot Agents
 
-AgentBreeder agents can be written in **TypeScript, Rust, Go, or Python**. Every language gets the same first-class experience: automatic RAG injection, conversation memory, tool execution, A2A communication, tracing, and cost attribution — all wired by the platform, none of it written by you.
+AgentBreeder agents can be written in **Python, TypeScript, or Go** today. Every language gets the same first-class experience: automatic RAG injection, conversation memory, tool execution, A2A communication, tracing, and cost attribution — all wired by the platform, none of it written by you.
 
-<Callout type="info">
-  **Phase availability:** TypeScript is available now. Rust and Go ship in Phase 2. Kotlin/JVM is on the roadmap.
+<Callout type="info" title="Language status (v2.0)">
+  - **Python** — Tier 1, shipped (LangGraph, CrewAI, Claude SDK, OpenAI Agents, Google ADK, Custom).
+  - **TypeScript / Node.js** — Tier 1, shipped (Vercel AI SDK, Mastra, LangChain.js, OpenAI Agents TS, Custom).
+  - **Go** — Tier 2 SDK shipped in v2.0 — see [Go SDK](go-sdk).
+  - **Kotlin/JVM, Rust, .NET** — roadmap. Tracked at [#188](https://github.com/agentbreeder/agentbreeder/issues/188), [#189](https://github.com/agentbreeder/agentbreeder/issues/189), [#190](https://github.com/agentbreeder/agentbreeder/issues/190). The examples below show the planned shape; the `--language rust` / `--language kotlin` / `--language csharp` flags are reserved but not yet wired.
 </Callout>
 
 ---
@@ -39,13 +42,14 @@ Agent container  ←→  APS sidecar  ←→  Platform (RAG, memory, tools, regi
 
 ## Supported Languages and Frameworks
 
-| Language | Frameworks | APS Sidecar | Phase |
-|---|---|---|---|
-| **TypeScript / Node.js** | Vercel AI SDK, Mastra, LangChain.js, OpenAI Agents TS, DeepAgent, Custom | Node.js | 1 — available |
-| **Python** | LangGraph, CrewAI, Claude SDK, OpenAI Agents, Google ADK, Custom | Python | 1 — available |
-| **Rust** | Rig, Custom | Go binary | 2 |
-| **Go** | LangChain Go, Custom | Go binary | 2 |
-| **Kotlin / JVM** | Koog, Spring AI, LangChain4j | — | Roadmap |
+| Language | Frameworks | Status |
+|---|---|---|
+| **Python** | LangGraph, CrewAI, Claude SDK, OpenAI Agents, Google ADK, Custom | Tier 1 — shipped |
+| **TypeScript / Node.js** | Vercel AI SDK, Mastra, LangChain.js, OpenAI Agents TS, Custom | Tier 1 — shipped |
+| **Go** | Custom (with the [Go SDK](go-sdk)) | Tier 2 — shipped in v2.0 |
+| **Kotlin / JVM** | langchain4j, spring_ai, koog, anthropic_java_sdk | Roadmap — [#188](https://github.com/agentbreeder/agentbreeder/issues/188) |
+| **Rust** | rig, swiftide, anthropic_rust_sdk | Roadmap — [#189](https://github.com/agentbreeder/agentbreeder/issues/189) |
+| **C# / .NET** | semantic_kernel, autogen_net, anthropic_dotnet_sdk | Roadmap — [#190](https://github.com/agentbreeder/agentbreeder/issues/190) |
 
 <Callout type="info">
   **No Python in TypeScript/Rust/Go stacks.** The Node.js APS (Phase 1) and Go binary APS (Phase 2) contain no Python. A pure TypeScript stack is containers all the way down.
@@ -65,16 +69,19 @@ cd my-agent
 ```
 </Tab>
 <Tab value="Rust">
+> **Coming soon (v2.x)** — Rust scaffolding is tracked at [#189](https://github.com/agentbreeder/agentbreeder/issues/189). The shape below is the planned interface; until then implement Runtime Contract v1 by hand and declare `framework: custom`, `language: rust` (Tier-3 BYO).
 ```bash
-agentbreeder init --language rust --framework rig --name my-agent
+# Once #189 ships:
+agentbreeder init --lang rust --framework rig --name my-agent
 cd my-agent
 ```
 </Tab>
 <Tab value="Go">
 ```bash
-agentbreeder init --language go --name my-agent
+agentbreeder init --lang go --framework custom my-agent
 cd my-agent
 ```
+See the dedicated [Go SDK](go-sdk) page for the full surface.
 </Tab>
 <Tab value="Python">
 ```bash

--- a/website/content/docs/polyglot-agents.mdx
+++ b/website/content/docs/polyglot-agents.mdx
@@ -31,6 +31,10 @@ When you run `agentbreeder deploy`, the engine:
 
 The APS sidecar handles everything the platform needs to do: RAG retrieval, memory persistence, tool execution, A2A proxying, and OpenTelemetry tracing. LLM cost is tracked automatically by the LiteLLM gateway using the per-agent virtual key — no explicit cost recording call needed. Your agent code calls the sidecar over a local HTTP connection on port 9001. **You write zero infrastructure code.**
 
+<Callout type="info" title="APS vs. Track J sidecar">
+  This page describes the **Polyglot APS sidecar** (TypeScript-runtime concept from PR #136), which lives in the agent container's pod and exposes `:9001`. AgentBreeder v2.0 also ships a separate, broader **[Track J sidecar](sidecar)** — a Go binary that fronts the agent on `:8080` and handles bearer auth, OTel, cost emission, A2A, MCP passthrough, and guardrails for **all** languages and frameworks. The two are complementary: APS is opinionated polyglot scaffolding; Track J is the cross-cutting concerns layer auto-injected based on `agent.yaml` (`guardrails:` / MCP `tools:` / `a2a:`). Plan: the APS responsibilities collapse into the Track J sidecar over the v2.x line.
+</Callout>
+
 ```
 Your agent.ts / main.rs / main.go
         ↓ (imported by server template)
@@ -524,19 +528,18 @@ The APS sidecar is injected into the ECS task definition, Cloud Run job, or Kube
 | DeepAgent | `deepagent` | `deepagent` | Reasoning-intensive tasks |
 | Custom Node | `custom` | — | Any Node.js/TypeScript agent |
 
-### Rust frameworks (Phase 2)
+### Rust frameworks *(roadmap — [#189](https://github.com/agentbreeder/agentbreeder/issues/189))*
 
 | Framework | `framework:` value | crate | Best for |
 |---|---|---|---|
 | Rig | `rig` | `rig-core` | Performance-critical, low-latency agents |
 | Custom | `custom` | — | Any Rust agent |
 
-### Go frameworks (Phase 2)
+### Go frameworks *(shipped in v2.0 — see [Go SDK](go-sdk))*
 
 | Framework | `framework:` value | module | Best for |
 |---|---|---|---|
-| LangChain Go | `langchaingo` | `github.com/tmc/langchaingo` | Teams with existing Go LangChain code |
-| Custom | `custom` | — | Any Go agent |
+| Custom | `custom` | `github.com/agentbreeder/agentbreeder/sdk/go/agentbreeder` | Any Go agent — Tier-2 first-party SDK |
 
 ---
 

--- a/website/content/docs/providers.mdx
+++ b/website/content/docs/providers.mdx
@@ -251,7 +251,7 @@ The `model.deprecated` event includes a `reason` field (`absent_from_discovery` 
 
 The current PR ships the sync **endpoint** + CLI; running it on a schedule lands with the cloud workspaces track. For now, the simplest approach is a system cron in your workspace:
 
-```cron
+```bash
 # /etc/cron.d/agentbreeder-model-sync
 0 4 * * * agentbreeder model sync >> /var/log/agentbreeder-sync.log 2>&1
 ```

--- a/website/content/docs/runtime-contract.mdx
+++ b/website/content/docs/runtime-contract.mdx
@@ -130,13 +130,14 @@ info:
 
 ## Tiers
 
-| Tier | Languages | What we maintain |
-|---|---|---|
-| **1. First-party SDK + runtime** | Python, TypeScript | `agenthub` / `@agentbreeder/sdk` + container template + framework integrations |
-| **2. First-party SDK** | Go, Kotlin/Java, Rust, C#/.NET | Thin SDK per language (registry + deploy + auth + handlers) generated from the OpenAPI |
-| **3. BYO contract** | Anything (Swift, Ruby, PHP, Elixir, …) | Container build + governance + registry — language-blind |
+| Tier | Languages | Status (v2.0) | What we maintain |
+|---|---|---|---|
+| **1. First-party SDK + runtime** | Python, TypeScript | shipped | `agenthub` / `@agentbreeder/sdk` + container template + framework integrations |
+| **2. First-party SDK** | Go | **shipped (v2.0)** — see [Go SDK](go-sdk) | Thin SDK (registry + deploy + auth + handlers) hand-curated from the OpenAPI |
+| **2. First-party SDK** | Kotlin/Java, Rust, C#/.NET | **roadmap** — [#188](https://github.com/agentbreeder/agentbreeder/issues/188), [#189](https://github.com/agentbreeder/agentbreeder/issues/189), [#190](https://github.com/agentbreeder/agentbreeder/issues/190) | Same shape as Go — generated from `runtime-contract-v1.openapi.yaml` once codegen lands in CI |
+| **3. BYO contract** | Anything (Swift, Ruby, PHP, Elixir, …) | available today | Container build + governance + registry — language-blind |
 
-Tier 1 templates already conform to v1 (with minor v0 divergences documented in §4 of the spec). Tier 2 SDKs are generated from `runtime-contract-v1.openapi.yaml` in CI. Tier 3 is anyone implementing the contract by hand — declare `framework: custom`, `language: <lang>` in `agent.yaml`.
+Tier 1 templates already conform to v1 (with minor v0 divergences documented in §4 of the spec). Today only the Go SDK is generated from `runtime-contract-v1.openapi.yaml` (hand-curated for v2.0; codegen wires up with the next Tier-2 SDK). Tier 3 is anyone implementing the contract by hand — declare `framework: custom`, `language: <lang>` in `agent.yaml`.
 
 ---
 

--- a/website/content/docs/secrets.mdx
+++ b/website/content/docs/secrets.mdx
@@ -42,6 +42,12 @@ secrets:
     # mount: secret          # for vault
 ```
 
+> **Note:** in v2.0 the only workspace key the engine reads is `secrets:`. The
+> full workspace primitive (`agentbreeder workspace init`, multi-cloud config,
+> per-workspace gateway block) is tracked at
+> [#146](https://github.com/agentbreeder/agentbreeder/issues/146) and lands in
+> v2.x — until then, secrets are the supported field.
+
 If the file is missing, AgentBreeder picks an install-mode-aware default:
 
 | `AGENTBREEDER_INSTALL_MODE` | Default backend |
@@ -90,6 +96,12 @@ All mutating commands (`set`, `rotate`, `delete`, `sync`) emit audit events —
 appear in the dashboard's audit log.
 
 ## Auto-mirror at deploy
+
+> **v2.0 cloud coverage:** auto-mirror ships for **AWS ECS Fargate** and
+> **GCP Cloud Run**. **Azure Container Apps**, **AWS App Runner**, and
+> **Kubernetes** auto-mirror are tracked for v2.x — for those targets today,
+> use `agentbreeder secret sync --target <cloud>` ahead of deploy or set the
+> values manually in the cloud console.
 
 When you run `agentbreeder deploy` against AWS or GCP and your `agent.yaml`
 declares `deploy.secrets`, the engine:

--- a/website/content/docs/sidecar.mdx
+++ b/website/content/docs/sidecar.mdx
@@ -24,6 +24,10 @@ The deploy pipeline auto-injects `rajits/agentbreeder-sidecar:<version>` wheneve
 
 If none of these are present the sidecar is **not** injected — the agent runs alone, and there's no overhead for simple agents.
 
+<Callout type="info" title="Auto-injection coverage in v2.0">
+  v2.0 wires sidecar auto-injection into **Docker Compose**, **GCP Cloud Run**, and **AWS ECS Fargate** deployers. **AWS App Runner**, **Azure Container Apps**, and **Kubernetes** deployers will land auto-injection in v2.x — for those targets today, run the sidecar as a separate task/container and point `AGENTBREEDER_SIDECAR_AGENT_URL` at your agent. Tracking issue: open one at [agentbreeder/agentbreeder/issues](https://github.com/agentbreeder/agentbreeder/issues) if you need a specific target prioritised.
+</Callout>
+
 To override behaviour locally, set `AGENTBREEDER_SIDECAR=disabled` in the environment. The injection helper short-circuits and the agent runs solo regardless of `agent.yaml`.
 
 ```yaml title="agent.yaml — triggers sidecar injection"


### PR DESCRIPTION
## Summary

End-to-end website audit for v2.0.0. Walked every homepage component, all 36 docs pages, and all 5 blog posts; verified each concrete claim against `CHANGELOG.md`, `docs/architecture/platform-v2.md`, the `engine/` / `api/` / `sdk/` / `sidecar/` source, and open issues. Where a claim was wrong I corrected it; where a claim referenced a feature that hasn't shipped I scoped it to "v2.x roadmap" with an issue link instead of removing it. Did NOT soften accurate claims.

Includes the cherry-picked `docs/v2-marketing-polish` commit (13 features, migrations.mdx, v2 launch blog) so the audit layers on top of those fixes.

### Top corrections

1. **`five-layer-arch`** — claimed deploy step 5 uses Pulumi. Reality: deployers call boto3 / gcloud / kubernetes SDKs directly. No `import pulumi` anywhere in `engine/`. Reworded to "Cloud SDK calls".
2. **`docs/index`** — listed Go as Phase 2. Reality: Go SDK shipped in v2.0 (Track I phase 1, PR #191). Kotlin / Rust / .NET correctly marked as roadmap with #188/#189/#190.
3. **`docs/runtime-contract`** — claimed Tier-2 SDKs are CI-generated from the OpenAPI today. Reality: only Go, hand-curated. Updated tier matrix to per-language status with shipped vs. roadmap.
4. **`docs/sidecar`** — implied universal auto-injection. Reality: docker-compose, GCP Cloud Run, AWS ECS Fargate today; Azure / App Runner / K8s deferred. Added a callout listing coverage.
5. **`docs/secrets`** — `workspace.yaml` example implied the full workspace primitive ships today. Only `secrets:` is wired (Track A / #146 not shipped). Added a note.
6. **`docs/secrets`** — auto-mirror coverage was unscoped. Added a v2.0 note: AWS ECS + GCP Cloud Run only.
7. **`docs/agent-yaml`** — `gateways:` block was completely undocumented (added in v2.0). Added a section with example, scope, and a pointer to `parse_gateway_ref`.
8. **`docs/agent-yaml`** + **`docs/polyglot-agents`** — Rust / Kotlin / .NET were listed as Phase-2 supported. Reality: `engine/runtimes/rust/` does not exist; only `engine/runtimes/go/` ships. Reframed as roadmap.
9. **`docs/mcp-authoring`** — Rust scaffold tab was live-equal with TS/Python/Go. Added a callout that Rust is reserved-not-wired; tabs preserved as planned shape.
10. **`docs/polyglot-agents`** — page describes the older "APS sidecar" (PR #136 design) without distinguishing it from the v2.0 Track J sidecar. Added a callout disambiguating the two and noting planned consolidation. Marked Rust frameworks as roadmap, Go as shipped via the Go SDK.

### Build / lint
- `npm run build` passes (also fixed an unrelated build break: a `cron` code fence in providers.mdx — Shiki has no `cron` language; switched to `bash`).
- All 36 doc pages and all 5 blog posts statically render.

### Pages reviewed

**Homepage components (15):** `app/page.tsx`, `nav`, `hero`, `frameworks`, `agent-demo`, `agent-for-all`, `deploy-anywhere`, `platform-lock`, `five-layer-arch`, `registry-lifecycle`, `features`, `how-it-works`, `cloud-banner`, `cloud-coming`, `built-by`, `footer`.

**Docs (36):** `index`, `quickstart`, `no-code`, `low-code`, `full-code`, `polyglot-agents`, `go-sdk`, `mcp-authoring`, `prompts`, `tools`, `rag`, `graphrag`, `mcp-servers`, `authentication`, `gateway`, `gateways`, `providers`, `secrets`, `how-to`, `examples`, `deployment`, `local-development`, `playground`, `evaluations`, `connectors`, `memory`, `a2a-protocol`, `sidecar`, `agent-yaml`, `runtime-contract`, `registry-guide`, `api-stability`, `comparisons`, `cli-reference`, `orchestration-yaml`, `orchestration-sdk`, `migrations` + `migrations/*`.

**Blog (5):** `why-i-built-agentbreeder`, `agentbreeder-vs-competitors`, `the-big-four-agent-platforms-2026`, `five-layers-of-the-agent-platform-stack`, `v2-platform-substrate` (already accurate, verified).

### Open questions / things to flag for review
- **Homebrew tap** — only docs/quickstart and docs/how-to mention `brew install`, both already say "coming soon". Footer links to the tap repo only (not a `brew install` cmd). Kept as-is. Issue #195 about auto-update breakage doesn't yet need user-facing copy.
- **`go-agent` example** is on disk in `examples/go-agent/` but `docs/examples` doesn't list it under "Framework Examples". Did not add — flagging as follow-up.
- **`cloud-coming.tsx`** says "Just add cloud: claude-managed to your deploy block" to use AgentBreeder Cloud. That conflates Anthropic-managed runtime with AgentBreeder Cloud. Did not edit (waitlist marketing copy is owner's call), flagging.
- **CLAUDE.md tech-stack table** still lists Pulumi as IaC. Worth deciding whether to remove the Pulumi mention there too, or restore Pulumi-driven IaC for some deployer.

## Test plan
- [ ] Visual review on Vercel preview
- [ ] Click every "v2.x roadmap" issue link to confirm GitHub issue exists
- [ ] Confirm the v2.0.0 footer badge looks right on mobile
- [ ] Verify Polyglot APS-vs-Track-J callout reads cleanly in the page

Generated with [Claude Code](https://claude.com/claude-code)
