### PR TITLE
chore: add Discord community invite link

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -101,7 +101,7 @@ faster or slower depending on community needs.
 |---|---|
 | [GitHub Issues](https://github.com/agentbreeder/agentbreeder/issues) | Bug reports, feature requests, tracked work |
 | [GitHub Discussions](https://github.com/agentbreeder/agentbreeder/discussions) | Open-ended questions, RFCs, roadmap input |
-| Discord *(coming soon)* | Real-time chat: `#announcements`, `#help`, `#contributors`, `#cloud` |
+| [Discord](https://discord.gg/QT9j3Uj4s5) | Real-time chat: `#announcements`, `#help`, `#contributors`, `#cloud` |
 | security@agentbreeder.com | Security disclosures (see [SECURITY.md](SECURITY.md)) |
 | saha.rajit@gmail.com | Code of Conduct, license, trademark, governance, partnerships |
 

--- a/README.md
+++ b/README.md
@@ -397,8 +397,8 @@ cost rollups, compliance attestations, and a 99.95% SLA.
 Either way, the runtime is the same code. Switch at any time. **No data
 lock-in. No feature lock-out.**
 
-[Try Cloud →](https://www.agentbreeder.io/cloud) &nbsp;·&nbsp; [Self-host docs →](https://www.agentbreeder.io/docs/quickstart)
+[Try Cloud →](https://www.agentbreeder.io/cloud) &nbsp;·&nbsp; [Self-host docs →](https://www.agentbreeder.io/docs/quickstart) &nbsp;·&nbsp; [Join Discord →](https://discord.gg/QT9j3Uj4s5)
 
 ---
 
-[Contributing](CONTRIBUTING.md) · [Issues](https://github.com/agentbreeder/agentbreeder/issues) · [Discussions](https://github.com/agentbreeder/agentbreeder/discussions) · [Apache 2.0](LICENSE) · [Trademark](TRADEMARK.md)
+[Contributing](CONTRIBUTING.md) · [Issues](https://github.com/agentbreeder/agentbreeder/issues) · [Discussions](https://github.com/agentbreeder/agentbreeder/discussions) · [Discord](https://discord.gg/QT9j3Uj4s5) · [Apache 2.0](LICENSE) · [Trademark](TRADEMARK.md)


### PR DESCRIPTION
## Summary

Tiny follow-up to PR #330. Replaces the `(coming soon)` Discord placeholder
with the live community invite at https://discord.gg/QT9j3Uj4s5.

## Files

- `README.md` — Discord link added to the bottom footer + the "Want us to run it?" Cloud block
- `GOVERNANCE.md` — replaces *"Discord (coming soon)"* in the communication channels table with the live link

## Test plan

- [x] `gh pr create` — testing CLA Assistant on a maintainer-authored PR (should be auto-passed since maintainer is grandfathered)
- [ ] Verify invite renders correctly in GitHub markdown preview
- [ ] Click the link from the merged README to confirm it lands on the server