### PR TITLE
docs(architecture): memory + MCP platforms — last two architectural pillars

### DIFF
--- a/docs/architecture/mcp-platform.md
+++ b/docs/architecture/mcp-platform.md
@@ -1,0 +1,320 @@
+# MCP Platform — Internal Catalog + External Registration + Marketplace
+
+> **Status:** Design (not yet implemented). Tracked under epic `#TBD-F` (linked once filed).
+> **Author:** AgentBreeder team, 2026-04-30.
+> **Related design:** Sits alongside `docs/architecture/rag-tools.md` (#269), `docs/architecture/memory-platform.md` (this commit), and the AgentOps lifecycle (`docs/architecture/agentops-lifecycle.md`, #243).
+
+---
+
+## 1. The problem
+
+Today AgentBreeder treats MCP as a single homogeneous concept — `connectors/mcp_scanner/` discovers servers, `api/routes/mcp_servers.py` registers them, `engine/mcp/packager.py` ships them, the Track-J sidecar passes through traffic at `localhost:9090/mcp/<server>`. That works for the simplest case, but the platform stops short of a real MCP story:
+
+1. **No internal/external distinction.** The platform ships some MCPs (RAG #270, Memory Epic E) AND lets users bring third-party MCPs. Today both flow through the same registration path with no policy distinction.
+2. **No marketplace.** Users can't browse community MCPs from the dashboard. The existing `/marketplace` page (templates) doesn't include them.
+3. **No per-env routing.** A `dev` agent should hit a mock MCP; `prod` should hit the real one. The registry holds a single `(name, url)` row, not N rows per env.
+4. **No sandbox policy.** External MCPs run with the sidecar's full network egress. There's no per-server allowlist for outbound calls or filesystem access.
+5. **No health & cost telemetry per server.** When an external MCP starts failing, we have no per-server status board. When it costs money (via downstream LLM calls), the cost isn't attributed to the calling agent.
+6. **No git lifecycle.** Adding/changing an MCP is a `POST /api/v1/mcp_servers` call. That's exactly the kind of supply-chain change that needs PR review.
+7. **No auth scheme uniformity.** Each MCP has its own auth flow; the platform doesn't standardize bearer / OAuth / mTLS / API-key.
+8. **No discoverability for internal MCPs.** Once we ship 5+ internal servers (RAG, memory, registry, sandbox, A2A), users need a clean catalog page to know what's available out of the box.
+
+## 2. Goals and non-goals
+
+### Goals
+- Clear taxonomy: **internal MCPs we ship** (RAG, memory, registry, sandbox, A2A) vs **external MCPs the user brings** (third-party, marketplace, org-internal).
+- Per-env routing: same `mcp_servers` ref resolves differently in dev vs prod.
+- Sandbox policy as a first-class field on every external MCP — egress allowlist, filesystem mode, resource limits.
+- Health probes + per-server cost telemetry via the existing `cost_events` and audit infra.
+- ACL via ResourcePermission — `read` (call any tool on the server) and `admin` (register/update/delete the server entry).
+- Git lifecycle reuse from #244 — `mcp.yaml` is a registry artifact, PR-reviewed.
+- Marketplace integration — extend the existing `/marketplace` page to include MCPs.
+- Auth schemes standardized: `bearer`, `oauth2`, `mtls`, `api_key`, `none`. All credentials in the workspace secrets backend.
+
+### Non-goals
+- A bespoke MCP runtime. We use the upstream MCP protocol verbatim.
+- Dynamic / runtime tool registration (MCP servers can re-emit their manifest at runtime; we cache it). Hot-add of brand new servers without a registration step is out.
+- Cross-org MCP sharing.
+
+---
+
+## 3. Taxonomy
+
+```
+                ┌─────────────────────────────────────────────────────────┐
+                │                    MCP SERVERS                          │
+                │                                                          │
+                │   ┌─────────────────────┐    ┌─────────────────────┐  │
+                │   │     INTERNAL        │    │      EXTERNAL       │  │
+                │   │  (we ship)          │    │   (user brings)     │  │
+                │   │                     │    │                     │  │
+                │   │  rag-mcp (#270)     │    │ Marketplace browse  │  │
+                │   │  memory-mcp (Epic E)│    │ Direct CLI register │  │
+                │   │  registry-mcp       │    │ Auto-detect scanner │  │
+                │   │  sandbox-mcp        │    │                     │  │
+                │   │  a2a-mcp            │    │ Org-internal        │  │
+                │   │                     │    │ Third-party / SaaS  │  │
+                │   │  always available   │    │ per-workspace opt-in│  │
+                │   │  bundled in image   │    │ explicit registration│  │
+                │   └─────────────────────┘    └─────────────────────┘  │
+                │             │                          │                │
+                │             └──────────┬───────────────┘                │
+                │                        ▼                                 │
+                │     ┌──────────────────────────────────────────┐        │
+                │     │           MCP REGISTRY                    │        │
+                │     │                                            │        │
+                │     │  per-server row                           │        │
+                │     │   ├─ name, kind (internal | external)     │        │
+                │     │   ├─ per-env URL + auth (workspace secret)│        │
+                │     │   ├─ sandbox policy                       │        │
+                │     │   ├─ health probe config                  │        │
+                │     │   ├─ ResourcePermission ACL               │        │
+                │     │   ├─ cost attribution rules               │        │
+                │     │   └─ git_ref / deployed_by / env stamps   │        │
+                │     └──────────────────────────────────────────┘        │
+                └─────────────────────────────────────────────────────────┘
+```
+
+### Internal catalog (we ship)
+
+Bundled with every AgentBreeder install. Versioned (semver), pinnable in `agent.yaml`. No registration step needed — they're auto-attached when an agent declares them.
+
+| Server | Tools | Status | Notes |
+|---|---|---|---|
+| **rag-mcp** | 8 RAG tools (#270) | Designed | Ships with Epic D |
+| **memory-mcp** | 6 memory tools (Epic E) | Designed | Ships with Epic E |
+| **registry-mcp** | `list_agents`, `get_prompt`, `find_tool`, `get_eval`, `find_kb` | NEW (this epic) | Read-only registry queries; ACL-filtered |
+| **sandbox-mcp** | `python.exec`, `js.exec`, `shell.exec` | NEW (this epic) | Safe code execution with policy (CPU / memory / network egress) |
+| **a2a-mcp** | `agent.invoke`, `agent.list`, `agent.card` | NEW (this epic) | Cross-agent calls via JSON-RPC; extends scaffolding under #205 |
+
+### External MCPs (three discovery paths)
+
+1. **Direct register** (CLI or API):
+   ```
+   agentbreeder mcp register \
+     --name slack \
+     --url https://mcp.slack.example.com \
+     --transport http_sse \
+     --auth secret://slack-token \
+     --env prod
+   ```
+2. **Marketplace browse** (dashboard `/marketplace`):
+   - Existing `/marketplace` page already exists for templates
+   - Extend it with an "MCP Servers" tab showing community-vetted MCPs
+   - Each entry has author + reviews + auth scheme + sandbox profile
+   - One-click install (with explicit consent on the auth + sandbox manifest)
+3. **Auto-detect scanner** (extends `connectors/mcp_scanner/`):
+   - Scans Docker compose stacks, K8s services, `~/.claude.json`
+   - Surfaces detected MCPs in the dashboard with "Register?" CTA
+   - Never auto-registers; always requires explicit consent
+
+---
+
+## 4. `mcp.yaml` schema (NEW)
+
+```yaml
+name: zendesk
+description: Customer support MCP for Zendesk
+kind: external                          # internal | external | marketplace
+team: customer-success
+owner: alice@company.com
+
+transport: http_sse                     # stdio | http_sse | http
+auth:
+  scheme: bearer                        # bearer | oauth2 | mtls | api_key | none
+  token: secret://zendesk-token
+
+# Per-env routing
+environments:
+  - name: dev
+    url: http://localhost:8089
+    auth: { scheme: none }
+  - name: staging
+    url: https://mcp-staging.zendesk.example.com
+    auth: { scheme: bearer, token: secret://staging-zendesk-token }
+  - name: prod
+    url: https://mcp-prod.zendesk.example.com
+    auth: { scheme: bearer, token: secret://prod-zendesk-token }
+
+# Sandbox policy
+sandbox:
+  egress_allowlist:
+    - "*.zendesk.com"
+    - "api.zendesk.com"
+  filesystem: read-only                 # read-only | none | tmpfs
+  resource_limits:
+    cpu_millicores: 500
+    memory_mb: 512
+    timeout_per_call_ms: 30000
+
+# Health probe
+health:
+  endpoint: /health
+  interval: 60s
+  failure_threshold: 3                  # 3 failures → mark unhealthy + page
+
+# Cost attribution
+cost:
+  attribute_to: caller                  # caller | server_owner
+  upstream_model_meter: true            # extract usage from MCP responses
+
+# Tool ACL (per-tool, optional override of server-level ACL)
+tool_overrides:
+  - name: zendesk.create_ticket
+    required_role: deployer
+
+# Server-level ACL via ResourcePermission
+access:
+  visibility: team
+  allowed_callers:
+    - team:customer-success
+    - team:engineering
+
+# Marketplace metadata (only for kind=marketplace)
+marketplace:
+  publisher: zendesk
+  publisher_verified: true
+  reviews_url: https://github.com/agentbreeder/marketplace/issues?label=mcp:zendesk
+```
+
+The schema is identical for internal MCPs except `kind: internal`, no `marketplace:` block, and the platform owns the `auth.token` secret.
+
+---
+
+## 5. Sandbox policy
+
+Every external MCP runs inside the sidecar's existing tool-runner sandbox (already shipped) with the policy from `mcp.yaml.sandbox`:
+
+- **`egress_allowlist`** — outbound connections allowed only to listed domains. Enforced at the sidecar's HTTP egress proxy. A `slack` MCP can't accidentally exfiltrate to `evil.example.com`.
+- **`filesystem`** — `read-only` mounts the workspace's tools dir read-only; `none` denies all FS access; `tmpfs` mounts a per-call ephemeral RAM volume for sandbox-mcp's code execution.
+- **`resource_limits`** — CPU / memory caps via cgroups; per-call timeout enforced by the runtime.
+- **Internal MCPs** default to `egress_allowlist: ["*"]` + `filesystem: read-write` because they're trusted; the policy lives in their `mcp.yaml` for transparency.
+
+A failing sandbox check returns `403 Sandbox policy violation` from the sidecar with an audit event `mcp.sandbox_violation` carrying the server name + violation kind.
+
+---
+
+## 6. Health & cost telemetry
+
+### Health
+- Sidecar pings each registered MCP's `health.endpoint` at the configured `health.interval`
+- After `failure_threshold` consecutive failures, the registry's `mcp_servers.status` flips to `unhealthy`
+- Dashboard `/mcp-servers` page surfaces a per-server status badge (mirrors how `/providers` already shows provider health)
+- An auto-incident gets created via `IncidentService` (#207) when an `unhealthy` MCP is referenced by a deployed prod agent
+
+### Cost
+- Every MCP tool call emits a `cost_events` row with `(actor_email, agent_name, mcp_server, tool_name, duration_ms, status)`
+- For MCPs that proxy LLM calls (an MCP that itself hits Anthropic / OpenAI), the response carries usage tokens; the sidecar parses and attributes
+- `attribute_to: caller` (default) bills the calling agent's team; `attribute_to: server_owner` bills the MCP owner's team — useful for shared internal MCPs
+
+---
+
+## 7. Lifecycle integration (reuses #244)
+
+`mcp.yaml` is a registry artifact. Same `Save & Submit` flow as agents. Same `pr_approval_state` (#245). Same per-env promotion (#246).
+
+- Adding a new external MCP is a PR ("we now trust `slack-mcp` from publisher X") — explicitly reviewable
+- Changing `sandbox.egress_allowlist` is a PR — reviewers see the diff in egress policy
+- Promoting from `dev` to `prod` requires the env's approver count + eval gate (in this case, an MCP-conformance eval that makes sure the server actually serves the manifest it claimed)
+- Per-env service principals (#248) handle cloud creds for MCPs that talk to AWS/GCP/Azure backends
+
+The dashboard `/mcp-servers` page becomes the editor: list, create, edit, view health, view cost. Every action goes through the lifecycle.
+
+---
+
+## 8. Marketplace integration
+
+The existing `/marketplace` page (templates) gets a second tab: **MCP Servers**. Listings carry:
+
+- Name, description, publisher (verified or unverified)
+- Auth scheme + sandbox profile (visible up front so users know what they're consenting to)
+- Reviews + install count
+- Source link (GitHub repo / docs)
+- Categories (data, comms, productivity, dev tools, etc.)
+
+`POST /api/v1/marketplace/mcps/<id>/install` does:
+1. Renders `mcp.yaml` from the listing into the user's repo (creates a PR — reuses #244)
+2. The PR diff shows everything the MCP declares: tools, auth, sandbox, env routing
+3. User reviews + approves; merge triggers dev install
+4. Same promote flow to staging / prod
+
+This is the SECURE way to install — every install is git-tracked + reviewed. No silent updates.
+
+---
+
+## 9. Migration plan
+
+### Phase 1 — Schema + lifecycle
+- `mcp.yaml` schema landed
+- `mcp_servers` registry table extended with per-env URL/auth, sandbox policy, health config, cost attribution
+- Wire into AgentOps lifecycle (#244): `Save & Submit`, PR review, per-env promote
+- Audit events: `mcp.registered`, `mcp.installed`, `mcp.uninstalled`, `mcp.sandbox_violation`
+
+### Phase 2 — Internal MCP catalog
+- `registry-mcp` — 5 read-only tools
+- `sandbox-mcp` — `python.exec`, `js.exec`, `shell.exec` with policy
+- `a2a-mcp` — extends scaffolding from #205
+- (`rag-mcp` ships with epic #270, `memory-mcp` with Epic E — both already designed)
+
+### Phase 3 — External MCP infrastructure
+- CLI: `agentbreeder mcp register / list / health / uninstall`
+- Auto-detect scanner (extends `connectors/mcp_scanner/`)
+- Health probe runner (cron-based, reuses #199 infra)
+- Per-server cost attribution
+
+### Phase 4 — Sandbox policy enforcement
+- Egress allowlist via sidecar proxy
+- Filesystem modes via container mount
+- Resource limits via cgroups
+- Audit on every violation
+
+### Phase 5 — Marketplace
+- Extend `/marketplace` page with MCP Servers tab
+- Listing schema, review/rating system (reuse template marketplace's review primitives)
+- One-click install via PR generation
+- Publisher verification flow
+
+Each phase is independently shippable. v2.3 → v2.5 spans all five.
+
+---
+
+## 10. Open questions
+
+1. **Default sandbox for internal MCPs.** Should `internal` default to permissive (`*` egress) or be expected to declare allowlist too? Probably the latter — even internal MCPs should declare egress for least-privilege. Defer the policy to per-server `mcp.yaml`.
+2. **Marketplace verification.** Who verifies a publisher? Initially manual review by AgentBreeder team; automated checksumming + provenance attestation is v2.
+3. **Backwards compat.** Existing `mcp_servers` rows lack per-env URLs and sandbox policy. Migration backfills them with the existing single URL into all envs and `sandbox: { egress_allowlist: ["*"] }` (with a follow-up audit recommendation).
+4. **Auth refresh for OAuth.** OAuth2 tokens expire. The sidecar needs a refresh-token flow keyed by `(workspace, mcp_server, user)`. Reuse the existing OAuth refresher when it lands for RAG loaders (#250 sub-issues).
+5. **Tool-level vs server-level ACL.** A user has `read` on the `slack` MCP but should not be able to call `slack.send_dm`. `tool_overrides:` in the `mcp.yaml` schema covers this; default is to inherit server ACL.
+6. **Internal MCP versioning.** When the platform ships a new version of `rag-mcp`, agents pinned to v1.x should keep working. Need a side-by-side install model + a deprecation path.
+
+---
+
+## 11. What exists today that we keep
+
+| Primitive | Status | Reuse |
+|---|---|---|
+| `connectors/mcp_scanner/` | Shipped | Auto-detect scanner extends this |
+| `engine/mcp/packager.py` | Shipped | Internal MCP image build |
+| `api/routes/mcp_servers.py` | Shipped | Extend with per-env / sandbox / health fields |
+| `registry/mcp_servers.py` | Shipped | Extend with the same |
+| Sidecar (Track J) — MCP passthrough | Shipped | All servers route through the sidecar |
+| Sidecar tool-runner sandbox | Shipped | Sandbox policy enforcement plugs in here |
+| Workspace secrets backend (Track K) | Shipped | All MCP auth tokens live here |
+| `cost_events` table | Shipped | Per-server cost attribution |
+| `audit_log` | Shipped | New event types: `mcp.installed`, `mcp.sandbox_violation`, `mcp.health_state_changed` |
+| `IncidentService` (#207) | Shipped | Auto-create incidents on prod-MCP unhealthy |
+| `/marketplace` page | Shipped (templates) | Extend with MCP Servers tab |
+| AgentOps lifecycle (#244) | Designed | `mcp.yaml` follows the same flow |
+| Per-env service principals (#248) | Designed | MCPs that need cloud creds assume env role |
+| Daily cron infra (#199) | Shipped | Health probes + cost rollups |
+
+This epic adds **3 internal MCP servers + lifecycle integration + sandbox enforcement + marketplace tab**. Most of the security and lifecycle pieces come from already-designed work.
+
+---
+
+## 12. Out of scope
+
+- Hot-add of brand-new MCPs without a registration step
+- Cross-org MCP sharing
+- Custom MCP transport implementations beyond stdio / HTTP / SSE
+- MCP-to-MCP composition / piping (orchestration belongs in agents)

--- a/docs/architecture/memory-platform.md
+++ b/docs/architecture/memory-platform.md
@@ -1,0 +1,337 @@
+# Memory Platform — Working / Episodic / Semantic + Universal Tools
+
+> **Status:** Design (not yet implemented). Tracked under epic `#TBD-E` (linked once filed).
+> **Author:** AgentBreeder team, 2026-04-30.
+> **Related design:** Sits alongside `docs/architecture/rag-platform.md` (#249), `docs/architecture/rag-tools.md` (#269), and the AgentOps lifecycle (`docs/architecture/agentops-lifecycle.md`, #243).
+
+---
+
+## 1. The problem
+
+Track L (migrations 016/017) shipped basic memory persistence — `memory_configs`, `memory_messages`, `memory_entities` tables, an embedding column, and a `memory_manager.py` runtime helper. But it stops short of a complete memory platform:
+
+1. **No tiered abstraction.** Working memory (within a session), episodic memory (cross-session events), and semantic memory (distilled facts) are blurred together. Different storage requirements get the same schema.
+2. **No backend pluggability.** A team that wants Redis for working memory, pgvector for semantic, and Postgres for episodic has to fork.
+3. **No cross-framework tools.** Each runtime has its own `memory_manager`. A Python LangGraph agent and a Node OpenAI Agents agent in the same workspace can't share memory the same way.
+4. **No scope hierarchy.** Today memory is keyed by `(agent, session)`. Per-user memory across agents, per-team memory, and per-org memory don't exist as first-class scopes.
+5. **No compaction or summarization.** Episodic memory grows unbounded. There's no "summarize the last 100 turns into a single semantic fact" pipeline.
+6. **No retention or privacy policy.** GDPR-style "delete all memories belonging to this user" is operator-side scripting, not a tool call.
+7. **No per-env parity.** A `memory.yaml` that uses Redis locally and ElastiCache + pgvector in prod requires hand-editing.
+8. **No git lifecycle.** Memory configs are saved to the workspace DB, not git. There's no PR review for "this agent now stores per-user memory" — which is exactly the kind of change that needs review.
+
+## 2. Goals and non-goals
+
+### Goals
+
+- Three explicit tiers: **working** (in-session), **episodic** (cross-session events), **semantic** (distilled facts).
+- Pluggable backend abstraction per tier, reusing Epic B's `VectorStore` for the semantic layer.
+- 6 canonical memory tools shipped as an MCP server (peer of RAG tools epic #270).
+- Scope hierarchy: `session`, `agent`, `user`, `team`, `org`.
+- Compaction & summarization as platform concerns (cron-driven via #199).
+- Retention & privacy enforced server-side: `delete_on_request: true`, `max_age: 90d`, audit on every read/write/forget.
+- Per-env parity (same `memory.yaml`, different backends per env).
+- Full reuse of the AgentOps lifecycle (#244) — `memory.yaml` is git-backed, PR-reviewed, per-env promoted.
+
+### Non-goals
+
+- Custom embedders inside memory tools (use the index's `embedder` block — same pattern as RAG).
+- Cross-org memory sharing.
+- Differential privacy / synthetic memory anonymization (separate research effort).
+- Memory-augmented training of custom models.
+
+---
+
+## 3. Three memory tiers
+
+```
+                         ┌─────────────────────────────────────────────────┐
+                         │  Agent calls memory.recall("billing", "...")    │
+                         └─────────────────────┬───────────────────────────┘
+                                               │
+                                               ▼
+                         ┌─────────────────────────────────────────────────┐
+                         │           Memory MCP server (epic E)             │
+                         │                                                  │
+                         │   ┌─────────────────────────────────────────┐  │
+                         │   │ ACL → resolve scope → fan out to tiers  │  │
+                         │   └─────────────────────────────────────────┘  │
+                         │                                                  │
+                         │  ┌─────────┐    ┌─────────┐    ┌─────────────┐ │
+                         │  │ WORKING │    │EPISODIC │    │  SEMANTIC   │ │
+                         │  │         │    │         │    │             │ │
+                         │  │ Redis / │    │Postgres │    │ VectorStore │ │
+                         │  │ memory  │    │  rows   │    │  (Epic B)   │ │
+                         │  │         │    │+ graph  │    │             │ │
+                         │  │  TTL    │    │ slice   │    │  retention  │ │
+                         │  │  24h    │    │         │    │  + decay    │ │
+                         │  └─────────┘    └─────────┘    └─────────────┘ │
+                         │                                                  │
+                         │  ┌────────────────────────────────────────────┐ │
+                         │  │ Compaction cron — episodic → semantic     │ │
+                         │  │ Decay cron — semantic score erosion       │ │
+                         │  │ Retention cron — purge by max_age         │ │
+                         │  └────────────────────────────────────────────┘ │
+                         └─────────────────────────────────────────────────┘
+```
+
+### Working memory
+
+- Within one session — last N turns, scratchpad, intermediate tool outputs
+- Backend default: **process memory** for single-replica dev; **Redis** for multi-replica
+- TTL: configurable (default 24h)
+- Never embedded; raw text/JSON
+
+### Episodic memory
+
+- Cross-session events: "Alice cancelled order #1234 on March 12"
+- Backend: **Postgres** for the event rows (ordered, indexed by `(scope, actor, timestamp)`); **graph slice** in Neo4j/Aura/Neptune for entity relationships extracted from events
+- Retention: per-scope `max_age` (default 90d for `per_user`, indefinite for `per_team` / `per_org`)
+- Embeddings optional — used only when a row gets summarized into semantic memory
+
+### Semantic memory
+
+- Distilled facts: "Alice prefers email over SMS", "Customer XYZ's support tier is enterprise"
+- Backend: **vector store** (reuses Epic B's `VectorStore` Protocol — Chroma local, pgvector/Pinecone/etc. cloud)
+- Retention: indefinite, with **decay scoring** — facts not retrieved in N days lose score; facts at score < threshold get pruned by retention cron
+- The platform **owns the transition** from episodic to semantic via a compaction cron (see §6)
+
+---
+
+## 4. Memory tools (peer of RAG tools, ship as MCP)
+
+Same pattern as #270. Single MCP server at `engine/tools/standard/memory_mcp/`, thin SDK wrappers in Python / TypeScript / Go.
+
+| Tool | Purpose | ACL |
+|---|---|---|
+| `memory.recall(scope, query, k=5, tier=auto)` | Semantic search across memories. `tier=auto` queries semantic first, falls back to episodic. | `read` on scope |
+| `memory.write(scope, content, tags={}, tier=episodic)` | Store an episode/fact. `tier=working` for short-term scratchpad; `tier=episodic` for persistence; `tier=semantic` for distilled facts | `write` on scope |
+| `memory.forget(scope, doc_ids OR query)` | Privacy-aware deletion. Cascades across vector + episodic + working. Honors `delete_on_request: true` policy. | `write` on scope |
+| `memory.summarize(scope, since=..., max_tokens=...)` | Async compaction — collapse N episodes into a semantic fact. Returns the new semantic doc id. | `write` on scope |
+| `memory.list_scopes()` | Discovery. Returns scopes the calling agent has read access to. | filter |
+| `memory.export(scope, format=json/jsonl)` | GDPR-style export of all memories in a scope. | admin or self-export |
+
+Every result carries `{memory_id, scope, tier, source_event_id, score, metadata, written_at}` so the agent can cite recall.
+
+---
+
+## 5. Scope model
+
+```yaml
+# memory.yaml
+name: customer-support-memory
+description: Memory shared across customer-success agents
+team: customer-success
+
+scopes:
+  - name: per_session              # working memory — auto-purged on session end
+    backend:
+      working: redis               # or 'memory' for single-replica
+    ttl: 24h
+
+  - name: per_user                 # cross-session per individual user
+    backend:
+      episodic: postgres
+      semantic: pgvector           # reuses Epic B VectorStore
+      graph: neo4j                 # for entity extraction (optional)
+    retention:
+      max_age: 90d
+      delete_on_request: true      # GDPR-compliant
+      decay:
+        enabled: true
+        half_life_days: 30
+        prune_below_score: 0.1
+
+  - name: per_team                 # team-shared learnings, anonymized
+    backend:
+      episodic: postgres
+      semantic: pgvector
+    retention:
+      max_age: indefinite
+      delete_on_request: true
+    privacy:
+      pii_redaction: true          # via guardrails (existing)
+
+  - name: per_org                  # org-wide knowledge (admin-curated)
+    backend:
+      episodic: postgres
+      semantic: pgvector
+    retention:
+      max_age: indefinite
+
+# Per-env backend overrides (mirrors RAG platform)
+environments:
+  - name: dev
+    overrides:
+      per_user.backend.semantic: { type: chroma }
+      per_user.backend.graph:    { type: neo4j, uri: bolt://localhost:7687 }
+  - name: prod
+    overrides:
+      per_user.backend.semantic: { type: pgvector, dsn: secret://prod-pgvector }
+      per_user.backend.graph:    { type: neo4j_aura, uri: secret://prod-aura }
+
+compaction:
+  schedule: "0 4 * * *"             # nightly (uses #199 cron)
+  episodic_to_semantic:
+    after_n_events: 100
+    max_age: 30d
+    embedder:
+      model: text-embedding-3-large
+
+# Same git lifecycle as agents (epic #244)
+access:
+  visibility: team
+  allowed_callers:
+    - team:customer-success
+```
+
+### Scope authorization
+
+- **`per_session`** — auto-resolved by the runtime to the current session id; ACL is implicit (only the running agent + user)
+- **`per_user`** — keyed by `actor_email`; only the user themselves + admin can read; users can self-export and self-delete (GDPR)
+- **`per_agent`** — keyed by `agent_name`; only that agent + agent owner can read
+- **`per_team`** — keyed by `team`; team members + admin can read
+- **`per_org`** — keyed by `org`; admin-curated, all users can read
+
+ResourcePermission ACL (migration 015) backs all of these — same primitive as agents/RAG.
+
+---
+
+## 6. Compaction & summarization
+
+The platform owns the transition from episodic → semantic. A nightly cron job (using #199's daily-cron infra) runs per-scope:
+
+```python
+async def compact_scope(scope: MemoryScope, env: str) -> CompactionResult:
+    """Roll up old episodic events into a single semantic fact."""
+    cfg = scope.compaction.episodic_to_semantic
+    cutoff = now() - timedelta(days=cfg.max_age_days)
+
+    events = await EpisodicStore.list(
+        scope=scope.name,
+        env=env,
+        before=cutoff,
+        limit=cfg.after_n_events,
+    )
+    if len(events) < cfg.after_n_events:
+        return CompactionResult(skipped=True, reason="not enough events")
+
+    summary = await summarize_events(events, embedder=cfg.embedder)
+    fact = SemanticFact(
+        scope=scope.name,
+        content=summary.text,
+        embedding=summary.embedding,
+        source_event_ids=[e.id for e in events],
+        compacted_at=now(),
+    )
+    await SemanticStore.upsert([fact])
+    if scope.compaction.archive_episodes:
+        await EpisodicStore.archive([e.id for e in events])
+    return CompactionResult(compacted=len(events), new_fact_id=fact.id)
+```
+
+Decay scoring runs on the same cron — facts not retrieved in N days lose score; facts below threshold get pruned by the retention cron.
+
+---
+
+## 7. Privacy & retention (first-class, server-enforced)
+
+- `delete_on_request: true` makes `memory.forget` actually scrub from vector store (not soft-delete). Used for GDPR right-to-be-forgotten requests.
+- Auto-purge cron honors `max_age` per-scope.
+- Audit events on every read / write / forget / export. Audit row carries `actor`, `scope`, `tier`, `memory_id`, `delta_kind`.
+- `memory.export` is the platform's GDPR Article 15 (right of access) endpoint — JSON / JSONL output of every memory in a scope.
+- SOC 2 control coverage already lands via the compliance scanner (#208) — we add `memory_retention_enforced` and `memory_deletion_logged` controls.
+
+---
+
+## 8. Per-env parity
+
+Same as RAG platform: `memory.yaml` declares `environments:` overrides. The MCP server reads `AGENTBREEDER_ENV` at startup, resolves the per-env backends, opens connection pools per (env, scope), and uses the env's per-env service principal (#248) for cloud creds.
+
+The agent's call (`memory.recall("per_user", "...")`) is identical across envs. Local hits Redis + Postgres + Chroma; prod hits ElastiCache + RDS + pgvector — agent code never changes.
+
+---
+
+## 9. Lifecycle integration (reuses #244)
+
+`memory.yaml` is a git-backed registry artifact. It follows the same `Save & Submit` → PR → approve → deploy → registry flow as agents and RAG indexes:
+
+- Editing a scope's retention policy from `90d` → `1y` triggers a PR (these are reviewable changes, not silent edits)
+- Adding a new scope is a PR
+- Promotion from `dev` → `prod` re-runs any necessary backend setup (creates new tables, vector indexes, etc.)
+- Per-env registries (#247) get rows for each `memory.yaml` deploy with `git_ref` + `deployed_by` stamps
+
+This is the same point as the RAG platform: **memory inherits the lifecycle**. We do not build a parallel governance pipeline.
+
+---
+
+## 10. Migration plan
+
+### Phase 1 — Backend abstractions
+- `WorkingStore`, `EpisodicStore`, `SemanticStore` Protocols
+- Refactor existing memory_messages / memory_entities behind them
+- Land Redis as the first `WorkingStore` impl (Postgres fallback for single-replica dev)
+- Point `SemanticStore` at Epic B's `VectorStore` Protocol — no new vector code
+
+### Phase 2 — Memory MCP server
+- Server scaffolding (stdio + HTTP/SSE), reuses sidecar passthrough infra
+- 6 tools: recall, write, forget, summarize, list_scopes, export
+- ACL middleware, scope resolution, audit emission
+
+### Phase 3 — Compaction & retention
+- Compaction cron (uses #199)
+- Decay scoring + retention prune cron
+- `delete_on_request` cascade across all three tiers
+
+### Phase 4 — Lifecycle + per-env
+- Extend `memory.yaml` schema (scopes, environments, retention, compaction, privacy)
+- Wire into AgentOps lifecycle (#244): `Save & Submit` from dashboard, PR review, per-env promotion
+- Per-env service principal binding (#248)
+
+### Phase 5 — SDK wrappers
+- Python (`from agenthub.memory import recall, write, forget, ...`)
+- TypeScript (`@agentbreeder/sdk` / `memory`)
+- Go (`sdk/go/agentbreeder/memory/`)
+
+Each phase is independently shippable. v2.3 → v2.5 spans all five.
+
+---
+
+## 11. Open questions
+
+1. **PII redaction default.** Should `per_team` and `per_org` scopes default to `pii_redaction: true` (using existing guardrails)? Probably yes for `per_team` and above; `per_user` keeps PII because that's the point.
+2. **Cross-scope writes.** Should `memory.write` allow writing to multiple scopes atomically (e.g. an event that's both `per_user` and `per_team`)? Defer to v2 of the API; v1 is one scope per call.
+3. **Conflict resolution.** Two replicas update the same semantic fact concurrently. Last-write-wins is the default; an `optimistic_concurrency: true` flag gates conflict detection. Defer fancy CRDTs.
+4. **Embedding cost.** A naive compaction over 100 events per scope per day across 1k scopes is 100k embedding calls. Budget gate via `cost_events` table — defer to a follow-up issue.
+5. **Migration of existing memory.** Migrations 016/017 already populated `memory_messages` / `memory_entities`. Phase 1 needs a backfill step that maps existing rows to the new tier model. Specify in the migration PR.
+6. **Cross-scope queries.** `memory.recall("per_user")` returns only `per_user` memories. Should there be a `memory.recall(["per_user", "per_team"])` for layered context? Probably yes; defer the API surface to v2 of the recall tool.
+
+---
+
+## 12. What exists today that we keep
+
+| Primitive | Status | Reuse |
+|---|---|---|
+| Migration 016 (`memory_persistence`) | Shipped | Tier 2 `EpisodicStore` builds on `memory_messages` |
+| Migration 017 (`memory_phase2` — entities + embedding) | Shipped | Tier 3 `SemanticStore` uses the embedding column |
+| `engine/runtimes/templates/memory_manager.py` | Shipped | Refactor to call the Memory MCP server |
+| `engine/schema/memory.schema.json` | Shipped | Extend with scopes / environments / retention / compaction |
+| `api/routes/memory.py` | Shipped | Routes proxy to the MCP server (same shape as RAG) |
+| Sidecar (Track J) | Shipped | Memory MCP runs as another sidecar tool — no new networking |
+| Daily-cron infra (#199) | Shipped | Compaction + decay + retention crons |
+| AgentOps lifecycle (#244) | Designed | `memory.yaml` follows the same git → PR → approve → deploy flow |
+| Multi-store abstraction (#251) | Designed | `SemanticStore` IS Epic B's `VectorStore` |
+| Per-env registry (#247) | Designed | `memory_configs` rows get `git_ref` + `deployed_by` stamps |
+| Per-env service principals (#248) | Designed | MCP server's connection pools assume the env's role |
+| ResourcePermission ACL (migration 015) | Shipped | Scope authorization |
+
+This epic adds **one MCP server + thin wrappers + backend abstractions**. The lifecycle, governance, security, and infra all come from already-designed work.
+
+---
+
+## 13. Out of scope
+
+- Custom embedders inside memory tools (use the scope's `embedder`)
+- Differential privacy / synthetic memory
+- Multi-tenant org isolation beyond per-scope ACL
+- Memory-augmented training (separate ML effort)
+- Cross-region replication


### PR DESCRIPTION
## Summary
Two design docs that close the last two architectural gaps in the v2.x roadmap:

### `docs/architecture/memory-platform.md`
- Three memory tiers: **working** (Redis / process), **episodic** (Postgres + graph slice), **semantic** (`VectorStore` from Epic B)
- 6 canonical memory tools (`recall`, `write`, `forget`, `summarize`, `list_scopes`, `export`) shipped as an MCP server — peer of the RAG tools epic (#270)
- Scope hierarchy: `per_session` / `per_user` / `per_agent` / `per_team` / `per_org` with `ResourcePermission` ACL
- First-class privacy: `delete_on_request`, retention `max_age`, audit on every read/write/forget, GDPR `memory.export`
- Compaction cron (episodic → semantic) reuses #199 daily-cron infra
- Per-env parity (same `memory.yaml` works across Chroma+Postgres local and pgvector+RDS in cloud)
- Full reuse of AgentOps lifecycle (#244) — same `Save & Submit` → PR → approve → deploy → registry flow

### `docs/architecture/mcp-platform.md`
- Clear taxonomy: **internal MCPs we ship** (rag-mcp #270, memory-mcp Epic E, registry-mcp, sandbox-mcp, a2a-mcp) vs **external MCPs the user brings** (marketplace / direct register / auto-detect)
- `mcp.yaml` schema with per-env URL/auth, sandbox policy (`egress_allowlist`, `filesystem`, resource limits), health probe, cost attribution
- Marketplace integration (extends existing `/marketplace` tab)
- Health + per-server cost telemetry via `cost_events`
- ACL via `ResourcePermission`; tool-level overrides
- Lifecycle: `mcp.yaml` is git-backed, PR-reviewed; install from marketplace **generates a PR** so every new MCP supply-chain change is reviewable

## Why now
With the AgentOps lifecycle (#243), RAG platform (#249), and RAG tools (#269) docs landed, memory and MCP are the last two architectural pillars to design at this level. The pattern is now consistent across all five docs:

```
substrate (stores / loaders / scopes)  +  universal tools (MCP + SDK wrappers)  +  lifecycle reuse (#244)
```

## Test plan
- [x] Both docs render cleanly
- [ ] Reviewers concur on the 3-tier memory model (working / episodic / semantic)
- [ ] Reviewers concur on the internal/external MCP taxonomy and sandbox policy
- [ ] No objections to MCP-marketplace installs going through the PR flow (security review by default)
- [ ] No objections to per-scope retention as a first-class field

Generated with Claude Code.
