### PR TITLE
chore: add AsyncIterator return type to event_stream (mypy)

### DIFF
--- a/api/routes/providers.py
+++ b/api/routes/providers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import uuid
+from collections.abc import AsyncIterator
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
@@ -346,7 +347,7 @@ async def pull_ollama_model(
     )
     ollama = OllamaProvider(cfg)
 
-    async def event_stream():
+    async def event_stream() -> AsyncIterator[str]:
         try:
             async for event in ollama.pull_model(body.model):
                 yield f"data: {json.dumps(event)}\n\n"


### PR DESCRIPTION
Tiny mypy hotfix — adds the missing return annotation on the inner `event_stream` coroutine inside `pull_ollama_model` (introduced by #214/#227). Without it, mypy raises `[no-untyped-call]` on `StreamingResponse(event_stream(), ...)` and Lint Python fails — currently blocking #225, #226, #228.

Closes nothing; unblocks merges.

Generated with Claude Code.