### PR TITLE
ci(release): probe PyPI /simple/ instead of /pypi/<v>/json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,19 +385,23 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Wait for PyPI propagation
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          echo "Waiting for agentbreeder==$VERSION on PyPI..."
-          for i in $(seq 1 20); do
-            STATUS=$(curl -s "https://pypi.org/pypi/agentbreeder/${VERSION}/json" -o /dev/null -w "%{http_code}")
-            echo "Attempt $i: $STATUS"
-            if [ "$STATUS" = "200" ]; then
-              echo "Package visible on PyPI."
+          echo "Waiting for agentbreeder==$VERSION to be installable via pip..."
+          # Probe the /simple/ index that pip actually uses, not /pypi/<pkg>/<ver>/json.
+          # The JSON endpoint returns 200 the instant the file is uploaded, but pip
+          # reads /simple/ via the Fastly CDN, which lags by tens of seconds — long
+          # enough for the docker build below to start with a stale view.
+          for i in $(seq 1 30); do
+            if pip index versions agentbreeder --pre 2>/dev/null | grep -qE "(^|[^0-9])${VERSION}([^0-9]|$)"; then
+              echo "Attempt $i: pip sees ${VERSION}."
               exit 0
             fi
+            echo "Attempt $i: not yet visible via pip index."
             sleep 30
           done
-          echo "Timed out waiting for PyPI propagation."
+          echo "Timed out waiting for PyPI /simple/ propagation."
           exit 1
 
       - name: Build and push CLI image
@@ -423,18 +427,21 @@ jobs:
       - name: Wait for PyPI propagation
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
-          echo "Waiting for agentbreeder==$VERSION and agentbreeder-sdk==$VERSION on PyPI..."
-          for i in $(seq 1 20); do
-            AB=$(curl -s "https://pypi.org/pypi/agentbreeder/${VERSION}/json" -o /dev/null -w "%{http_code}")
-            SDK=$(curl -s "https://pypi.org/pypi/agentbreeder-sdk/${VERSION}/json" -o /dev/null -w "%{http_code}")
-            echo "Attempt $i: agentbreeder=$AB  agentbreeder-sdk=$SDK"
-            if [ "$AB" = "200" ] && [ "$SDK" = "200" ]; then
-              echo "Both packages visible on PyPI."
+          echo "Waiting for agentbreeder==$VERSION and agentbreeder-sdk==$VERSION on PyPI /simple/..."
+          # Probe the /simple/ index (what pip uses), not /pypi/<pkg>/<ver>/json,
+          # which can return 200 before /simple/ has propagated through Fastly.
+          for i in $(seq 1 30); do
+            AB_OK=0; SDK_OK=0
+            pip index versions agentbreeder     --pre 2>/dev/null | grep -qE "(^|[^0-9])${VERSION}([^0-9]|$)" && AB_OK=1
+            pip index versions agentbreeder-sdk --pre 2>/dev/null | grep -qE "(^|[^0-9])${VERSION}([^0-9]|$)" && SDK_OK=1
+            echo "Attempt $i: agentbreeder=$AB_OK  agentbreeder-sdk=$SDK_OK"
+            if [ "$AB_OK" = "1" ] && [ "$SDK_OK" = "1" ]; then
+              echo "Both packages visible to pip."
               exit 0
             fi
             sleep 30
           done
-          echo "Timed out waiting for PyPI propagation after 10 minutes."
+          echo "Timed out waiting for PyPI /simple/ propagation."
           exit 1
 
       - name: Extract version from tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+### Fixed
+- **Release workflow PyPI propagation race** — `Build & Push CLI Image` and `Update Homebrew Tap` jobs now probe the PyPI `/simple/` index (via `pip index versions`) instead of the `/pypi/<pkg>/<ver>/json` Warehouse endpoint. The JSON endpoint returns 200 the moment a file is uploaded, but `pip install` reads `/simple/` through Fastly, which can lag by tens of seconds — long enough for the v2.0.1 CLI image build to fail with `Could not find a version that satisfies the requirement agentbreeder==2.0.1`.
+
 ---
 
 ## [2.0.1] — 2026-04-29


### PR DESCRIPTION
## Summary
- v2.0.1's `Build & Push CLI Image` job failed with `Could not find a version that satisfies the requirement agentbreeder==2.0.1` immediately after PyPI publish succeeded.
- Root cause: the wait loop polls `/pypi/<pkg>/<ver>/json`, which returns `200` the moment the sdist is uploaded — but `pip install` reads `/simple/` through Fastly, which propagates seconds-to-minutes later.
- Switching the gate to `pip index versions` makes the check use the same code path `pip install` does, so passing the gate now guarantees the docker build's `pip install agentbreeder==<v>` will succeed.
- Same fix applied to the Homebrew tap update job (it had identical code, identical race).

## Test plan
- [ ] Merge to main; the next `v*.*.*` tag push exercises the workflow.
- [ ] On the next release, confirm `Wait for PyPI propagation` step uses `pip index versions` and reports `pip sees <version>.` before the docker build starts.
- [ ] Confirm the CLI image and Homebrew tap update jobs both succeed without intervention.

## Note — separate Homebrew failure
The v2.0.1 release workflow also hit a `Permission to agentbreeder/homebrew-agentbreeder.git denied to rajitsaha` failure, which is **not** fixed by this PR. That is a credential issue with the `HOMEBREW_TAP_TOKEN` secret — likely created before the org transfer (Apr 19) and never re-authorized for the `agentbreeder` org. Tracking separately.

Generated with [Claude Code](https://claude.com/claude-code)
