### PR TITLE
chore: Week 1 plumbing — CLA, governance, CoC, trademark, README positioning

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,74 @@
+# Contributor License Agreement (CLA)
+
+AgentBreeder uses the Apache Software Foundation's standard Contributor License
+Agreement. Every external contributor signs the CLA once — automatically, via
+[CLA Assistant](https://cla-assistant.io/) — before their first pull request
+can be merged. Once signed, you never need to sign again, and the signature
+applies to all future contributions across `agentbreeder/agentbreeder` and
+`agentbreeder/agentbreeder-showcase`.
+
+## Why a CLA
+
+We use a CLA so we can keep AgentBreeder **Apache 2.0 forever** and protect the
+project against bad-actor relicensing claims. The CLA gives the AgentBreeder
+maintainers a clear license to redistribute your contribution under Apache 2.0
+(and any compatible license a future steering committee may adopt with public
+notice). It does **not** transfer copyright — you retain ownership of your
+contribution. It does not prevent you from using your own contribution
+elsewhere, including in commercial products.
+
+The two practical effects are:
+
+1. **License durability.** If a contributor's employer later claims the
+   contribution was made on company time and tries to revoke the license, the
+   CLA gives the project a defense.
+2. **License flexibility for the project.** If we ever need to dual-license a
+   subset of the code (e.g., to allow embedding in GPL-incompatible distributions),
+   the CLA allows the maintainers to do so without re-contacting every
+   contributor.
+
+We do not currently anticipate moving off Apache 2.0. The CLA is an insurance
+policy, not a foreshadowing.
+
+## How signing works
+
+1. Open a pull request as normal.
+2. The CLA Assistant bot comments on the PR with a link.
+3. Click the link; sign in with your GitHub account; click "I agree."
+4. The bot updates the PR status check to passing.
+5. A maintainer reviews and merges per the standard
+   [PR review process](CONTRIBUTING.md#pull-request-process).
+
+## Individual vs. Corporate CLA
+
+- **Individual contributors** sign the **Apache ICLA** (Individual Contributor
+  License Agreement). This is the default and covers contributions made on
+  your own time.
+- **Corporate contributors** — if you are contributing on behalf of your
+  employer or as part of paid work — your company should sign the **Apache
+  CCLA** (Corporate Contributor License Agreement) once, listing approved
+  individual contributors. Email **saha.rajit@gmail.com** with the subject
+  `[CCLA] <Company Name>` to request the corporate version.
+
+## Grandfathered contributors
+
+Anyone who merged a pull request to `agentbreeder/agentbreeder` before
+**2026-04-30** is grandfathered. No CLA needed for past contributions or
+new ones — though you can still sign voluntarily if you'd like to be listed
+as a CLA-signed contributor.
+
+## The CLA text
+
+We use the **unmodified Apache ICLA and CCLA** text published by the Apache
+Software Foundation:
+
+- Individual: <https://www.apache.org/licenses/icla.pdf>
+- Corporate: <https://www.apache.org/licenses/cla-corporate.pdf>
+
+If a contributor's lawyer asks "what is this CLA," the answer is "the Apache
+Foundation's standard CLA, used unmodified." That tends to end the
+conversation quickly.
+
+## Questions
+
+CLA-related questions: **saha.rajit@gmail.com** with subject `[CLA] <topic>`.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,80 @@
+# Code of Conduct
+
+## Our pledge
+
+The AgentBreeder community pledges to make participation in our project and
+community a welcoming, inclusive, and harassment-free experience for everyone,
+regardless of age, body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+caste, color, religion, or sexual identity and orientation.
+
+We pledge to act in ways that contribute to an open, welcoming, diverse,
+inclusive, and healthy community.
+
+## The standard we adopt
+
+The AgentBreeder project adopts the **Contributor Covenant, version 2.1**, as
+the standard for community behavior. The full canonical text — including
+the standards we expect, what is unacceptable, enforcement responsibilities,
+scope, and the four-tier enforcement guidelines — is published at:
+
+> **<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>**
+
+That URL is the authoritative version. We adopt it without modification. By
+participating in this project (contributing code, opening issues, posting in
+discussions, joining Discord, attending events) you agree to abide by it.
+
+## Summary of expected behavior
+
+Examples of behavior that contribute to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility, apologizing to those affected by mistakes, and
+  learning from the experience
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior — see the canonical text linked above for
+the complete list.
+
+## Enforcement
+
+Instances of behavior that may violate this Code of Conduct can be reported
+to the project lead at **saha.rajit@gmail.com** with the subject line
+`[CoC] <topic>`. All complaints will be reviewed and investigated promptly
+and fairly.
+
+The project lead is obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement guidelines
+
+We follow the four-tier enforcement guidelines defined in the Contributor
+Covenant 2.1: **Correction**, **Warning**, **Temporary Ban**, and
+**Permanent Ban**. The full guidelines — including what triggers each tier
+and what consequences apply — are documented at the canonical URL above.
+
+The project lead has final authority on enforcement actions.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — the GitHub repos,
+GitHub Discussions, Discord, mailing lists, social media accounts where the
+project posts officially, and in-person or virtual events organized under
+the AgentBreeder name. It also applies when an individual is officially
+representing the project in public spaces.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/),
+available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.
+
+Community Impact Guidelines were inspired by Mozilla's code of conduct
+enforcement ladder.
+
+For answers to common questions about this Code of Conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -361,6 +361,16 @@ chore: bump FastAPI to 0.110
 
 PRs are reviewed within 48 hours. Changes to `engine/` require two maintainer approvals. All other changes require one.
 
+### Contributor License Agreement (CLA)
+
+External contributors sign the **Apache ICLA** (or **CCLA** for corporate
+contributions) once before their first PR can be merged. The
+[CLA Assistant](https://cla-assistant.io/) bot prompts you on your PR — one
+click signs it for all future contributions. Contributors who merged before
+**2026-04-30** are grandfathered and don't need to sign.
+
+Full rationale and process: see [CLA.md](CLA.md).
+
 ---
 
 ## Extension Points
@@ -436,6 +446,7 @@ Add templates to `examples/templates/` and open a PR with the label `marketplace
 |---|---|
 | `good first issue` | Approachable for new contributors |
 | `help wanted` | Maintainers want community input |
+| `needs design` | Discussion required before implementation; do not open a PR yet |
 | `deployer:aws` / `deployer:gcp` / `deployer:azure` | Cloud deployer work |
 | `runtime:langgraph` / `runtime:crewai` / `runtime:claude-sdk` | Framework runtime work |
 | `area:cli` / `area:dashboard` / `area:registry` / `area:engine` | Component area |
@@ -447,9 +458,12 @@ Add templates to `examples/templates/` and open a PR with the label `marketplace
 
 ## Code of Conduct
 
-We follow the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/). Be constructive, be kind, assume good intent. Harassment or discrimination of any kind will not be tolerated.
+We adopt the [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as
+our community standard. See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for the
+full text and enforcement process. Be constructive, be kind, assume good intent.
 
-Report conduct issues to **saha.rajit@gmail.com**.
+Report Code of Conduct issues to **saha.rajit@gmail.com** with the subject
+line `[CoC] <topic>`.
 
 ---
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,126 @@
+# AgentBreeder Project Governance
+
+This document describes how decisions are made on the AgentBreeder open-source
+project (`agentbreeder/agentbreeder` and `agentbreeder/agentbreeder-showcase`).
+
+## Current model: BDFL
+
+AgentBreeder is currently led by a Benevolent Dictator For Life (BDFL):
+
+- **Project Lead:** Rajit Saha (saha.rajit@gmail.com)
+
+The BDFL has final authority on all project decisions: roadmap, architecture,
+release timing, license posture, contributor admission, and code-of-conduct
+enforcement. The BDFL delegates day-to-day decisions to maintainers and the
+community whenever practical.
+
+This is the standard model for early-stage projects. As the project grows it
+will evolve — see [Future evolution](#future-evolution) below.
+
+## How decisions get made
+
+### Day-to-day technical decisions
+
+- **Single-area changes** (one runtime, one deployer, one connector, doc
+  fixes): one maintainer approval is sufficient. The project lead may waive
+  this for trivial fixes.
+- **Cross-area changes** (anything touching `engine/`, the deploy pipeline,
+  the registry schema, or the public CLI surface): two maintainer approvals,
+  one of whom must be the project lead or a delegated reviewer.
+- **Schema changes** to `agent.yaml`, `orchestration.yaml`, or any registry
+  table: project lead must approve. Schema changes require a corresponding
+  doc update in `website/content/docs/agent-yaml.mdx` or equivalent in the
+  same PR.
+
+### Roadmap decisions
+
+The roadmap is public — see
+[`ROADMAP.md`](ROADMAP.md) and the
+[GitHub Project board](https://github.com/orgs/agentbreeder/projects).
+Anyone can propose a feature by opening an issue tagged `type:feature`. The
+project lead triages and assigns a milestone (or rejects with a reason).
+
+### License and trademark decisions
+
+The project license (Apache 2.0) and trademark policy
+([TRADEMARK.md](TRADEMARK.md)) are stable commitments. They will not change
+without:
+
+1. Public discussion in GitHub Discussions for at least 30 days.
+2. A blog post on agentbreeder.io explaining the rationale.
+3. The project lead's signed-off proposal.
+
+This is intentional — predictable license posture is part of the contract
+with contributors.
+
+## Maintainer ladder
+
+Anyone in the community can climb the ladder. The criteria are public and
+applied consistently.
+
+| Tier | Requirements | What you can do |
+|---|---|---|
+| **Contributor** | Signed [CLA](CLA.md) and merged at least one PR | Open issues and PRs |
+| **Triager** | 5+ merged PRs over at least 30 days, sustained activity, demonstrated good judgment in issue triage | Apply labels, close stale issues, assign milestones, request changes on PRs |
+| **Maintainer** | 15+ merged PRs over 90+ days, deep expertise in at least one subsystem (`engine/`, `cli/`, `dashboard/`, `sdk/`, etc.), proven ability to mentor newer contributors | Approve and merge PRs in their area, run release builds for their area, vote on RFCs |
+| **Project Lead** | One person at a time. Currently Rajit Saha. | All maintainer rights, plus license/trademark/governance authority |
+
+Promotions are decided by the existing maintainers and the project lead. We
+expect to promote the first non-founder triagers and maintainers within
+6 months of public launch.
+
+## Conflict resolution
+
+1. **Technical disagreement:** discuss in the relevant PR or issue. If no
+   consensus is reached within 7 days, escalate to a maintainer in the
+   affected area. If still unresolved, the project lead makes the call.
+2. **Code of Conduct issues:** see
+   [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). Report to
+   **saha.rajit@gmail.com**. The project lead investigates within 48 hours
+   and follows the Contributor Covenant 2.1 enforcement guidelines.
+3. **Disputes over license, trademark, or project direction:** the project
+   lead has final authority. The lead is expected to explain reasoning
+   publicly when overruling community consensus.
+
+## Future evolution
+
+This governance model will evolve as the project grows. The intended path:
+
+| Trigger | Change |
+|---|---|
+| First Cloud paying customer | Form an internal AgentBreeder maintainer team (employees + key external maintainers) |
+| 50+ active external contributors | Form a public **Steering Committee** — 5–7 members, including at least 2 non-employee maintainers, elected annually. Steering Committee decisions can override the project lead by 2/3 vote, except on license/trademark. |
+| 1000+ active monthly contributors or significant enterprise dependency | Consider transferring stewardship to a neutral foundation (Apache Software Foundation, Linux Foundation, or Open Source Initiative) |
+
+These triggers are guideposts, not commitments. The project lead may move
+faster or slower depending on community needs.
+
+## Communication channels
+
+| Channel | Purpose |
+|---|---|
+| [GitHub Issues](https://github.com/agentbreeder/agentbreeder/issues) | Bug reports, feature requests, tracked work |
+| [GitHub Discussions](https://github.com/agentbreeder/agentbreeder/discussions) | Open-ended questions, RFCs, roadmap input |
+| Discord *(coming soon)* | Real-time chat: `#announcements`, `#help`, `#contributors`, `#cloud` |
+| security@agentbreeder.com | Security disclosures (see [SECURITY.md](SECURITY.md)) |
+| saha.rajit@gmail.com | Code of Conduct, license, trademark, governance, partnerships |
+
+## Maintainer responsibilities
+
+Maintainers commit to:
+
+- **48-hour PR triage** — every PR gets a first response within 48 hours of
+  opening, even if it's only "thanks, will review by EOW."
+- **7-day review** — PRs from external contributors get a full review and a
+  merge-or-changes decision within 7 days unless explicitly deferred.
+- **Public reasoning** — when rejecting a PR or design proposal, explain
+  why in writing.
+- **Mentor newer contributors** — make time to help triagers and contributors
+  level up.
+
+Failure to uphold these responsibilities is grounds for stepping down from
+or being removed from a maintainer role.
+
+---
+
+*Document version: 1.0 — adopted 2026-04-30.*

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 # AgentBreeder™ — v2.0
 
-### Stop wrangling agents. Start shipping them.
+### The only agent platform that doesn't pick a winner.
 
-**One YAML file. Any framework. Any language. Any cloud. Governance built in.**
+**Build with anyone's framework. Deploy to anyone's cloud. Govern automatically.**
+One YAML, one command — Apache 2.0, no vendor lock-in.
 
 [![PyPI](https://img.shields.io/pypi/v/agentbreeder?color=blue&label=PyPI)](https://pypi.org/project/agentbreeder/)
 [![PyPI Downloads](https://img.shields.io/pypi/dm/agentbreeder?color=green&label=Downloads)](https://pypi.org/project/agentbreeder/)
@@ -375,8 +376,29 @@ The same pattern (`agentbreeder deploy`) works for AWS ECS Fargate, App Runner, 
 | [ROADMAP.md](ROADMAP.md) | Release plan and milestone status |
 | [CHANGELOG.md](CHANGELOG.md) | Version history |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How to contribute — setup, standards, PR process |
+| [GOVERNANCE.md](GOVERNANCE.md) | Project governance, decision-making, maintainer ladder |
+| [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) | Community standards (Contributor Covenant 2.1) |
+| [CLA.md](CLA.md) | Contributor License Agreement (Apache ICLA / CCLA) |
+| [TRADEMARK.md](TRADEMARK.md) | AgentBreeder™ trademark policy and permitted uses |
 | [SECURITY.md](SECURITY.md) | Security policy and vulnerability reporting |
 
 ---
 
-[Contributing](CONTRIBUTING.md) · [Issues](https://github.com/agentbreeder/agentbreeder/issues) · [Discussions](https://github.com/agentbreeder/agentbreeder/discussions) · [Apache 2.0](LICENSE)
+## Want us to run it?
+
+AgentBreeder is fully self-hostable — that's the point. But operating it in
+production means running Postgres, ClickHouse, Redis, the control plane,
+sidecars, autoscaling, and on-call across five clouds.
+
+If you'd rather skip that, **[AgentBreeder Cloud](https://www.agentbreeder.io/cloud)**
+is the same Apache 2.0 platform, run by us, with multi-tenant SSO, cross-cloud
+cost rollups, compliance attestations, and a 99.95% SLA.
+
+Either way, the runtime is the same code. Switch at any time. **No data
+lock-in. No feature lock-out.**
+
+[Try Cloud →](https://www.agentbreeder.io/cloud) &nbsp;·&nbsp; [Self-host docs →](https://www.agentbreeder.io/docs/quickstart)
+
+---
+
+[Contributing](CONTRIBUTING.md) · [Issues](https://github.com/agentbreeder/agentbreeder/issues) · [Discussions](https://github.com/agentbreeder/agentbreeder/discussions) · [Apache 2.0](LICENSE) · [Trademark](TRADEMARK.md)

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,72 @@
+# Trademark Policy
+
+**AGENTBREEDER™** is a trademark of Rajit Saha.
+
+| Field | Value |
+|---|---|
+| Wordmark | AGENTBREEDER |
+| Serial number | 99773158 |
+| Registration number | *(pending)* |
+| Filing date | 2026-04-19 |
+| Status | Live / Pending (US Principal Register) |
+| Jurisdiction | United States Patent and Trademark Office (USPTO) |
+
+While the application is pending, we use **™**. We will switch to **®** once
+the registration is granted by the USPTO.
+
+## What's covered by the trademark
+
+The wordmark `AGENTBREEDER` and any future logos.
+
+## What's covered by Apache 2.0
+
+The source code in this repository is licensed under
+[Apache License 2.0](LICENSE). You may fork, modify, and redistribute the
+code freely, including for commercial purposes, subject to the Apache 2.0
+terms.
+
+The Apache 2.0 license **does not grant trademark rights**. This is standard
+for permissive licenses — see Section 6 of the Apache License 2.0 itself:
+*"This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor."*
+
+## What you can do
+
+- **Fork the code** and use it for any purpose under Apache 2.0.
+- **Refer to AgentBreeder by name** in factual contexts: blog posts, talks,
+  documentation, comparisons, integration descriptions ("works with
+  AgentBreeder"), academic citations.
+- **Use the AgentBreeder name** in materials that describe your contribution
+  to or use of AgentBreeder.
+
+## What you cannot do without permission
+
+- **Distribute a modified fork under the AgentBreeder name.** If you fork the
+  code and ship a modified version, rename it. Do not call it
+  "AgentBreeder," "AgentBreeder Plus," "Open AgentBreeder," "[Your-Company]
+  AgentBreeder," or any other variant that contains the wordmark.
+- **Operate a commercial managed service using the AgentBreeder name.** If
+  you run a managed/hosted service, do not use "AgentBreeder" in the
+  product name, marketing, or domain. This is the standard
+  trademark-meets-permissive-license pattern (Elastic, MongoDB, Redis, Sentry).
+- **Imply endorsement or partnership** with AgentBreeder where none exists.
+- **Use the AgentBreeder logo** without written permission.
+
+## Licensing inquiries
+
+For permission to use the AgentBreeder mark in a way that would otherwise
+require permission, email **saha.rajit@gmail.com** with subject
+`[TRADEMARK] <your use case>`. We respond to most inquiries within 14 days.
+
+## Why this matters for the open-source community
+
+This policy is not about restricting use of the code — the code is Apache 2.0
+and we want it forked, embedded, and built upon. The trademark protects
+*users* from confusion: if someone runs a modified fork under the
+AgentBreeder name and it behaves differently or breaks, end users have no way
+to tell whether the upstream project is at fault. Renaming forks keeps the
+ecosystem honest.
+
+This is the same posture used by many widely-respected OSS projects,
+including the Apache Software Foundation projects, Linux (the kernel name
+is trademarked even though the source is GPL), and Django.


### PR DESCRIPTION
## Summary

Implements Week 1 of the open-core strategy adopted in the 2026-04-30 brainstorm. No code or runtime changes — only contributor-facing scaffolding.

## What changed

**New files:**
- `CLA.md` — Apache ICLA / CCLA via [CLA Assistant](https://cla-assistant.io/). Existing contributors grandfathered up to 2026-04-30.
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1 (canonical text via link).
- `GOVERNANCE.md` — BDFL model, decision rules, maintainer ladder, future evolution triggers.
- `TRADEMARK.md` — AGENTBREEDER™ wordmark policy, USPTO serial 99773158, fork/rename rules.

**`CONTRIBUTING.md`:**
- New CLA section under "Pull Request Process"
- Adds `needs design` row to the issue labels table
- Code of Conduct section now points at the new file

**`README.md`:**
- Replaces tagline with "the only agent platform that doesn't pick a winner"
- Adds "Want us to run it?" Cloud footer block (with the structural "no feature lock-out" promise)
- Adds GOVERNANCE / CoC / CLA / TRADEMARK rows to the documentation table
- Adds Trademark link to the bottom footer

## Why now

Pre-launch plumbing — Show HN / Product Hunt cadence kicks off in Weeks 2-3 and the public repo needs to look like a real OSS project before the traffic arrives.

## Test plan

- [x] All new files render correctly on GitHub web preview
- [x] `CONTRIBUTING.md` PR-process section reads cleanly with new CLA block
- [x] `README.md` hero + footer changes preserve existing structure
- [x] No code paths touched; CI pre-push hooks (ruff lint + format) pass
- [ ] Verify on github.com — links resolve, badges render, table of contents flows

## Strategy reference

Full strategy doc: `agentbreeder-cloud:docs/strategy/2026-04-30-open-core-strategy.md` (private repo)