### PR TITLE
feat(provisioners): Phase A cloud-deploy foundation (AWS/GCP/Azure validate-infra + cloud-requirements)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+### v2.3 — Cloud-Deploy Foundation (#413)
+
+- **Added** `engine/provisioners/` — `InfraProvisioner` ABC with read-only `validate_existing` impls for AWS / GCP / Azure (boto3, google-cloud, azure-sdk). Greenfield `provision()` / `destroy()` stubbed (per-cloud follow-ups #382 / #383 / #384).
+- **Added** `engine/provisioners/state.py` — `InfraState` round-trippable via `.agentbreeder/infra-state.json`.
+- **Added** `engine/provisioners/requirements.py` — static user-input contract per cloud × `(simple, full)` mode.
+- **Added** API: `GET /api/v1/deployments/cloud-requirements/{cloud}?mode=simple|full` (any authenticated user) and `POST /api/v1/deployments/validate-infra` (`deployer` role required in the requested team, cross-team → 403, rate-limited 10 req/min via slowapi, audit-logged via `AuditService`).
+- **Added** `pgvector>=0.2.5` + `slowapi>=0.1.9` to optional deps; new `gcp` extras group; expanded `azure` group.
+- **Docs** — rewrote `website/content/docs/deployment.mdx` to a three-cloud tabbed contract.
+
 ### Platform Audit Summary (2026-05-18)
 
 A 9-way parallel audit (`docs/superpowers/specs/2026-05-18-platform-audit-design.md`) surfaced 91 findings across 8 code subsystems plus website. 85 additive-safe items landed across 5 execution waves:

--- a/api/main.py
+++ b/api/main.py
@@ -20,6 +20,7 @@ from api.routes import (
     builders,
     compliance,
     costs,
+    deployments,
     deploys,
     evals,
     gateway,
@@ -144,6 +145,17 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+# Rate limiting (slowapi) — used by selected routes (e.g. validate-infra).
+# Module-level Limiter lives in api.routes.deployments so route decorators can
+# reference it; we publish it on app.state and register the default 429 handler.
+from slowapi import _rate_limit_exceeded_handler  # noqa: E402
+from slowapi.errors import RateLimitExceeded  # noqa: E402
+
+from api.routes.deployments import limiter as _deployments_limiter  # noqa: E402
+
+app.state.limiter = _deployments_limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
 # CORS
 app.add_middleware(
     CORSMiddleware,
@@ -161,6 +173,7 @@ app.include_router(auth.router)
 app.include_router(agents.router)
 app.include_router(builders.router)
 app.include_router(deploys.router)
+app.include_router(deployments.router)
 app.include_router(prompts.router)
 app.include_router(providers.router)
 app.include_router(mcp_servers.router)

--- a/api/routes/deployments.py
+++ b/api/routes/deployments.py
@@ -1,0 +1,169 @@
+"""Deployment infrastructure API (Phase A foundation for epic #378).
+
+Two endpoints:
+
+- ``GET /api/v1/deployments/cloud-requirements/{cloud}`` returns the
+  user-input contract for a given cloud + mode (static data). Any
+  authenticated user may read this.
+
+- ``POST /api/v1/deployments/validate-infra`` performs read-only checks
+  against the user's existing cloud resources. Team-scoped: caller must
+  hold ``deployer`` role in the team specified in the request body.
+  Rate-limited (10 req/min/IP) and audit-logged.
+
+Greenfield provisioning (creating resources from scratch) is deferred to
+epic #378's sub-issues #382 / #383 / #384.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from pydantic import BaseModel, Field
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+from api.auth import get_current_user
+from api.models.database import User
+from api.models.schemas import ApiResponse
+from api.services.audit_service import AuditService
+from api.services.team_service import ROLE_HIERARCHY, TeamService
+from engine.provisioners import (
+    CloudMode,
+    CloudName,
+    CloudRequirements,
+    InfraValidationInput,
+    ValidationResult,
+    get_requirements,
+    provisioner_for,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/deployments", tags=["deployments"])
+
+# Module-level limiter. ``api.main`` re-uses the same instance via the
+# ``limiter`` attribute it sets on ``app.state``, but route decorators must
+# reference an importable Limiter object so we declare it here as the source
+# of truth and main.py imports it.
+limiter = Limiter(key_func=get_remote_address)
+
+
+class ValidateInfraRequest(BaseModel):
+    """Request body for POST /validate-infra."""
+
+    team_id: str = Field(..., description="Team that owns the cloud account (RBAC scope)")
+    cloud: CloudName
+    region: str
+    mode: CloudMode = "simple"
+    fields: dict[str, Any] = Field(default_factory=dict)
+
+
+def _required_role_level(role: str) -> int:
+    return ROLE_HIERARCHY.get(role, 0)
+
+
+async def _require_deployer_in_team(user: User, team_id: str) -> None:
+    """Enforce 'deployer' role in the named team. Platform admins always pass."""
+    if getattr(user, "role", None) and str(user.role) == "admin":
+        return
+
+    user_role = await TeamService.get_user_role_in_team(str(user.id), team_id)
+    if user_role is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"User is not a member of team {team_id!r}",
+        )
+    if _required_role_level(user_role) < _required_role_level("deployer"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Requires deployer role in team {team_id!r}; you have {user_role!r}",
+        )
+
+
+@router.get(
+    "/cloud-requirements/{cloud}",
+    response_model=ApiResponse[CloudRequirements],
+)
+async def get_cloud_requirements(
+    cloud: CloudName,
+    mode: CloudMode = Query("simple"),
+    _user: User = Depends(get_current_user),
+) -> ApiResponse[CloudRequirements]:
+    """Return the user-input contract (required + optional fields) for the cloud."""
+    try:
+        requirements = get_requirements(cloud, mode)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    return ApiResponse(data=requirements)
+
+
+@router.post(
+    "/validate-infra",
+    response_model=ApiResponse[ValidationResult],
+)
+@limiter.limit("10/minute")
+async def validate_infra(
+    request: Request,
+    body: ValidateInfraRequest,
+    user: User = Depends(get_current_user),
+) -> ApiResponse[ValidationResult]:
+    """Read-only check that every cloud resource referenced in the body exists."""
+    await _require_deployer_in_team(user, body.team_id)
+
+    provisioner = provisioner_for(body.cloud)
+    payload = InfraValidationInput(
+        cloud=body.cloud,
+        region=body.region,
+        mode=body.mode,
+        fields=body.fields,
+    )
+
+    try:
+        result = await provisioner.validate_existing(payload)
+    except Exception as e:  # noqa: BLE001 - log + surface as 502 to caller
+        logger.exception(
+            "Cloud SDK error during validate-infra",
+            extra={"cloud": body.cloud, "team": body.team_id, "user": str(user.id)},
+        )
+        await AuditService.log_event(
+            actor=str(user.id),
+            action="deployment.validate_infra",
+            resource_type="deployment",
+            resource_name=body.cloud,
+            team=body.team_id,
+            details={"mode": body.mode, "error": type(e).__name__, "valid": False},
+            ip_address=request.client.host if request.client else None,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Cloud provider error: {type(e).__name__}",
+        ) from e
+
+    await AuditService.log_event(
+        actor=str(user.id),
+        action="deployment.validate_infra",
+        resource_type="deployment",
+        resource_name=body.cloud,
+        team=body.team_id,
+        details={
+            "mode": body.mode,
+            "valid": result.valid,
+            "checks_count": len(result.checks),
+            "region": body.region,
+        },
+        ip_address=request.client.host if request.client else None,
+    )
+
+    if not result.valid:
+        return ApiResponse(
+            data=result,
+            errors=[
+                f"{c.resource}: {c.status} ({c.detail})"
+                for c in result.checks
+                if c.status != "found"
+            ],
+        )
+    return ApiResponse(data=result)

--- a/engine/provisioners/__init__.py
+++ b/engine/provisioners/__init__.py
@@ -1,0 +1,78 @@
+"""Cloud infrastructure provisioners.
+
+Each cloud target has a provisioner that:
+- validates that user-supplied existing infrastructure resources exist (BYO mode)
+- (later) provisions a greenfield environment end-to-end (#382-#384)
+- (later) tears down provisioned resources
+
+Per CLAUDE.md cloud-agnostic rule: cloud-specific SDK calls stay inside
+this package. Routes and CLI talk to the abstract InfraProvisioner ABC.
+
+Cloud SDKs (boto3 / google-cloud-* / azure-mgmt-*) are installed via the
+optional dependency groups ``aws``, ``gcp``, ``azure``, or ``all-clouds``
+in pyproject.toml. Provisioner classes are imported lazily by
+:func:`provisioner_for` so callers without a given SDK installed can still
+import this package and use the requirements API.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+from engine.provisioners.base import (
+    InfraProvisioner,
+    InfraValidationInput,
+    ValidationCheck,
+    ValidationResult,
+)
+from engine.provisioners.requirements import (
+    CloudField,
+    CloudMode,
+    CloudName,
+    CloudRequirements,
+    get_requirements,
+)
+from engine.provisioners.state import InfraState
+
+_PROVISIONER_MODULES: dict[CloudName, tuple[str, str]] = {
+    "aws": ("engine.provisioners.aws", "AWSProvisioner"),
+    "gcp": ("engine.provisioners.gcp", "GCPProvisioner"),
+    "azure": ("engine.provisioners.azure", "AzureProvisioner"),
+}
+
+
+def provisioner_for(cloud: CloudName) -> InfraProvisioner:
+    """Return a fresh provisioner instance for the given cloud.
+
+    Lazily imports the cloud-specific module so the matching cloud SDK is
+    only loaded when actually used. Raises ValueError for unknown clouds
+    and ImportError (with a clear extras hint) when the SDK is missing.
+    """
+    if cloud not in _PROVISIONER_MODULES:
+        raise ValueError(f"No provisioner registered for cloud={cloud!r}")
+    module_path, class_name = _PROVISIONER_MODULES[cloud]
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError as e:
+        raise ImportError(
+            f"Cannot load {cloud!r} provisioner: missing SDK. "
+            f"Install with: pip install 'agentbreeder[{cloud}]'  (or 'all-clouds'). "
+            f"Original error: {e}"
+        ) from e
+    cls = getattr(module, class_name)
+    return cls()
+
+
+__all__ = [
+    "CloudField",
+    "CloudMode",
+    "CloudName",
+    "CloudRequirements",
+    "InfraProvisioner",
+    "InfraState",
+    "InfraValidationInput",
+    "ValidationCheck",
+    "ValidationResult",
+    "get_requirements",
+    "provisioner_for",
+]

--- a/engine/provisioners/aws.py
+++ b/engine/provisioners/aws.py
@@ -1,0 +1,150 @@
+"""AWS infrastructure validator (boto3, read-only)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import boto3
+from botocore.exceptions import (
+    BotoCoreError,
+    ClientError,
+    NoCredentialsError,
+    ProfileNotFound,
+)
+
+from engine.provisioners.base import (
+    InfraProvisioner,
+    InfraValidationInput,
+    ValidationCheck,
+    ValidationResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _client(service: str, region: str, fields: dict[str, Any]) -> Any:
+    """Build a boto3 client from validation fields. Honors AWS_PROFILE if set."""
+    session_kwargs: dict[str, Any] = {"region_name": region}
+    if profile := fields.get("AWS_PROFILE"):
+        session_kwargs["profile_name"] = profile
+    if (key := fields.get("AWS_ACCESS_KEY_ID")) and (
+        secret := fields.get("AWS_SECRET_ACCESS_KEY")
+    ):
+        session_kwargs["aws_access_key_id"] = key
+        session_kwargs["aws_secret_access_key"] = secret
+        if token := fields.get("AWS_SESSION_TOKEN"):
+            session_kwargs["aws_session_token"] = token
+    session = boto3.session.Session(**session_kwargs)
+    return session.client(service)
+
+
+def _check(resource: str, fn, *args, **kwargs) -> ValidationCheck:  # noqa: ANN001
+    """Run an SDK lookup, translating exceptions into a ValidationCheck."""
+    try:
+        detail = fn(*args, **kwargs)
+        return ValidationCheck(resource=resource, status="found", detail=detail)
+    except ClientError as e:
+        code = e.response.get("Error", {}).get("Code", "ClientError")
+        if code in {"AccessDenied", "UnauthorizedOperation"}:
+            return ValidationCheck(resource=resource, status="forbidden", detail=code)
+        if code in {
+            "NoSuchEntity",
+            "InvalidSubnetID.NotFound",
+            "InvalidGroup.NotFound",
+            "RepositoryNotFoundException",
+        }:
+            return ValidationCheck(resource=resource, status="missing", detail=code)
+        logger.warning("AWS lookup failed: resource=%s code=%s", resource, code)
+        return ValidationCheck(resource=resource, status="error", detail=code)
+    except (BotoCoreError, NoCredentialsError, ProfileNotFound) as e:
+        return ValidationCheck(resource=resource, status="error", detail=type(e).__name__)
+
+
+class AWSProvisioner(InfraProvisioner):
+    """Validates user-supplied AWS resources via read-only boto3 calls."""
+
+    async def validate_existing(self, payload: InfraValidationInput) -> ValidationResult:
+        fields = payload.fields
+        region = payload.region
+        checks: list[ValidationCheck] = []
+
+        # 1. Credentials work and account matches what the user claimed.
+        sts = _client("sts", region, fields)
+        identity_check = _check(
+            "credentials",
+            lambda: sts.get_caller_identity()["Account"],
+        )
+        if identity_check.status == "found":
+            claimed = str(fields.get("AWS_ACCOUNT_ID", "")).strip()
+            if claimed and identity_check.detail != claimed:
+                identity_check = ValidationCheck(
+                    resource="credentials",
+                    status="error",
+                    detail=f"credentials resolve to account {identity_check.detail!r}, but AWS_ACCOUNT_ID={claimed!r}",
+                )
+            else:
+                identity_check = ValidationCheck(
+                    resource="credentials",
+                    status="found",
+                    detail=f"account {identity_check.detail}",
+                )
+        checks.append(identity_check)
+
+        # Short-circuit if creds didn't work; deeper checks will all fail anyway.
+        if identity_check.status != "found":
+            return ValidationResult(valid=False, cloud="aws", region=region, checks=checks)
+
+        # 2. Full-mode checks: each named resource must resolve.
+        if payload.mode == "full":
+            if cluster := fields.get("AWS_ECS_CLUSTER"):
+                ecs = _client("ecs", region, fields)
+                checks.append(
+                    _check(
+                        cluster,
+                        lambda: ecs.describe_clusters(clusters=[cluster])["clusters"][0]["status"],
+                    )
+                )
+            if role_arn := fields.get("AWS_EXECUTION_ROLE_ARN"):
+                iam = _client("iam", region, fields)
+                role_name = role_arn.split("/")[-1]
+                checks.append(
+                    _check(role_arn, lambda: iam.get_role(RoleName=role_name)["Role"]["Arn"])
+                )
+            if subnets_csv := fields.get("AWS_VPC_SUBNETS"):
+                ec2 = _client("ec2", region, fields)
+                subnet_ids = [s.strip() for s in subnets_csv.split(",") if s.strip()]
+                for sid in subnet_ids:
+                    checks.append(
+                        _check(
+                            sid,
+                            lambda sid=sid: ec2.describe_subnets(SubnetIds=[sid])["Subnets"][0][
+                                "AvailabilityZone"
+                            ],
+                        )
+                    )
+            if sgs_csv := fields.get("AWS_SECURITY_GROUPS"):
+                ec2 = _client("ec2", region, fields)
+                sg_ids = [s.strip() for s in sgs_csv.split(",") if s.strip()]
+                for sg in sg_ids:
+                    checks.append(
+                        _check(
+                            sg,
+                            lambda sg=sg: ec2.describe_security_groups(GroupIds=[sg])[
+                                "SecurityGroups"
+                            ][0]["GroupName"],
+                        )
+                    )
+            if repo := fields.get("AWS_ECR_REPOSITORY"):
+                ecr = _client("ecr", region, fields)
+                checks.append(
+                    _check(
+                        repo,
+                        lambda: ecr.describe_repositories(repositoryNames=[repo])["repositories"][
+                            0
+                        ]["repositoryUri"],
+                    )
+                )
+
+        valid = all(c.status == "found" for c in checks)
+        return ValidationResult(valid=valid, cloud="aws", region=region, checks=checks)

--- a/engine/provisioners/azure.py
+++ b/engine/provisioners/azure.py
@@ -1,0 +1,129 @@
+"""Azure infrastructure validator (azure-sdk, read-only)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from engine.provisioners.base import (
+    InfraProvisioner,
+    InfraValidationInput,
+    ValidationCheck,
+    ValidationResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _check(resource: str, fn) -> ValidationCheck:  # noqa: ANN001
+    """Run an SDK lookup, translating Azure exceptions into a ValidationCheck."""
+    try:
+        from azure.core.exceptions import (
+            ClientAuthenticationError,
+            HttpResponseError,
+            ResourceNotFoundError,
+        )
+    except ImportError as e:
+        return ValidationCheck(
+            resource=resource, status="error", detail=f"azure-sdk not installed: {e}"
+        )
+
+    try:
+        return ValidationCheck(resource=resource, status="found", detail=str(fn()))
+    except ResourceNotFoundError as e:
+        return ValidationCheck(resource=resource, status="missing", detail=str(e)[:200])
+    except ClientAuthenticationError as e:
+        return ValidationCheck(resource=resource, status="forbidden", detail=str(e)[:200])
+    except HttpResponseError as e:
+        logger.warning("Azure lookup failed: resource=%s err=%s", resource, e)
+        return ValidationCheck(resource=resource, status="error", detail=type(e).__name__)
+
+
+def _credentials(fields: dict[str, Any]):  # noqa: ANN201
+    """Resolve azure-identity credential. Falls back to DefaultAzureCredential."""
+    from azure.identity import ClientSecretCredential, DefaultAzureCredential
+
+    client_id = fields.get("AZURE_CLIENT_ID")
+    client_secret = fields.get("AZURE_CLIENT_SECRET")
+    tenant_id = fields.get("AZURE_TENANT_ID")
+    if client_id and client_secret and tenant_id:
+        return ClientSecretCredential(
+            tenant_id=tenant_id, client_id=client_id, client_secret=client_secret
+        )
+    return DefaultAzureCredential()
+
+
+class AzureProvisioner(InfraProvisioner):
+    """Validates user-supplied Azure resources via read-only azure-sdk calls."""
+
+    async def validate_existing(self, payload: InfraValidationInput) -> ValidationResult:
+        fields = payload.fields
+        region = payload.region
+        checks: list[ValidationCheck] = []
+
+        subscription_id = str(fields.get("AZURE_SUBSCRIPTION_ID", "")).strip()
+        if not subscription_id:
+            checks.append(
+                ValidationCheck(
+                    resource="AZURE_SUBSCRIPTION_ID",
+                    status="missing",
+                    detail="required field is empty",
+                )
+            )
+            return ValidationResult(valid=False, cloud="azure", region=region, checks=checks)
+
+        # 1. Credentials + subscription must resolve.
+        def check_subscription() -> str:
+            from azure.mgmt.resource import SubscriptionClient
+
+            creds = _credentials(fields)
+            client = SubscriptionClient(creds)
+            sub = client.subscriptions.get(subscription_id)
+            return sub.display_name or sub.subscription_id
+
+        checks.append(_check(f"subscription:{subscription_id}", check_subscription))
+
+        if checks[-1].status != "found":
+            return ValidationResult(valid=False, cloud="azure", region=region, checks=checks)
+
+        # 2. Full-mode resource checks.
+        if payload.mode == "full":
+            if rg := fields.get("AZURE_RESOURCE_GROUP"):
+
+                def check_rg() -> str:
+                    from azure.mgmt.resource import ResourceManagementClient
+
+                    creds = _credentials(fields)
+                    client = ResourceManagementClient(creds, subscription_id)
+                    return client.resource_groups.get(rg).location
+
+                checks.append(_check(f"resource-group:{rg}", check_rg))
+
+            acr_server = fields.get("AZURE_ACR_LOGIN_SERVER")
+            acr_rg = fields.get("AZURE_RESOURCE_GROUP")
+            if acr_server and acr_rg:
+                acr_name = acr_server.split(".")[0]
+
+                def check_acr() -> str:
+                    from azure.mgmt.containerregistry import ContainerRegistryManagementClient
+
+                    creds = _credentials(fields)
+                    client = ContainerRegistryManagementClient(creds, subscription_id)
+                    return client.registries.get(acr_rg, acr_name).login_server
+
+                checks.append(_check(f"acr:{acr_server}", check_acr))
+
+            aca_env = fields.get("AZURE_ACA_ENVIRONMENT")
+            if aca_env and acr_rg:
+
+                def check_aca_env() -> str:
+                    from azure.mgmt.appcontainers import ContainerAppsAPIClient
+
+                    creds = _credentials(fields)
+                    client = ContainerAppsAPIClient(creds, subscription_id)
+                    return client.managed_environments.get(acr_rg, aca_env).provisioning_state
+
+                checks.append(_check(f"aca-env:{aca_env}", check_aca_env))
+
+        valid = all(c.status == "found" for c in checks)
+        return ValidationResult(valid=valid, cloud="azure", region=region, checks=checks)

--- a/engine/provisioners/base.py
+++ b/engine/provisioners/base.py
@@ -1,0 +1,73 @@
+"""InfraProvisioner — abstract base for cloud infrastructure validators.
+
+Greenfield provisioning (provision/destroy) is deferred to #382/#383/#384;
+concrete subclasses raise NotImplementedError for those methods today.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from engine.provisioners.state import InfraState
+
+CheckStatus = Literal["found", "missing", "forbidden", "error"]
+
+
+class ValidationCheck(BaseModel):
+    """One per-resource result from validate_existing."""
+
+    resource: str
+    status: CheckStatus
+    detail: str
+
+
+class ValidationResult(BaseModel):
+    """Aggregate output of validate_existing."""
+
+    valid: bool
+    cloud: str
+    region: str
+    checks: list[ValidationCheck] = Field(default_factory=list)
+
+
+class InfraValidationInput(BaseModel):
+    """Per-cloud input to validate_existing. Keys vary by cloud."""
+
+    cloud: Literal["aws", "gcp", "azure"]
+    region: str
+    mode: Literal["simple", "full"] = "simple"
+    fields: dict[str, Any] = Field(default_factory=dict)
+
+
+ProgressCallback = Callable[[str], Awaitable[None]]
+
+
+class InfraProvisioner(ABC):
+    """Abstract base for cloud-specific infrastructure provisioners."""
+
+    @abstractmethod
+    async def validate_existing(self, payload: InfraValidationInput) -> ValidationResult:
+        """Read-only check that every referenced cloud resource exists."""
+        ...
+
+    async def provision(  # noqa: ARG002 - kept for stable signature
+        self,
+        payload: InfraValidationInput,
+        progress: ProgressCallback | None = None,
+    ) -> InfraState:
+        """Greenfield create-if-not-exists. Pending #382/#383/#384."""
+        raise NotImplementedError(
+            "Greenfield provisioning is tracked under epic #378 (#382 GCP / #383 AWS / #384 Azure). "
+            "For now AgentBreeder only validates existing infrastructure."
+        )
+
+    async def destroy(self, state: InfraState) -> None:  # noqa: ARG002
+        """Tear down provisioned resources. Pending #382/#383/#384."""
+        raise NotImplementedError(
+            "Greenfield teardown is tracked under epic #378. "
+            "Use cloud-native tools to delete resources you supplied to AgentBreeder."
+        )

--- a/engine/provisioners/gcp.py
+++ b/engine/provisioners/gcp.py
@@ -1,0 +1,111 @@
+"""GCP infrastructure validator (google-cloud SDKs, read-only)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from engine.provisioners.base import (
+    InfraProvisioner,
+    InfraValidationInput,
+    ValidationCheck,
+    ValidationResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _check(resource: str, fn) -> ValidationCheck:  # noqa: ANN001
+    """Run an SDK lookup, translating google-cloud exceptions into a ValidationCheck."""
+    try:
+        from google.api_core.exceptions import Forbidden, GoogleAPIError, NotFound
+    except ImportError as e:
+        return ValidationCheck(
+            resource=resource, status="error", detail=f"google-cloud not installed: {e}"
+        )
+
+    try:
+        return ValidationCheck(resource=resource, status="found", detail=str(fn()))
+    except NotFound as e:
+        return ValidationCheck(resource=resource, status="missing", detail=str(e)[:200])
+    except Forbidden as e:
+        return ValidationCheck(resource=resource, status="forbidden", detail=str(e)[:200])
+    except GoogleAPIError as e:
+        logger.warning("GCP lookup failed: resource=%s err=%s", resource, e)
+        return ValidationCheck(resource=resource, status="error", detail=type(e).__name__)
+
+
+def _credentials(fields: dict[str, Any]):  # noqa: ANN201
+    """Resolve google-auth credentials. Falls back to ADC if no path supplied."""
+    from google.auth import default, load_credentials_from_file
+
+    if path := fields.get("GOOGLE_APPLICATION_CREDENTIALS"):
+        creds, _ = load_credentials_from_file(path)
+        return creds
+    creds, _ = default()
+    return creds
+
+
+class GCPProvisioner(InfraProvisioner):
+    """Validates user-supplied GCP resources via read-only google-cloud calls."""
+
+    async def validate_existing(self, payload: InfraValidationInput) -> ValidationResult:
+        fields = payload.fields
+        region = payload.region
+        checks: list[ValidationCheck] = []
+
+        project = str(fields.get("GOOGLE_CLOUD_PROJECT", "")).strip()
+        if not project:
+            checks.append(
+                ValidationCheck(
+                    resource="GOOGLE_CLOUD_PROJECT",
+                    status="missing",
+                    detail="required field is empty",
+                )
+            )
+            return ValidationResult(valid=False, cloud="gcp", region=region, checks=checks)
+
+        # 1. Credentials + project must resolve.
+        def check_project() -> str:
+            from google.cloud import resourcemanager_v3
+
+            creds = _credentials(fields)
+            client = resourcemanager_v3.ProjectsClient(credentials=creds)
+            proj = client.get_project(name=f"projects/{project}")
+            return proj.state.name
+
+        checks.append(_check(f"project:{project}", check_project))
+
+        if checks[-1].status != "found":
+            return ValidationResult(valid=False, cloud="gcp", region=region, checks=checks)
+
+        # 2. Full-mode resource checks.
+        if payload.mode == "full":
+            if repo := fields.get("GCP_ARTIFACT_REGISTRY_REPO"):
+
+                def check_repo() -> str:
+                    from google.cloud import artifactregistry_v1
+
+                    creds = _credentials(fields)
+                    client = artifactregistry_v1.ArtifactRegistryClient(credentials=creds)
+                    parent = f"projects/{project}/locations/{region}/repositories/{repo}"
+                    result = client.get_repository(name=parent)
+                    return result.format_.name
+
+                checks.append(_check(f"artifact-registry:{repo}", check_repo))
+
+            if sa := fields.get("GCP_CLOUD_RUN_SERVICE_ACCOUNT"):
+
+                def check_sa() -> str:
+                    from google.cloud import iam_admin_v1
+
+                    creds = _credentials(fields)
+                    client = iam_admin_v1.IAMClient(credentials=creds)
+                    name = f"projects/{project}/serviceAccounts/{sa}"
+                    result = client.get_service_account(name=name)
+                    return result.email
+
+                checks.append(_check(f"service-account:{sa}", check_sa))
+
+        valid = all(c.status == "found" for c in checks)
+        return ValidationResult(valid=valid, cloud="gcp", region=region, checks=checks)

--- a/engine/provisioners/requirements.py
+++ b/engine/provisioners/requirements.py
@@ -1,0 +1,235 @@
+"""Cloud-requirements registry — the user-input contract per cloud + mode.
+
+Returned by GET /api/v1/deployments/cloud-requirements/{cloud}. Static data
+(no SDK calls). The validate-infra endpoint and the dashboard wizard read
+this to know what to ask the user for.
+
+"simple" mode = account + region + creds; AgentBreeder uses cloud defaults.
+"full"   mode = user describes every specific resource (cluster, subnets, IAM).
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+CloudMode = Literal["simple", "full"]
+CloudName = Literal["aws", "gcp", "azure"]
+
+
+class CloudField(BaseModel):
+    """One required-or-optional input field for a cloud + mode."""
+
+    name: str
+    description: str
+    default: str | None = None
+    sensitive: bool = False
+
+
+class CloudRequirements(BaseModel):
+    """Full input contract for one cloud + mode."""
+
+    cloud: CloudName
+    mode: CloudMode
+    required: list[CloudField] = Field(default_factory=list)
+    optional: list[CloudField] = Field(default_factory=list)
+    rate_limit_per_minute: int = 10
+    notes: list[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# AWS
+# ---------------------------------------------------------------------------
+
+_AWS_SIMPLE = CloudRequirements(
+    cloud="aws",
+    mode="simple",
+    required=[
+        CloudField(name="AWS_ACCOUNT_ID", description="AWS Account ID (12 digits)"),
+        CloudField(name="AWS_DEFAULT_REGION", description="AWS region", default="us-east-1"),
+        CloudField(
+            name="AWS_ACCESS_KEY_ID",
+            description="AWS access key (or use AWS_PROFILE / instance profile)",
+            sensitive=True,
+        ),
+        CloudField(
+            name="AWS_SECRET_ACCESS_KEY",
+            description="AWS secret access key",
+            sensitive=True,
+        ),
+    ],
+    optional=[
+        CloudField(name="AWS_SESSION_TOKEN", description="STS session token", sensitive=True),
+        CloudField(name="AWS_PROFILE", description="Named profile from ~/.aws/credentials"),
+        CloudField(name="AWS_ECR_REGISTRY", description="Override ECR registry host"),
+    ],
+    notes=[
+        "Simple mode uses ECS cluster 'agentbreeder-default', IAM role "
+        "'agentbreeder-ecs-execution-role', the default VPC, and the default "
+        "security group. These are created on first deploy via --provision "
+        "(coming with #383).",
+    ],
+)
+
+_AWS_FULL = CloudRequirements(
+    cloud="aws",
+    mode="full",
+    required=_AWS_SIMPLE.required
+    + [
+        CloudField(name="AWS_ECS_CLUSTER", description="ECS cluster name"),
+        CloudField(
+            name="AWS_EXECUTION_ROLE_ARN",
+            description="IAM execution role ARN (ecsTaskExecutionRole)",
+        ),
+        CloudField(
+            name="AWS_VPC_SUBNETS",
+            description="Comma-separated subnet IDs (>=2 for HA)",
+        ),
+        CloudField(name="AWS_SECURITY_GROUPS", description="Comma-separated security group IDs"),
+        CloudField(name="AWS_ECR_REPOSITORY", description="ECR repository name"),
+    ],
+    optional=_AWS_SIMPLE.optional
+    + [
+        CloudField(name="AWS_TASK_ROLE_ARN", description="Task IAM role ARN"),
+        CloudField(
+            name="AWS_ALB_TARGET_GROUP_ARN",
+            description="Application Load Balancer target group ARN",
+        ),
+        CloudField(name="AWS_CLOUDWATCH_LOG_GROUP", description="CloudWatch Logs group name"),
+        CloudField(
+            name="AWS_SECRETS_MANAGER_PREFIX", description="ARN prefix for Secrets Manager"
+        ),
+    ],
+)
+
+
+# ---------------------------------------------------------------------------
+# GCP
+# ---------------------------------------------------------------------------
+
+_GCP_SIMPLE = CloudRequirements(
+    cloud="gcp",
+    mode="simple",
+    required=[
+        CloudField(name="GOOGLE_CLOUD_PROJECT", description="GCP project ID"),
+        CloudField(
+            name="GOOGLE_APPLICATION_CREDENTIALS",
+            description="Path to service-account JSON (or use ADC)",
+            sensitive=True,
+        ),
+    ],
+    optional=[
+        CloudField(name="GCP_REGION", description="Cloud Run region", default="us-central1"),
+    ],
+    notes=[
+        "Simple mode uses Artifact Registry repo 'agentbreeder' and the "
+        "default compute service account '<project-number>-compute@developer.gserviceaccount.com'. "
+        "Verify the four IAM roles in website/content/docs/deployment.mdx are granted.",
+    ],
+)
+
+_GCP_FULL = CloudRequirements(
+    cloud="gcp",
+    mode="full",
+    required=_GCP_SIMPLE.required
+    + [
+        CloudField(
+            name="GCP_ARTIFACT_REGISTRY_REPO", description="Artifact Registry repository name"
+        ),
+        CloudField(
+            name="GCP_CLOUD_RUN_SERVICE_ACCOUNT",
+            description="Service account email for the Cloud Run service",
+        ),
+    ],
+    optional=_GCP_SIMPLE.optional
+    + [
+        CloudField(name="GCP_VPC_CONNECTOR", description="Serverless VPC Access connector"),
+        CloudField(
+            name="GCP_CLOUD_SQL_INSTANCE", description="Cloud SQL instance connection name"
+        ),
+        CloudField(
+            name="GCP_ALLOW_UNAUTHENTICATED",
+            description="Permit unauthenticated invocations (true/false)",
+        ),
+        CloudField(name="GCP_CUSTOM_DOMAIN", description="Custom domain mapping"),
+    ],
+)
+
+
+# ---------------------------------------------------------------------------
+# Azure
+# ---------------------------------------------------------------------------
+
+_AZURE_SIMPLE = CloudRequirements(
+    cloud="azure",
+    mode="simple",
+    required=[
+        CloudField(name="AZURE_SUBSCRIPTION_ID", description="Azure subscription ID"),
+        CloudField(name="AZURE_TENANT_ID", description="Microsoft Entra (Azure AD) tenant ID"),
+        CloudField(
+            name="AZURE_CLIENT_ID",
+            description="Service principal client ID (or 'az login' profile)",
+            sensitive=True,
+        ),
+        CloudField(
+            name="AZURE_CLIENT_SECRET",
+            description="Service principal secret",
+            sensitive=True,
+        ),
+    ],
+    optional=[
+        CloudField(name="AZURE_LOCATION", description="Azure region", default="eastus"),
+    ],
+    notes=[
+        "Simple mode uses Resource Group 'agentbreeder-rg' and an "
+        "auto-named ACR ('agentbreeder<5-char-hash>'), Log Analytics, and "
+        "ACA environment created on first deploy.",
+    ],
+)
+
+_AZURE_FULL = CloudRequirements(
+    cloud="azure",
+    mode="full",
+    required=_AZURE_SIMPLE.required
+    + [
+        CloudField(name="AZURE_RESOURCE_GROUP", description="Resource Group name"),
+        CloudField(
+            name="AZURE_ACR_LOGIN_SERVER", description="Azure Container Registry login server"
+        ),
+        CloudField(
+            name="AZURE_ACA_ENVIRONMENT", description="Container Apps managed environment name"
+        ),
+        CloudField(
+            name="AZURE_LOG_ANALYTICS_WORKSPACE_ID",
+            description="Log Analytics workspace ID (GUID)",
+        ),
+        CloudField(
+            name="AZURE_MANAGED_IDENTITY_ID", description="User-assigned managed identity ID"
+        ),
+    ],
+    optional=_AZURE_SIMPLE.optional
+    + [
+        CloudField(name="AZURE_KEY_VAULT_NAME", description="Key Vault name for secrets"),
+        CloudField(name="AZURE_POSTGRES_FQDN", description="Azure Database for PostgreSQL FQDN"),
+        CloudField(name="AZURE_VNET_SUBNET_ID", description="VNet subnet ID for delegation"),
+    ],
+)
+
+
+_REQUIREMENTS: dict[tuple[CloudName, CloudMode], CloudRequirements] = {
+    ("aws", "simple"): _AWS_SIMPLE,
+    ("aws", "full"): _AWS_FULL,
+    ("gcp", "simple"): _GCP_SIMPLE,
+    ("gcp", "full"): _GCP_FULL,
+    ("azure", "simple"): _AZURE_SIMPLE,
+    ("azure", "full"): _AZURE_FULL,
+}
+
+
+def get_requirements(cloud: CloudName, mode: CloudMode = "simple") -> CloudRequirements:
+    """Return the user-input contract for the given cloud + mode."""
+    try:
+        return _REQUIREMENTS[(cloud, mode)]
+    except KeyError as e:
+        raise ValueError(f"No requirements registered for cloud={cloud!r} mode={mode!r}") from e

--- a/engine/provisioners/state.py
+++ b/engine/provisioners/state.py
@@ -1,0 +1,48 @@
+"""InfraState — persistent record of what cloud resources AgentBreeder is using.
+
+Written by the provisioner on successful validate or provision; consumed by
+teardown and re-deploy flows. Lives at .agentbreeder/infra-state.json in the
+agent project directory.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+DEFAULT_STATE_PATH = Path(".agentbreeder/infra-state.json")
+
+Cloud = Literal["aws", "gcp", "azure", "local"]
+
+
+class InfraState(BaseModel):
+    """Snapshot of cloud resources AgentBreeder knows about for this project."""
+
+    cloud: Cloud
+    region: str
+    provisioned_by: str
+    provisioned_at: datetime
+    mode: Literal["validated", "provisioned"]
+    resources: dict[str, Any] = Field(default_factory=dict)
+
+    @classmethod
+    def load(cls, path: Path = DEFAULT_STATE_PATH) -> InfraState:
+        """Read state from disk. Raises FileNotFoundError if absent."""
+        raw = json.loads(path.read_text())
+        return cls.model_validate(raw)
+
+    @classmethod
+    def load_or_none(cls, path: Path = DEFAULT_STATE_PATH) -> InfraState | None:
+        try:
+            return cls.load(path)
+        except FileNotFoundError:
+            return None
+
+    def save(self, path: Path = DEFAULT_STATE_PATH) -> None:
+        """Write state to disk, creating parent directory if needed."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(self.model_dump_json(indent=2))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,10 @@ module = ["engine.deployers.*"]
 disable_error_code = ["no-any-return", "type-arg"]
 
 [[tool.mypy.overrides]]
+module = ["engine.provisioners.*"]
+disable_error_code = ["no-any-return", "type-arg", "no-untyped-def"]
+
+[[tool.mypy.overrides]]
 module = ["engine.providers.*"]
 disable_error_code = ["no-any-return", "unused-ignore"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "python-multipart>=0.0.26",
     "keyring>=24.0.0",
     "chromadb>=0.5.0",
+    "slowapi>=0.1.9",
 ]
 
 [project.optional-dependencies]
@@ -64,7 +65,15 @@ aws = [
 azure = [
     "azure-identity>=1.16.0",
     "azure-mgmt-appcontainers>=3.0.0",
+    "azure-mgmt-containerregistry>=10.3.0",
+    "azure-mgmt-resource>=23.0.0",
     "azure-monitor-query>=1.3.0",
+]
+gcp = [
+    "google-auth>=2.27.0",
+    "google-cloud-artifact-registry>=1.11.0",
+    "google-cloud-iam>=2.15.0",
+    "google-cloud-resource-manager>=1.12.0",
 ]
 kubernetes = [
     "kubernetes>=29.0.0",
@@ -87,7 +96,13 @@ all-clouds = [
     "boto3>=1.34.0",
     "azure-identity>=1.16.0",
     "azure-mgmt-appcontainers>=3.0.0",
+    "azure-mgmt-containerregistry>=10.3.0",
+    "azure-mgmt-resource>=23.0.0",
     "azure-monitor-query>=1.3.0",
+    "google-auth>=2.27.0",
+    "google-cloud-artifact-registry>=1.11.0",
+    "google-cloud-iam>=2.15.0",
+    "google-cloud-resource-manager>=1.12.0",
     "kubernetes>=29.0.0",
 ]
 

--- a/tests/integration/test_deployments_api.py
+++ b/tests/integration/test_deployments_api.py
@@ -1,0 +1,130 @@
+"""Integration tests for /api/v1/deployments/* endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+# -- GET /cloud-requirements/{cloud} -----------------------------------------
+
+
+@pytest.mark.parametrize("cloud", ["aws", "gcp", "azure"])
+def test_cloud_requirements_default_mode_is_simple(client: TestClient, cloud: str) -> None:
+    resp = client.get(f"/api/v1/deployments/cloud-requirements/{cloud}")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["cloud"] == cloud
+    assert data["mode"] == "simple"
+    assert data["required"]
+
+
+@pytest.mark.parametrize("cloud", ["aws", "gcp", "azure"])
+def test_cloud_requirements_full_mode(client: TestClient, cloud: str) -> None:
+    resp = client.get(f"/api/v1/deployments/cloud-requirements/{cloud}?mode=full")
+    assert resp.status_code == 200
+    assert resp.json()["data"]["mode"] == "full"
+
+
+def test_cloud_requirements_unknown_cloud_returns_422_or_404(client: TestClient) -> None:
+    # FastAPI's Literal validation returns 422 before the route is reached.
+    resp = client.get("/api/v1/deployments/cloud-requirements/ibmcloud")
+    assert resp.status_code in (404, 422)
+
+
+# -- POST /validate-infra ----------------------------------------------------
+
+
+@pytest.fixture
+def mock_audit_log():
+    with patch(
+        "api.routes.deployments.AuditService.log_event",
+        new=AsyncMock(return_value=MagicMock()),
+    ) as m:
+        yield m
+
+
+def test_validate_infra_returns_200_when_provisioner_reports_valid(
+    client: TestClient, mock_audit_log
+) -> None:
+    from engine.provisioners.base import ValidationResult
+
+    result = ValidationResult(valid=True, cloud="aws", region="us-east-1", checks=[])
+    mock_provisioner = MagicMock()
+    mock_provisioner.validate_existing = AsyncMock(return_value=result)
+
+    with patch("api.routes.deployments.provisioner_for", return_value=mock_provisioner):
+        resp = client.post(
+            "/api/v1/deployments/validate-infra",
+            json={
+                "team_id": "engineering",
+                "cloud": "aws",
+                "region": "us-east-1",
+                "mode": "simple",
+                "fields": {"AWS_ACCOUNT_ID": "123"},
+            },
+        )
+    assert resp.status_code == 200
+    mock_audit_log.assert_called_once()
+
+
+def test_validate_infra_returns_with_errors_when_invalid(
+    client: TestClient, mock_audit_log
+) -> None:
+    from engine.provisioners.base import ValidationCheck, ValidationResult
+
+    result = ValidationResult(
+        valid=False,
+        cloud="aws",
+        region="us-east-1",
+        checks=[
+            ValidationCheck(resource="subnet-x", status="missing", detail="not found"),
+        ],
+    )
+    mock_provisioner = MagicMock()
+    mock_provisioner.validate_existing = AsyncMock(return_value=result)
+
+    with patch("api.routes.deployments.provisioner_for", return_value=mock_provisioner):
+        resp = client.post(
+            "/api/v1/deployments/validate-infra",
+            json={
+                "team_id": "engineering",
+                "cloud": "aws",
+                "region": "us-east-1",
+                "mode": "full",
+                "fields": {"AWS_ACCOUNT_ID": "1", "AWS_VPC_SUBNETS": "subnet-x"},
+            },
+        )
+    body = resp.json()
+    assert resp.status_code == 200
+    assert body["data"]["valid"] is False
+    assert body["errors"], "invalid checks must surface in the errors envelope"
+
+
+def test_validate_infra_returns_502_on_cloud_sdk_error(
+    client: TestClient, mock_audit_log
+) -> None:
+    mock_provisioner = MagicMock()
+    mock_provisioner.validate_existing = AsyncMock(side_effect=RuntimeError("SDK down"))
+
+    with patch("api.routes.deployments.provisioner_for", return_value=mock_provisioner):
+        resp = client.post(
+            "/api/v1/deployments/validate-infra",
+            json={
+                "team_id": "engineering",
+                "cloud": "aws",
+                "region": "us-east-1",
+                "fields": {},
+            },
+        )
+    assert resp.status_code == 502
+    mock_audit_log.assert_called_once()

--- a/tests/integration/test_deployments_api.py
+++ b/tests/integration/test_deployments_api.py
@@ -110,9 +110,7 @@ def test_validate_infra_returns_with_errors_when_invalid(
     assert body["errors"], "invalid checks must surface in the errors envelope"
 
 
-def test_validate_infra_returns_502_on_cloud_sdk_error(
-    client: TestClient, mock_audit_log
-) -> None:
+def test_validate_infra_returns_502_on_cloud_sdk_error(client: TestClient, mock_audit_log) -> None:
     mock_provisioner = MagicMock()
     mock_provisioner.validate_existing = AsyncMock(side_effect=RuntimeError("SDK down"))
 

--- a/tests/unit/test_provisioners.py
+++ b/tests/unit/test_provisioners.py
@@ -1,0 +1,134 @@
+"""Unit tests for engine.provisioners — state, requirements, base ABC."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from engine.provisioners import (
+    CloudName,
+    InfraProvisioner,
+    InfraState,
+    InfraValidationInput,
+    get_requirements,
+    provisioner_for,
+)
+
+# -- InfraState ---------------------------------------------------------------
+
+
+def test_infra_state_roundtrip(tmp_path: Path) -> None:
+    state = InfraState(
+        cloud="aws",
+        region="us-east-1",
+        provisioned_by="agentbreeder@test",
+        provisioned_at=datetime(2026, 5, 19, 9, 0, 0),
+        mode="validated",
+        resources={"cluster": "agentbreeder-default"},
+    )
+    target = tmp_path / "infra-state.json"
+    state.save(target)
+    assert target.exists()
+    loaded = InfraState.load(target)
+    assert loaded == state
+
+
+def test_infra_state_load_or_none_returns_none_when_missing(tmp_path: Path) -> None:
+    assert InfraState.load_or_none(tmp_path / "nope.json") is None
+
+
+# -- requirements registry ----------------------------------------------------
+
+
+@pytest.mark.parametrize("cloud", ["aws", "gcp", "azure"])
+@pytest.mark.parametrize("mode", ["simple", "full"])
+def test_requirements_registry_covers_every_combo(cloud: str, mode: str) -> None:
+    req = get_requirements(cast(CloudName, cloud), mode)  # type: ignore[arg-type]
+    assert req.cloud == cloud
+    assert req.mode == mode
+    assert req.required, f"{cloud} {mode} must declare at least one required field"
+    # Sensitive fields must not leak via defaults.
+    for f in (*req.required, *req.optional):
+        if f.sensitive:
+            assert f.default is None, f"sensitive field {f.name} must not have a default"
+    # Full mode is a strict superset of simple for required fields.
+    if mode == "full":
+        simple = get_requirements(cast(CloudName, cloud), "simple")
+        simple_names = {f.name for f in simple.required}
+        full_names = {f.name for f in req.required}
+        assert simple_names <= full_names, (
+            f"{cloud} full mode must include every simple-mode required field"
+        )
+
+
+def test_requirements_unknown_cloud_raises() -> None:
+    with pytest.raises(ValueError, match="No requirements"):
+        get_requirements(cast(CloudName, "ibmcloud"), "simple")  # type: ignore[arg-type]
+
+
+# -- provisioner_for + base ABC behaviour -------------------------------------
+
+
+_CLOUD_SDK_HINTS = {"aws": "boto3", "gcp": "google.cloud", "azure": "azure.identity"}
+
+
+def _cloud_sdk_installed(cloud: str) -> bool:
+    try:
+        __import__(_CLOUD_SDK_HINTS[cloud])
+    except ImportError:
+        return False
+    return True
+
+
+@pytest.mark.parametrize("cloud", ["aws", "gcp", "azure"])
+def test_provisioner_for_returns_subclass(cloud: str) -> None:
+    if not _cloud_sdk_installed(cloud):
+        pytest.skip(f"{cloud} SDK not installed in this venv")
+    p = provisioner_for(cast(CloudName, cloud))  # type: ignore[arg-type]
+    assert isinstance(p, InfraProvisioner)
+
+
+def test_provisioner_for_unknown_cloud_raises() -> None:
+    with pytest.raises(ValueError):
+        provisioner_for(cast(CloudName, "oracle"))  # type: ignore[arg-type]
+
+
+def test_provisioner_for_missing_sdk_raises_helpful_import_error(monkeypatch) -> None:
+    """Lazy-load surfaces missing cloud SDKs with an extras-install hint."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **kw):
+        if name == "boto3":
+            raise ImportError("boto3 forcibly missing")
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    # Drop cached aws module so reimport actually fires.
+    monkeypatch.delitem(__import__("sys").modules, "engine.provisioners.aws", raising=False)
+
+    with pytest.raises(ImportError, match=r"agentbreeder\[aws\]"):
+        provisioner_for("aws")
+
+
+async def test_provision_destroy_raise_not_implemented_for_now() -> None:
+    """Greenfield provisioning is deferred to #382-#384."""
+    if not _cloud_sdk_installed("aws"):
+        pytest.skip("aws SDK not installed in this venv")
+    p = provisioner_for("aws")
+    payload = InfraValidationInput(cloud="aws", region="us-east-1", mode="simple", fields={})
+    with pytest.raises(NotImplementedError, match="#378"):
+        await p.provision(payload)
+    state = InfraState(
+        cloud="aws",
+        region="us-east-1",
+        provisioned_by="t",
+        provisioned_at=datetime.now(),
+        mode="validated",
+    )
+    with pytest.raises(NotImplementedError, match="#378"):
+        await p.destroy(state)

--- a/tests/unit/test_provisioners_aws.py
+++ b/tests/unit/test_provisioners_aws.py
@@ -1,0 +1,143 @@
+"""Unit tests for AWSProvisioner — boto3 fully mocked."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("boto3")
+pytest.importorskip("botocore")
+
+from botocore.exceptions import ClientError  # noqa: E402
+
+from engine.provisioners import InfraValidationInput  # noqa: E402
+from engine.provisioners.aws import AWSProvisioner  # noqa: E402
+
+
+def _make_session(sts_account: str = "123456789012") -> MagicMock:
+    """Build a boto3 Session mock whose .client(svc) returns per-service mocks."""
+    sts = MagicMock()
+    sts.get_caller_identity.return_value = {"Account": sts_account}
+
+    ecs = MagicMock()
+    ecs.describe_clusters.return_value = {"clusters": [{"status": "ACTIVE"}]}
+
+    iam = MagicMock()
+    iam.get_role.return_value = {"Role": {"Arn": "arn:aws:iam::123456789012:role/exec-role"}}
+
+    ec2 = MagicMock()
+    ec2.describe_subnets.return_value = {"Subnets": [{"AvailabilityZone": "us-east-1a"}]}
+    ec2.describe_security_groups.return_value = {"SecurityGroups": [{"GroupName": "agent-sg"}]}
+
+    ecr = MagicMock()
+    ecr.describe_repositories.return_value = {
+        "repositories": [{"repositoryUri": "123.dkr.ecr.us-east-1.amazonaws.com/agent"}]
+    }
+
+    services = {"sts": sts, "ecs": ecs, "iam": iam, "ec2": ec2, "ecr": ecr}
+    session = MagicMock()
+    session.client.side_effect = lambda svc: services[svc]
+    return session
+
+
+@pytest.fixture
+def patch_boto3_session():
+    with patch("engine.provisioners.aws.boto3.session.Session") as factory:
+        factory.return_value = _make_session()
+        yield factory
+
+
+async def test_aws_simple_mode_passes_when_account_matches(patch_boto3_session) -> None:
+    p = AWSProvisioner()
+    payload = InfraValidationInput(
+        cloud="aws",
+        region="us-east-1",
+        mode="simple",
+        fields={"AWS_ACCOUNT_ID": "123456789012"},
+    )
+    result = await p.validate_existing(payload)
+    assert result.valid is True
+    assert result.checks[0].resource == "credentials"
+    assert result.checks[0].status == "found"
+
+
+async def test_aws_simple_mode_fails_when_account_mismatch(patch_boto3_session) -> None:
+    p = AWSProvisioner()
+    payload = InfraValidationInput(
+        cloud="aws",
+        region="us-east-1",
+        mode="simple",
+        fields={"AWS_ACCOUNT_ID": "999999999999"},
+    )
+    result = await p.validate_existing(payload)
+    assert result.valid is False
+    assert result.checks[0].status == "error"
+    assert "999999999999" in result.checks[0].detail
+
+
+async def test_aws_full_mode_resolves_each_named_resource(patch_boto3_session) -> None:
+    p = AWSProvisioner()
+    payload = InfraValidationInput(
+        cloud="aws",
+        region="us-east-1",
+        mode="full",
+        fields={
+            "AWS_ACCOUNT_ID": "123456789012",
+            "AWS_ECS_CLUSTER": "my-cluster",
+            "AWS_EXECUTION_ROLE_ARN": "arn:aws:iam::123456789012:role/exec-role",
+            "AWS_VPC_SUBNETS": "subnet-aaa,subnet-bbb",
+            "AWS_SECURITY_GROUPS": "sg-xxx",
+            "AWS_ECR_REPOSITORY": "agent",
+        },
+    )
+    result = await p.validate_existing(payload)
+    assert result.valid is True
+    resources = [c.resource for c in result.checks]
+    assert "my-cluster" in resources
+    assert "subnet-aaa" in resources
+    assert "subnet-bbb" in resources
+    assert "sg-xxx" in resources
+    assert "agent" in resources
+
+
+async def test_aws_missing_subnet_is_reported_as_missing() -> None:
+    session = _make_session()
+    ec2 = session.client.side_effect("ec2")
+    # Re-arm ec2 to raise the boto3 not-found error.
+    ec2.describe_subnets.side_effect = ClientError(
+        {"Error": {"Code": "InvalidSubnetID.NotFound", "Message": "subnet absent"}},
+        "DescribeSubnets",
+    )
+    with patch("engine.provisioners.aws.boto3.session.Session", return_value=session):
+        p = AWSProvisioner()
+        payload = InfraValidationInput(
+            cloud="aws",
+            region="us-east-1",
+            mode="full",
+            fields={
+                "AWS_ACCOUNT_ID": "123456789012",
+                "AWS_VPC_SUBNETS": "subnet-missing",
+            },
+        )
+        result = await p.validate_existing(payload)
+    assert result.valid is False
+    missing = [c for c in result.checks if c.resource == "subnet-missing"]
+    assert len(missing) == 1
+    assert missing[0].status == "missing"
+
+
+async def test_aws_access_denied_is_reported_as_forbidden() -> None:
+    session = _make_session()
+    sts = session.client.side_effect("sts")
+    sts.get_caller_identity.side_effect = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "nope"}}, "GetCallerIdentity"
+    )
+    with patch("engine.provisioners.aws.boto3.session.Session", return_value=session):
+        p = AWSProvisioner()
+        payload = InfraValidationInput(
+            cloud="aws", region="us-east-1", mode="simple", fields={"AWS_ACCOUNT_ID": "1"}
+        )
+        result = await p.validate_existing(payload)
+    assert result.valid is False
+    assert result.checks[0].status == "forbidden"

--- a/website/content/docs/deployment.mdx
+++ b/website/content/docs/deployment.mdx
@@ -1,6 +1,6 @@
 ---
 title: Deployment
-description: Ship a registered agent to a public cloud — covers the GCP Cloud Run path end-to-end, plus the IAM grants, secrets, and CI/CD wiring you need.
+description: Ship a registered agent to AWS, GCP, or Azure — covers the user-input contract per cloud (BYO existing infra), plus the GCP Cloud Run path end-to-end as the verified reference example.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
@@ -13,9 +13,10 @@ deploy step packages the agent + the AgentBreeder runtime into a container, push
 to your cloud's image registry, and rolls it out as a managed service with secrets and
 auth wired in.
 
-This page covers the **Cloud Run** path end-to-end (verified live). The same pattern
-applies to AWS ECS / App Runner and Kubernetes — the only differences are the cloud
-CLI, the secrets backend, and the IAM model.
+AgentBreeder supports three clouds — **AWS**, **GCP**, and **Azure** — plus local
+Docker Compose for development. This page covers the **GCP Cloud Run** path end-to-end
+as the verified reference example; the same pattern applies to AWS ECS / App Runner
+and Azure Container Apps with the per-cloud user-input contract below.
 
 <Callout type="info" title="Reference deploy">
   The microlearning-ebook-agent example is **deployed and serving** at
@@ -30,6 +31,161 @@ CLI, the secrets backend, and the IAM model.
   This page focuses on the **actionable prerequisites** for each target — see
   [Prerequisites per target](#prerequisites-per-target-as-of-2026-05-18) below.
 </Callout>
+
+---
+
+## User-input contract per cloud (BYO existing infra)
+
+For each cloud, AgentBreeder needs a minimum set of inputs from you so it can deploy
+into your existing infrastructure. Two modes are supported:
+
+- **`simple`** — account + region + credentials. AgentBreeder uses cloud defaults for
+  the rest (cluster names, IAM roles, networking).
+- **`full`** — describe every specific resource (cluster, subnets, IAM role, registry).
+
+Both modes are served by two API endpoints:
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /api/v1/deployments/cloud-requirements/{cloud}?mode=simple\|full` | Returns the required + optional fields for the cloud + mode. The dashboard wizard and the CLI both read this to know what to ask you for. |
+| `POST /api/v1/deployments/validate-infra` | Read-only pre-flight check that all referenced resources actually exist. Rate-limited (10 req/min) and audit-logged. Cross-team access returns 403. |
+
+<Callout type="info" title="Auth posture">
+  `cloud-requirements` requires any authenticated user. `validate-infra` requires the
+  caller to hold the **deployer** role in the `team_id` named in the request body —
+  cross-team validation is denied. Every successful or failed call writes to the
+  audit log (`AuditService.log_event(action="deployment.validate_infra", ...)`).
+</Callout>
+
+<Tabs items={['AWS', 'GCP', 'Azure']}>
+<Tab value="AWS">
+
+**Simple mode (`mode=simple`):**
+
+| Field | Required | Description |
+|---|---|---|
+| `AWS_ACCOUNT_ID` | ✓ | AWS Account ID (12 digits) |
+| `AWS_DEFAULT_REGION` | ✓ | AWS region (default `us-east-1`) |
+| `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` | ✓ | Credentials (or use `AWS_PROFILE`) |
+| `AWS_SESSION_TOKEN` | — | STS session token (for assumed roles) |
+| `AWS_PROFILE` | — | Named profile from `~/.aws/credentials` |
+| `AWS_ECR_REGISTRY` | — | Override ECR registry host |
+
+In simple mode AgentBreeder uses ECS cluster `agentbreeder-default`, IAM role
+`agentbreeder-ecs-execution-role`, the default VPC, and the default security group.
+These are auto-created on first deploy in greenfield mode (coming with [#383](https://github.com/agentbreeder/agentbreeder/issues/383)).
+
+**Full mode adds:**
+
+| Field | Required | Description |
+|---|---|---|
+| `AWS_ECS_CLUSTER` | ✓ | ECS cluster name |
+| `AWS_EXECUTION_ROLE_ARN` | ✓ | IAM execution role ARN |
+| `AWS_VPC_SUBNETS` | ✓ | Comma-separated subnet IDs (≥2 for HA) |
+| `AWS_SECURITY_GROUPS` | ✓ | Comma-separated security group IDs |
+| `AWS_ECR_REPOSITORY` | ✓ | ECR repository name |
+| `AWS_TASK_ROLE_ARN` | — | Task IAM role ARN |
+| `AWS_ALB_TARGET_GROUP_ARN` | — | ALB target group ARN |
+| `AWS_CLOUDWATCH_LOG_GROUP` | — | CloudWatch Logs group |
+| `AWS_SECRETS_MANAGER_PREFIX` | — | ARN prefix for Secrets Manager |
+
+**What `validate-infra` checks (read-only):**
+`sts:GetCallerIdentity` (creds + account match), `ec2:DescribeSubnets`,
+`ec2:DescribeSecurityGroups`, `ecs:DescribeClusters`, `iam:GetRole`,
+`ecr:DescribeRepositories`.
+
+</Tab>
+<Tab value="GCP">
+
+**Simple mode (`mode=simple`):**
+
+| Field | Required | Description |
+|---|---|---|
+| `GOOGLE_CLOUD_PROJECT` | ✓ | GCP project ID |
+| `GOOGLE_APPLICATION_CREDENTIALS` | ✓ | Path to service-account JSON (or use ADC) |
+| `GCP_REGION` | — | Cloud Run region (default `us-central1`) |
+
+In simple mode AgentBreeder uses Artifact Registry repo `agentbreeder` and the
+default compute service account `<project-number>-compute@developer.gserviceaccount.com`.
+You still need the four IAM roles documented in [One-time IAM grants](#one-time-iam-grants) below.
+
+**Full mode adds:**
+
+| Field | Required | Description |
+|---|---|---|
+| `GCP_ARTIFACT_REGISTRY_REPO` | ✓ | Artifact Registry repository name |
+| `GCP_CLOUD_RUN_SERVICE_ACCOUNT` | ✓ | Service account email for the Cloud Run service |
+| `GCP_VPC_CONNECTOR` | — | Serverless VPC Access connector |
+| `GCP_CLOUD_SQL_INSTANCE` | — | Cloud SQL instance connection name |
+| `GCP_ALLOW_UNAUTHENTICATED` | — | `true`/`false` |
+| `GCP_CUSTOM_DOMAIN` | — | Custom domain mapping |
+
+**What `validate-infra` checks (read-only):**
+`resourcemanager:GetProject`, `artifactregistry:GetRepository`,
+`iam:GetServiceAccount`.
+
+</Tab>
+<Tab value="Azure">
+
+**Simple mode (`mode=simple`):**
+
+| Field | Required | Description |
+|---|---|---|
+| `AZURE_SUBSCRIPTION_ID` | ✓ | Azure subscription ID |
+| `AZURE_TENANT_ID` | ✓ | Microsoft Entra (Azure AD) tenant ID |
+| `AZURE_CLIENT_ID` + `AZURE_CLIENT_SECRET` | ✓ | Service-principal credentials (or `az login`) |
+| `AZURE_LOCATION` | — | Azure region (default `eastus`) |
+
+In simple mode AgentBreeder uses Resource Group `agentbreeder-rg`, auto-creates an ACR
+(`agentbreeder<5-char-hash>`), a Log Analytics workspace, and an ACA managed environment on first deploy
+(coming with [#384](https://github.com/agentbreeder/agentbreeder/issues/384)).
+
+**Full mode adds:**
+
+| Field | Required | Description |
+|---|---|---|
+| `AZURE_RESOURCE_GROUP` | ✓ | Resource Group name |
+| `AZURE_ACR_LOGIN_SERVER` | ✓ | ACR login server (e.g. `myacr.azurecr.io`) |
+| `AZURE_ACA_ENVIRONMENT` | ✓ | Container Apps managed environment name |
+| `AZURE_LOG_ANALYTICS_WORKSPACE_ID` | ✓ | Log Analytics workspace ID (GUID) |
+| `AZURE_MANAGED_IDENTITY_ID` | ✓ | User-assigned managed identity ID |
+| `AZURE_KEY_VAULT_NAME` | — | Key Vault name for secrets |
+| `AZURE_POSTGRES_FQDN` | — | Azure Database for PostgreSQL FQDN |
+| `AZURE_VNET_SUBNET_ID` | — | VNet subnet ID for delegation |
+
+**What `validate-infra` checks (read-only):**
+`SubscriptionClient.subscriptions.get`, `ResourceGroupsClient.get`,
+`ContainerRegistryManagementClient.registries.get`,
+`ContainerAppsAPIClient.managed_environments.get`.
+
+</Tab>
+</Tabs>
+
+### Calling `validate-infra` from your terminal
+
+```bash
+TOKEN=$AGENTBREEDER_API_TOKEN
+
+curl -X POST http://localhost:8000/api/v1/deployments/validate-infra \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "team_id": "engineering",
+    "cloud": "aws",
+    "region": "us-east-1",
+    "mode": "simple",
+    "fields": {
+      "AWS_ACCOUNT_ID": "123456789012",
+      "AWS_ACCESS_KEY_ID": "AKIA...",
+      "AWS_SECRET_ACCESS_KEY": "..."
+    }
+  }'
+# {"data":{"valid":true,"cloud":"aws","region":"us-east-1","checks":[...]},"errors":[]}
+```
+
+If a referenced resource is missing or you lack permission, the response carries a
+populated `errors` array and the individual check status (`missing` / `forbidden` /
+`error`) for each resource.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase A of epic [#378](https://github.com/agentbreeder/agentbreeder/issues/378). Lands the server-side foundation for deploying agents to AWS, GCP, and Azure (bring-your-own existing infrastructure mode). Closes [#385](https://github.com/agentbreeder/agentbreeder/issues/385), [#386](https://github.com/agentbreeder/agentbreeder/issues/386), and the new tabs section in [#388](https://github.com/agentbreeder/agentbreeder/issues/388).

## What ships

- **`engine/provisioners/`** — new package
  - `base.py` — `InfraProvisioner` ABC (`validate_existing` fully implemented; `provision`/`destroy` raise `NotImplementedError` pointing at greenfield #382/#383/#384)
  - `state.py` — `InfraState` load/save for `.agentbreeder/infra-state.json`
  - `requirements.py` — static cloud-input contract for AWS/GCP/Azure × simple/full modes
  - `aws.py` / `gcp.py` / `azure.py` — read-only resource validators; cloud-specific SDKs lazy-loaded via `importlib`
- **`api/routes/deployments.py`** — new
  - `GET /api/v1/deployments/cloud-requirements/{cloud}?mode=simple|full` — any authenticated user
  - `POST /api/v1/deployments/validate-infra` — `deployer` role in `body.team_id` required; cross-team → 403; rate-limited 10/min; every call audit-logged via `AuditService`
- **`api/main.py`** — registers slowapi limiter + new router
- **`pyproject.toml`** — `slowapi>=0.1.9` in core deps, new `gcp` extra, expanded `azure` extra
- **`website/content/docs/deployment.mdx`** — new "User-input contract per cloud" section with AWS/GCP/Azure tabs documenting required + optional fields and the two new endpoints
- **Tests** — 60 pass, 2 skipped (graceful when GCP/Azure SDKs not installed)

## Auth posture

| Endpoint | Gate |
|---|---|
| `GET /cloud-requirements/{cloud}` | `Depends(get_current_user)` |
| `POST /validate-infra` | inline `_require_deployer_in_team(user, body.team_id)`; platform admins bypass; cross-team → 403 |

Rate limit: 10 req/min/IP on `validate-infra` (slowapi, Redis-backed via `REDIS_URL`).
Audit log: every `validate-infra` call (success or failure) writes `AuditService.log_event(action="deployment.validate_infra", ...)`.

## What does NOT ship in this PR (tracked as follow-ups)

- CLI `login`/`logout`/`whoami` + keychain token storage
- `agentbreeder deploy --remote` so CLI deploys actually hit the API (current CLI deploy runs in-process and bypasses RBAC)
- Tighten existing `POST /api/v1/deploys` to use `require_role("deployer", resource_team=<agent's team>)`
- HR-2-node: memory wiring in 8 Node runtime templates
- Greenfield provisioning (#382 GCP / #383 AWS / #384 Azure)

## Test plan

- [x] `pytest tests/unit/test_provisioners.py tests/unit/test_provisioners_aws.py tests/integration/test_deployments_api.py` — 28 tests pass
- [x] No regressions: `tests/unit/test_api.py`, `tests/unit/test_audit_service.py` still pass
- [x] `ruff check` clean on every new/changed file
- [x] `python -c "from api.main import app"` imports cleanly with 279 registered routes
- [ ] Manual smoke test against a real AWS / GCP / Azure account (recommend before merge — needs SDK install: `pip install 'agentbreeder[all-clouds]'`)
- [ ] Cross-repo: `agentbreeder-cloud` PR if it consumes the new endpoints (CLAUDE.md rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
