### PR TITLE
fix(ci): rollback asyncpg session in _enforce_acl + idempotent enums in 020

### DIFF
--- a/alembic/versions/020_incidents_table.py
+++ b/alembic/versions/020_incidents_table.py
@@ -39,12 +39,17 @@ branch_labels: str | None = None
 depends_on: str | None = None
 
 
+# ``create_type=False`` keeps SQLAlchemy from re-issuing CREATE TYPE
+# inside ``create_table`` — we create the enums explicitly in
+# ``upgrade()`` with ``checkfirst=True`` so the migration is idempotent
+# against partially-applied state.
 _SEVERITY_ENUM = sa.Enum(
     "critical",
     "high",
     "medium",
     "low",
     name="incidentseverity",
+    create_type=False,
 )
 _STATUS_ENUM = sa.Enum(
     "open",
@@ -52,6 +57,7 @@ _STATUS_ENUM = sa.Enum(
     "mitigated",
     "resolved",
     name="incidentstatus",
+    create_type=False,
 )
 
 

--- a/api/routes/agents.py
+++ b/api/routes/agents.py
@@ -109,8 +109,14 @@ async def _enforce_acl(
     except Exception as exc:
         if "403" in str(exc) or "Access denied" in str(exc):
             raise
-        # DB unavailable or table not yet migrated — allow access
-        pass
+        # DB unavailable or table not yet migrated — allow access. Roll
+        # back so the asyncpg connection isn't left mid-transaction
+        # (otherwise the *next* await on this session would fail with
+        # "another operation is in progress").
+        try:
+            await db.rollback()
+        except Exception:  # pragma: no cover — rollback on already-bad session
+            pass
 
 
 @router.get("", response_model=ApiResponse[list[AgentResponse]])


### PR DESCRIPTION
Fixes the two CI failures on main from #229 + #207 landing:

1. `alembic upgrade head` raised `type "incidentseverity" already exists` — set `create_type=False` on the Enums so the explicit `.create(checkfirst=True)` is the single idempotent owner.
2. `test_delete_agent` hit asyncpg "cannot perform operation: another operation is in progress" — `_enforce_acl` swallowed the `resource_permissions does not exist` error but left the connection mid-transaction. Roll back inside the except block so the next `db.commit()` works.

Generated with Claude Code.