### PR TITLE
feat(graphrag): accept custom_entity_types in agent.yaml + thread to LLM (HR-3, closes #405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
-<<<<<<< HEAD
 ### v2.3 — Cloud-Deploy Foundation (#413)
 
 - **Added** `engine/provisioners/` — `InfraProvisioner` ABC with read-only `validate_existing` impls for AWS / GCP / Azure (boto3, google-cloud, azure-sdk). Greenfield `provision()` / `destroy()` stubbed (per-cloud follow-ups #382 / #383 / #384).
@@ -17,13 +16,18 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 - **Added** API: `GET /api/v1/deployments/cloud-requirements/{cloud}?mode=simple|full` (any authenticated user) and `POST /api/v1/deployments/validate-infra` (`deployer` role required in the requested team, cross-team → 403, rate-limited 10 req/min via slowapi, audit-logged via `AuditService`).
 - **Added** `pgvector>=0.2.5` + `slowapi>=0.1.9` to optional deps; new `gcp` extras group; expanded `azure` group.
 - **Docs** — rewrote `website/content/docs/deployment.mdx` to a three-cloud tabbed contract.
-=======
+
 ### v2.3 — HR-1 memory team-scope enforcement (#418, closes #403)
 
 - **Fixed** `api/routes/memory.py` now forwards `user.team` to `MemoryService` on every read/write. Cross-team access → HTTP 403.
 - **Hardened** `MemoryService` now raises `PermissionError` when a team-scoped config is accessed without `requesting_team` (previously a silent allow).
 - **Tests** — flipped 2 `MM7` xfail tests to passing + added route-layer 403 coverage.
->>>>>>> 0860a0a (docs(changelog): HR-1 entry (#418))
+
+### v2.3 — HR-3 GraphRAG `custom_entity_types` (#419, closes #405)
+
+- **Added** `entity_extraction.custom_types[]` accepted by `engine/schema/agent.schema.json` + Pydantic mirror (`engine/config_parser.py`).
+- **Threaded** `custom_types` through `extract_entities` / `_call_claude` / `_call_ollama`; cache key extended so different type sets don't collide.
+- **Docs** — flipped roadmap callout in `graphrag.mdx` to shipped.
 
 ### Platform Audit Summary (2026-05-18)
 

--- a/api/services/graph_extraction.py
+++ b/api/services/graph_extraction.py
@@ -32,11 +32,18 @@ async def extract_entities(
     text: str,
     model: str = DEFAULT_ENTITY_MODEL,
     cache: dict[str, tuple[list[GraphNode], list[GraphEdge]]] | None = None,
+    custom_types: list[dict[str, str]] | None = None,
 ) -> tuple[list[GraphNode], list[GraphEdge]]:
     """Extract entities and relationships from a text chunk using an LLM.
 
     Uses module-level cache by default. Pass cache={} to use a fresh cache.
     Returns ([], []) on LLM failure (never raises).
+
+    ``custom_types`` (HR-3 / #405): optional domain-specific entity categories
+    appended to the six built-ins in the LLM prompt. Each item is a dict with
+    ``name`` (required) and optional ``description``. Names should be uppercase
+    snake-case (CONTRACT, DIAGNOSIS, MEDICATION). Cache keys include custom
+    types so different type sets don't collide on the same text.
 
     Note: returned GraphNode/GraphEdge objects always have chunk_ids=[].
     The caller must append the source chunk_id after calling this function.
@@ -46,9 +53,13 @@ async def extract_entities(
         _extraction_cache if cache is None else cache
     )
 
-    # Cache key: SHA-256 of JSON-serialised (text, model) to avoid pipe-char collisions
+    # Cache key: SHA-256 of JSON-serialised (text, model, custom_types) so
+    # different type sets don't collide on the same text.
     cache_key = hashlib.sha256(
-        json.dumps({"text": text, "model": model}, sort_keys=True).encode()
+        json.dumps(
+            {"text": text, "model": model, "custom_types": custom_types or []},
+            sort_keys=True,
+        ).encode()
     ).hexdigest()
 
     if cache_key in active_cache:
@@ -56,9 +67,9 @@ async def extract_entities(
 
     # Call LLM
     if model.startswith("ollama/"):
-        raw = await _call_ollama(text, model[len("ollama/") :])
+        raw = await _call_ollama(text, model[len("ollama/") :], custom_types=custom_types)
     else:
-        raw = await _call_claude(text, model)
+        raw = await _call_claude(text, model, custom_types=custom_types)
 
     # Parse results
     nodes, edges = _parse_extraction_result(raw, text)
@@ -74,6 +85,7 @@ async def extract_entities_batch(
     model: str = DEFAULT_ENTITY_MODEL,
     batch_size: int = 5,
     cache: dict[str, tuple[list[GraphNode], list[GraphEdge]]] | None = None,
+    custom_types: list[dict[str, str]] | None = None,
 ) -> list[tuple[list[GraphNode], list[GraphEdge]]]:
     """Extract entities from multiple chunks concurrently.
 
@@ -87,12 +99,39 @@ async def extract_entities_batch(
 
     async def _extract_with_semaphore(text: str) -> tuple[list[GraphNode], list[GraphEdge]]:
         async with semaphore:
-            return await extract_entities(text, model=model, cache=cache)
+            return await extract_entities(
+                text, model=model, cache=cache, custom_types=custom_types
+            )
 
     return list(await asyncio.gather(*[_extract_with_semaphore(t) for t in texts]))
 
 
-async def _call_claude(text: str, model: str) -> dict[str, Any]:
+def _entity_type_enum(custom_types: list[dict[str, str]] | None) -> str:
+    """Build the pipe-separated type enum for the LLM JSON schema."""
+    builtins = ["organization", "person", "concept", "location", "event", "other"]
+    extras = [t["name"] for t in (custom_types or []) if t.get("name")]
+    return "|".join(builtins + extras)
+
+
+def _custom_types_hint(custom_types: list[dict[str, str]] | None) -> str:
+    """Render an extra prompt block describing custom entity categories."""
+    if not custom_types:
+        return ""
+    lines = ["", "Additional domain-specific categories you must use when applicable:"]
+    for t in custom_types:
+        name = t.get("name", "").strip()
+        if not name:
+            continue
+        desc = t.get("description", "").strip()
+        lines.append(f"- {name}: {desc}" if desc else f"- {name}")
+    return "\n".join(lines)
+
+
+async def _call_claude(
+    text: str,
+    model: str,
+    custom_types: list[dict[str, str]] | None = None,
+) -> dict[str, Any]:
     """Call Claude API to extract entities and relationships.
 
     Returns a dict with 'entities' and 'relationships' keys.
@@ -109,6 +148,7 @@ async def _call_claude(text: str, model: str) -> dict[str, Any]:
         "Return ONLY valid JSON — no prose."
     )
 
+    type_enum = _entity_type_enum(custom_types)
     user_prompt = (
         f"Extract from the following text chunk:\n"
         f"<chunk>{text}</chunk>\n\n"
@@ -116,7 +156,7 @@ async def _call_claude(text: str, model: str) -> dict[str, Any]:
         "{\n"
         '  "entities": [\n'
         '    {"entity": "string",'
-        ' "type": "organization|person|concept|location|event|other",'
+        f' "type": "{type_enum}",'
         ' "description": "string"}\n'
         "  ],\n"
         '  "relationships": [\n'
@@ -125,6 +165,7 @@ async def _call_claude(text: str, model: str) -> dict[str, Any]:
         ' "object": "entity name"}\n'
         "  ]\n"
         "}"
+        f"{_custom_types_hint(custom_types)}"
     )
 
     payload = {
@@ -164,7 +205,11 @@ async def _call_claude(text: str, model: str) -> dict[str, Any]:
         return {"entities": [], "relationships": []}
 
 
-async def _call_ollama(text: str, model_name: str) -> dict[str, Any]:
+async def _call_ollama(
+    text: str,
+    model_name: str,
+    custom_types: list[dict[str, str]] | None = None,
+) -> dict[str, Any]:
     """Call local Ollama chat API to extract entities and relationships.
 
     model_name is the bare name (e.g. "qwen2.5:7b"), without the "ollama/" prefix.
@@ -178,6 +223,7 @@ async def _call_ollama(text: str, model_name: str) -> dict[str, Any]:
         "Extract entities and relationships from text. "
         "Return ONLY valid JSON — no prose."
     )
+    type_enum = _entity_type_enum(custom_types)
     user_prompt = (
         f"Extract from the following text chunk:\n"
         f"<chunk>{text}</chunk>\n\n"
@@ -185,7 +231,7 @@ async def _call_ollama(text: str, model_name: str) -> dict[str, Any]:
         "{\n"
         '  "entities": [\n'
         '    {"entity": "string",'
-        ' "type": "organization|person|concept|location|event|other",'
+        f' "type": "{type_enum}",'
         ' "description": "string"}\n'
         "  ],\n"
         '  "relationships": [\n'
@@ -194,6 +240,7 @@ async def _call_ollama(text: str, model_name: str) -> dict[str, Any]:
         ' "object": "entity name"}\n'
         "  ]\n"
         "}"
+        f"{_custom_types_hint(custom_types)}"
     )
     payload = {
         "model": model_name,

--- a/engine/config_parser.py
+++ b/engine/config_parser.py
@@ -107,8 +107,22 @@ class ToolRef(BaseModel):
     model_config = {"populate_by_name": True}
 
 
+class CustomEntityType(BaseModel):
+    """One user-defined entity category for domain-specific GraphRAG extraction."""
+
+    name: str
+    description: str = ""
+
+
+class EntityExtractionConfig(BaseModel):
+    """Per-knowledge-base overrides for the LLM-backed entity extractor."""
+
+    custom_types: list[CustomEntityType] = Field(default_factory=list)
+
+
 class KnowledgeBaseRef(BaseModel):
     ref: str
+    entity_extraction: EntityExtractionConfig | None = None
 
 
 class SubagentRef(BaseModel):

--- a/engine/schema/agent.schema.json
+++ b/engine/schema/agent.schema.json
@@ -235,6 +235,26 @@
           "ref": {
             "type": "string"
           },
+          "entity_extraction": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Per-KB overrides for GraphRAG LLM-backed entity extraction (HR-3 / #405)",
+            "properties": {
+              "custom_types": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["name"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {"type": "string"},
+                    "description": {"type": "string"}
+                  }
+                },
+                "description": "Domain-specific entity categories (e.g. CONTRACT, DIAGNOSIS, MEDICATION) used in addition to the six built-in types."
+              }
+            }
+          },
           "retrieval": {
             "type": "object",
             "additionalProperties": false,

--- a/tests/unit/test_coverage_phase2.py
+++ b/tests/unit/test_coverage_phase2.py
@@ -546,7 +546,9 @@ class TestBatchExtractEntities:
         fake_nodes = [MagicMock(), MagicMock()]
         fake_edges: list = []
 
-        async def fake_extract(text: str, model: str, cache: Any) -> tuple:
+        async def fake_extract(
+            text: str, model: str, cache: Any, custom_types: Any = None
+        ) -> tuple:
             return (fake_nodes, fake_edges)
 
         with patch("api.services.graph_extraction.extract_entities", fake_extract):

--- a/tests/unit/test_graph_extraction.py
+++ b/tests/unit/test_graph_extraction.py
@@ -144,9 +144,13 @@ def test_parse_extraction_result_empty():
 async def test_extract_entities_cache_hit():
     """Cache hit must return stored value without calling _call_claude."""
     cache: dict = {}
-    # Pre-populate cache with the exact key that extract_entities would compute
+    # Pre-populate cache with the exact key that extract_entities would compute.
+    # HR-3 / #405: cache key now includes custom_types — empty list for default.
     cache_key = hashlib.sha256(
-        json.dumps({"text": "hello", "model": DEFAULT_ENTITY_MODEL}, sort_keys=True).encode()
+        json.dumps(
+            {"text": "hello", "model": DEFAULT_ENTITY_MODEL, "custom_types": []},
+            sort_keys=True,
+        ).encode()
     ).hexdigest()
     cached_nodes = [
         GraphNode(id="n1", entity="Cached", entity_type="concept", description="", chunk_ids=[])
@@ -215,7 +219,7 @@ async def test_extract_entities_batch_ordering():
 
     call_count = 0
 
-    async def fake_call_claude(text: str, model: str) -> dict:
+    async def fake_call_claude(text: str, model: str, custom_types=None) -> dict:  # noqa: ANN001
         nonlocal call_count
         call_count += 1
         return {
@@ -290,7 +294,7 @@ async def test_extract_entities_routes_to_ollama_for_ollama_prefix():
     with patch("api.services.graph_extraction._call_ollama", new_callable=AsyncMock) as mock:
         mock.return_value = mock_result
         nodes, edges = await extract_entities("test text", model="ollama/qwen2.5:7b", cache={})
-    mock.assert_called_once_with("test text", "qwen2.5:7b")
+    mock.assert_called_once_with("test text", "qwen2.5:7b", custom_types=None)
     assert len(nodes) == 1
     assert nodes[0].entity == "AgentBreeder"
 

--- a/tests/unit/test_graph_extraction_custom_types.py
+++ b/tests/unit/test_graph_extraction_custom_types.py
@@ -60,7 +60,9 @@ async def test_extract_entities_forwards_custom_types_to_claude() -> None:
         captured["custom_types"] = custom_types
         return {"entities": [], "relationships": []}
 
-    with patch("api.services.graph_extraction._call_claude", new=AsyncMock(side_effect=fake_claude)):
+    with patch(
+        "api.services.graph_extraction._call_claude", new=AsyncMock(side_effect=fake_claude)
+    ):
         custom = [{"name": "STATUTE", "description": "Specific laws"}]
         # Fresh cache so we actually call the patched LLM.
         await extract_entities(
@@ -84,7 +86,9 @@ async def test_extract_entities_cache_key_separates_custom_types() -> None:
         return {"entities": [], "relationships": []}
 
     cache: dict = {}
-    with patch("api.services.graph_extraction._call_claude", new=AsyncMock(side_effect=fake_claude)):
+    with patch(
+        "api.services.graph_extraction._call_claude", new=AsyncMock(side_effect=fake_claude)
+    ):
         await extract_entities("same text", cache=cache, custom_types=[{"name": "A"}])
         await extract_entities("same text", cache=cache, custom_types=[{"name": "B"}])
         # Repeat first → must hit cache (no new call).

--- a/tests/unit/test_graph_extraction_custom_types.py
+++ b/tests/unit/test_graph_extraction_custom_types.py
@@ -1,0 +1,126 @@
+"""HR-3 / #405: custom entity types threaded into the entity-extraction prompt."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.services.graph_extraction import (
+    _custom_types_hint,
+    _entity_type_enum,
+    extract_entities,
+)
+
+
+def test_entity_type_enum_built_ins_only() -> None:
+    assert _entity_type_enum(None) == "organization|person|concept|location|event|other"
+    assert _entity_type_enum([]) == "organization|person|concept|location|event|other"
+
+
+def test_entity_type_enum_appends_custom_types() -> None:
+    enum_str = _entity_type_enum(
+        [{"name": "CONTRACT", "description": "Legal agreements"}, {"name": "PARTY"}]
+    )
+    assert "organization" in enum_str
+    assert "CONTRACT" in enum_str
+    assert "PARTY" in enum_str
+
+
+def test_entity_type_enum_skips_missing_name() -> None:
+    enum_str = _entity_type_enum([{"description": "no name"}, {"name": "GOOD"}])
+    assert "GOOD" in enum_str
+    assert "no name" not in enum_str
+
+
+def test_custom_types_hint_empty() -> None:
+    assert _custom_types_hint(None) == ""
+    assert _custom_types_hint([]) == ""
+
+
+def test_custom_types_hint_renders_with_descriptions() -> None:
+    hint = _custom_types_hint(
+        [
+            {"name": "DIAGNOSIS", "description": "ICD-10 codes and diagnoses"},
+            {"name": "MEDICATION"},
+        ]
+    )
+    assert "DIAGNOSIS: ICD-10 codes and diagnoses" in hint
+    assert "- MEDICATION" in hint
+    assert "Additional domain-specific categories" in hint
+
+
+@pytest.mark.asyncio
+async def test_extract_entities_forwards_custom_types_to_claude() -> None:
+    """The LLM call must receive a prompt that lists the user-supplied types."""
+    captured: dict[str, object] = {}
+
+    async def fake_claude(text, model, custom_types=None):  # noqa: ANN001
+        captured["text"] = text
+        captured["custom_types"] = custom_types
+        return {"entities": [], "relationships": []}
+
+    with patch("api.services.graph_extraction._call_claude", new=AsyncMock(side_effect=fake_claude)):
+        custom = [{"name": "STATUTE", "description": "Specific laws"}]
+        # Fresh cache so we actually call the patched LLM.
+        await extract_entities(
+            "Some legal text.",
+            model="claude-sonnet-4",
+            cache={},
+            custom_types=custom,
+        )
+
+    assert captured["custom_types"] == [{"name": "STATUTE", "description": "Specific laws"}]
+
+
+@pytest.mark.asyncio
+async def test_extract_entities_cache_key_separates_custom_types() -> None:
+    """Same text + different custom_types must hit the LLM twice, not collide."""
+    calls = 0
+
+    async def fake_claude(text, model, custom_types=None):  # noqa: ANN001
+        nonlocal calls
+        calls += 1
+        return {"entities": [], "relationships": []}
+
+    cache: dict = {}
+    with patch("api.services.graph_extraction._call_claude", new=AsyncMock(side_effect=fake_claude)):
+        await extract_entities("same text", cache=cache, custom_types=[{"name": "A"}])
+        await extract_entities("same text", cache=cache, custom_types=[{"name": "B"}])
+        # Repeat first → must hit cache (no new call).
+        await extract_entities("same text", cache=cache, custom_types=[{"name": "A"}])
+
+    assert calls == 2
+
+
+def test_schema_accepts_custom_types() -> None:
+    """The agent.schema.json now allows entity_extraction.custom_types under knowledge_bases."""
+    import json
+    from pathlib import Path
+
+    import jsonschema
+
+    schema_path = Path(__file__).resolve().parents[2] / "engine/schema/agent.schema.json"
+    schema = json.loads(schema_path.read_text())
+
+    minimal = {
+        "name": "domain-agent",
+        "version": "0.1.0",
+        "team": "platform",
+        "owner": "owner@example.com",
+        "framework": "claude_sdk",
+        "model": {"primary": "claude-sonnet-4"},
+        "deploy": {"cloud": "local"},
+        "knowledge_bases": [
+            {
+                "ref": "kb/legal-docs",
+                "entity_extraction": {
+                    "custom_types": [
+                        {"name": "CONTRACT", "description": "Legal agreements"},
+                        {"name": "PARTY"},
+                    ]
+                },
+            }
+        ],
+    }
+    jsonschema.validate(minimal, schema)

--- a/website/content/docs/graphrag.mdx
+++ b/website/content/docs/graphrag.mdx
@@ -13,7 +13,7 @@ GraphRAG extends vector search with entity extraction and relationship traversal
 <Callout type="info" title="Status as of 2026-05-18">
 **Shipped (Waves 1–5):** in-memory + Neo4j backends, BFS traversal with hop-limit, native Neo4j vector indexes when available, atomic batch ingestion, hybrid (vector + graph) search, four GraphRAG eval metrics (`entity_recall`, `relationship_precision`, `hop_coverage`, `vector_fallback_rate`), per-result fields `entity_path` / `vector_score` / `graph_score`, observability log `graphrag.search.complete`, and the `DELETE /api/v1/rag/indexes/{id}/extraction-cache` invalidation endpoint.
 
-**Roadmap (not yet shipped):** custom entity types (`entity_extraction.custom_types`) — see HR-3 below.
+**Shipped (HR-3 / #405):** custom entity types via `entity_extraction.custom_types` are accepted by the schema and threaded into the LLM extraction prompt. See [Custom Entity Types](#custom-entity-types) below.
 </Callout>
 
 :::note Prerequisites for local GraphRAG
@@ -383,16 +383,26 @@ AgentBreeder recognizes these entity types by default:
 
 ### Custom Entity Types
 
-<Callout type="warn" title="Status as of 2026-05-18 — Roadmap">
-Custom entity types via `entity_extraction.custom_types` are on the roadmap (audit item HR-3) but **not yet implemented**. Today AgentBreeder uses a fixed prompt with the six built-in types listed above. Custom types are extracted opportunistically by the LLM but will not be enforced as discrete categories until HR-3 ships. The YAML shown below is the planned shape — feel free to author config against it now; the parser will accept and ignore the keys until support lands.
+<Callout type="info" title="Shipped in HR-3 (#405)">
+Custom entity types via `entity_extraction.custom_types` are now part of the
+`agent.yaml` schema and threaded into the LLM extraction prompt. Names are
+added to the JSON-schema enum the model is required to return, and a short
+description block is appended so the model knows what each category means.
+
+The agent-side wire-through (resolving these from `agent.yaml` to the RAG
+ingestion pipeline) is staged: today, custom types apply when calling
+`api.services.graph_extraction.extract_entities(..., custom_types=[...])`
+directly. The companion PR in `agentbreeder-cloud` lands the index-side
+persistence so the types flow automatically from the agent config.
 </Callout>
 
-Define your own for domain-specific extraction (planned syntax):
+Define your own for domain-specific extraction:
 
 ```yaml
 knowledge_bases:
   - ref: kb/legal-docs
-    index_type: graph
+    retrieval:
+      type: graph
     entity_extraction:
       custom_types:
         - name: CONTRACT
@@ -402,6 +412,10 @@ knowledge_bases:
         - name: OBLIGATION
           description: "Duties and responsibilities"
 ```
+
+Names should be uppercase snake-case (`CONTRACT`, `DIAGNOSIS`, `MEDICATION`).
+Descriptions are optional but recommended — they go into the system prompt
+so the model knows when to apply each category.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes [HR-3 #405](https://github.com/agentbreeder/agentbreeder/issues/405). `entity_extraction.custom_types` was documented in `graphrag.mdx` but absent from `engine/schema/agent.schema.json` — `agentbreeder validate` rejected configs that used it. The LLM extractor was also hardcoded to the six built-in entity categories, so even if the field were accepted, the model had no way to honour domain-specific types like `CONTRACT` or `DIAGNOSIS`.

This PR adds the schema field, the Pydantic mirror, and threads the custom types through the LLM extraction prompt.

## Changes

- **`engine/schema/agent.schema.json`** — `knowledge_bases[]` items accept `entity_extraction.custom_types[]` (each `{ name, description? }`).
- **`engine/config_parser.py`** — new `CustomEntityType` + `EntityExtractionConfig` models; `KnowledgeBaseRef.entity_extraction: EntityExtractionConfig | None`.
- **`api/services/graph_extraction.py`** — `extract_entities()` and `extract_entities_batch()` accept a `custom_types` parameter; `_call_claude` / `_call_ollama` forward it. The type enum in the JSON schema the model returns is extended (built-ins + user-supplied names), and an *"Additional categories"* block is appended to the prompt with names and descriptions. The cache key now includes `custom_types`, so different type sets don't collide on the same text.
- **`website/content/docs/graphrag.mdx`** — flips the "Roadmap (not yet shipped)" + "Status as of 2026-05-18 — Roadmap" callouts to shipped notices; working YAML syntax.
- **Tests** — 28 graph_extraction tests pass (8 new HR-3-specific tests + 3 existing tests updated for the new signatures).

## Out of scope (separate follow-ups)

- **Index-side wire-through.** When a RAG index is created or re-indexed with a KB ref carrying `entity_extraction.custom_types`, those types should flow through `rag_service` to `extract_entities_batch` automatically. This needs a small `RAGIndex` / `registry/rag.py` change plus a companion `agentbreeder-cloud` PR — opening as a sibling issue.
- **Domain example.** A standalone `examples/graphrag-domain-extraction/` (e.g. legal contracts) is deferred until the index-side wire-through lands so the example works end-to-end without manual SDK calls. Until then the cleanest way to test is `api.services.graph_extraction.extract_entities(..., custom_types=[...])` directly.

## Test plan

- [x] `pytest tests/unit/test_graph_extraction.py tests/unit/test_graph_extraction_custom_types.py` — 28 pass
- [x] `pytest tests/unit/test_agent_yaml.py tests/unit/test_config_parser.py` — 62 pass (no regressions)
- [x] `ruff check` clean on every changed file
- [x] `jsonschema.validate` succeeds on the new agent.yaml shape with `custom_types`
- [ ] Cross-repo: open companion issue for `agentbreeder-cloud` index-side wire-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)
