### PR TITLE
fix(examples): 6 template/quickstart yamls fail schema validation (#183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Fixed
 - **Release workflow PyPI propagation race** — `Build & Push CLI Image` and `Update Homebrew Tap` jobs now probe the PyPI `/simple/` index (via `pip index versions`) instead of the `/pypi/<pkg>/<ver>/json` Warehouse endpoint. The JSON endpoint returns 200 the moment a file is uploaded, but `pip install` reads `/simple/` through Fastly, which can lag by tens of seconds — long enough for the v2.0.1 CLI image build to fail with `Could not find a version that satisfies the requirement agentbreeder==2.0.1`.
+- **6 example/template `agent.yaml` files now pass schema validation** (#183) — `examples/quickstart/rag-agent/agent.yaml` switched from inline `knowledge_bases` to a registry `ref`; `examples/quickstart/search-agent/agent.yaml` dropped the unrecognized top-level `entrypoint`; the four `examples/templates/{competitor-monitor,github-pr-reviewer,meeting-summarizer,returns-processor}/agent.yaml` switched `claude_sdk.thinking.type: adaptive` to the schema-correct `claude_sdk.thinking.enabled: true`. All 44 example/template yamls now validate.
 
 ---
 

--- a/examples/quickstart/rag-agent/agent.yaml
+++ b/examples/quickstart/rag-agent/agent.yaml
@@ -29,10 +29,7 @@ tools:
       required: [query]
 
 knowledge_bases:
-  - name: agentbreeder-docs
-    type: chromadb
-    collection: agentbreeder_knowledge
-    url: http://chromadb:8000
+  - ref: kb/agentbreeder-knowledge
 
 prompts:
   system: |

--- a/examples/quickstart/search-agent/agent.yaml
+++ b/examples/quickstart/search-agent/agent.yaml
@@ -12,8 +12,6 @@ model:
 
 framework: langgraph
 
-entrypoint: agent.py
-
 tools:
   - ref: tools/mcp-filesystem
   - ref: tools/mcp-memory

--- a/examples/templates/competitor-monitor/agent.yaml
+++ b/examples/templates/competitor-monitor/agent.yaml
@@ -14,7 +14,7 @@ framework: claude_sdk
 
 claude_sdk:
   thinking:
-    type: adaptive
+    enabled: true
     effort: medium
   prompt_caching: true
 

--- a/examples/templates/github-pr-reviewer/agent.yaml
+++ b/examples/templates/github-pr-reviewer/agent.yaml
@@ -14,7 +14,7 @@ framework: claude_sdk
 
 claude_sdk:
   thinking:
-    type: adaptive
+    enabled: true
     effort: high
   prompt_caching: true
 

--- a/examples/templates/meeting-summarizer/agent.yaml
+++ b/examples/templates/meeting-summarizer/agent.yaml
@@ -14,7 +14,7 @@ framework: claude_sdk
 
 claude_sdk:
   thinking:
-    type: adaptive
+    enabled: true
     effort: medium
   prompt_caching: true
 

--- a/examples/templates/returns-processor/agent.yaml
+++ b/examples/templates/returns-processor/agent.yaml
@@ -14,7 +14,7 @@ framework: claude_sdk
 
 claude_sdk:
   thinking:
-    type: adaptive
+    enabled: true
     effort: medium
   prompt_caching: true
 


### PR DESCRIPTION
## Summary
Fixes #183 — 6 example/template `agent.yaml` files failed `engine/schema/agent.schema.json` validation. After this PR, all 44 example/template yamls validate cleanly.

| File | Error | Fix |
|---|---|---|
| `examples/quickstart/rag-agent/agent.yaml` | `knowledge_bases.0` missing required `ref` | Inline KB block → `ref: kb/agentbreeder-knowledge` |
| `examples/quickstart/search-agent/agent.yaml` | top-level `entrypoint` not allowed | Removed (langgraph discovers by convention) |
| `examples/templates/competitor-monitor/agent.yaml` | `claude_sdk.thinking.type` not allowed | `type: adaptive` → `enabled: true` |
| `examples/templates/github-pr-reviewer/agent.yaml` | same | same |
| `examples/templates/meeting-summarizer/agent.yaml` | same | same |
| `examples/templates/returns-processor/agent.yaml` | same | same |

Note: the `claude_sdk.thinking.type: adaptive` pattern in the templates was borrowed from a draft of `CLAUDE.md` that doesn't match the schema or the actual runtime — both use `enabled: bool`. `CLAUDE.md` is independently incorrect on this point and is out of scope for this PR (separate doc fix).

## Test plan
- [x] `validate_config()` returns `valid=True` for all 44 example/template yamls
- [x] 365 schema/template/yaml-related unit tests pass
- [ ] CI pipelines on the PR
EOF
