### PR TITLE
chore(infra): migrate Docker Hub namespace from rajits/ to agentbreeder/ (HR-7, closes #408)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,8 +154,8 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/api:${{ steps.version.outputs.version }}
             ghcr.io/${{ github.repository }}/api:latest
-            rajits/agentbreeder-api:${{ steps.version.outputs.version }}
-            rajits/agentbreeder-api:latest
+            agentbreeder/agentbreeder-api:${{ steps.version.outputs.version }}
+            agentbreeder/agentbreeder-api:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -168,12 +168,12 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/dashboard:${{ steps.version.outputs.version }}
             ghcr.io/${{ github.repository }}/dashboard:latest
-            rajits/agentbreeder-dashboard:${{ steps.version.outputs.version }}
-            rajits/agentbreeder-dashboard:latest
+            agentbreeder/agentbreeder-dashboard:${{ steps.version.outputs.version }}
+            agentbreeder/agentbreeder-dashboard:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Track J: Go sidecar — multi-arch publish (rajits/agentbreeder-sidecar).
+      # Track J: Go sidecar — multi-arch publish (agentbreeder/agentbreeder-sidecar).
       - name: Build and push Sidecar image
         uses: docker/build-push-action@v6
         with:
@@ -186,8 +186,8 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/sidecar:${{ steps.version.outputs.version }}
             ghcr.io/${{ github.repository }}/sidecar:latest
-            rajits/agentbreeder-sidecar:${{ steps.version.outputs.version }}
-            rajits/agentbreeder-sidecar:latest
+            agentbreeder/agentbreeder-sidecar:${{ steps.version.outputs.version }}
+            agentbreeder/agentbreeder-sidecar:latest
           cache-from: type=gha,scope=sidecar
           cache-to: type=gha,scope=sidecar,mode=max
 
@@ -204,8 +204,8 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/go-agent-example:${{ steps.version.outputs.version }}
             ghcr.io/${{ github.repository }}/go-agent-example:latest
-            rajits/agentbreeder-go-agent-example:${{ steps.version.outputs.version }}
-            rajits/agentbreeder-go-agent-example:latest
+            agentbreeder/agentbreeder-go-agent-example:${{ steps.version.outputs.version }}
+            agentbreeder/agentbreeder-go-agent-example:latest
           cache-from: type=gha,scope=go-example
           cache-to: type=gha,scope=go-example,mode=max
 
@@ -413,8 +413,8 @@ jobs:
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
           tags: |
-            rajits/agentbreeder-cli:${{ steps.version.outputs.version }}
-            rajits/agentbreeder-cli:latest
+            agentbreeder/agentbreeder-cli:${{ steps.version.outputs.version }}
+            agentbreeder/agentbreeder-cli:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+### v2.3 — HR-7 Docker Hub namespace migration (#420, closes #408)
+
+- **Changed** every operational reference from `rajits/agentbreeder-*` to `agentbreeder/agentbreeder-*` across 18 files (CI workflow, docker-compose, sidecar, CLI defaults, docs, tests). Symmetric +54/-54.
+- Historical files (`CHANGELOG.md`, `ROADMAP.md`, audit specs/plans) intentionally untouched.
+
 ### Platform Audit Summary (2026-05-18)
 
 A 9-way parallel audit (`docs/superpowers/specs/2026-05-18-platform-audit-design.md`) surfaced 91 findings across 8 code subsystems plus website. 85 additive-safe items landed across 5 execution waves:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,7 +267,7 @@ Every deployed agent that declares `guardrails:`, MCP `tools:`, or `a2a:` gets t
 
 > **Source:** `sidecar/` (Go module), `engine/sidecar/` (Python deployer integration), `website/content/docs/sidecar.mdx` (user docs).
 > **Bypass:** set `AGENTBREEDER_SIDECAR=disabled` for local dev; agents without `guardrails:` / MCP / A2A do not get a sidecar at all.
-> **Image:** `rajits/agentbreeder-sidecar:<version>` (linux/amd64, linux/arm64).
+> **Image:** `agentbreeder/agentbreeder-sidecar:<version>` (linux/amd64, linux/arm64).
 
 ### 4. Framework Agnosticism
 The `engine/runtimes/` layer abstracts all framework differences. Every runtime implements:
@@ -327,9 +327,9 @@ AgentBreeder is distributed through three channels for maximum reach.
 
 | Image | Purpose | Dockerfile |
 |-------|---------|-----------|
-| `rajits/agentbreeder-api` | API server | `Dockerfile` |
-| `rajits/agentbreeder-dashboard` | React frontend | `dashboard/Dockerfile` |
-| `rajits/agentbreeder-cli` | Lightweight CLI for CI/CD pipelines | `Dockerfile.cli` |
+| `agentbreeder/agentbreeder-api` | API server | `Dockerfile` |
+| `agentbreeder/agentbreeder-dashboard` | React frontend | `dashboard/Dockerfile` |
+| `agentbreeder/agentbreeder-cli` | Lightweight CLI for CI/CD pipelines | `Dockerfile.cli` |
 
 All images tagged with version + `latest`, built for linux/amd64 and linux/arm64.
 
@@ -349,7 +349,7 @@ Plan to migrate to Homebrew core once the project has sufficient traction.
 |--------|-----------|
 | GitHub | `agentbreeder/agentbreeder` |
 | PyPI | `agentbreeder`, `agentbreeder-sdk` |
-| Docker Hub | `rajits/agentbreeder-api`, `rajits/agentbreeder-dashboard`, `rajits/agentbreeder-cli` |
+| Docker Hub | `agentbreeder/agentbreeder-api`, `agentbreeder/agentbreeder-dashboard`, `agentbreeder/agentbreeder-cli` |
 | Homebrew | `agentbreeder/homebrew-agentbreeder` |
 
 ### Release Flow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,7 +236,7 @@ The CLI (`python -m cli.main`) works in any additional terminal once the service
 **Or use `agentbreeder quickstart` for a one-command local stack:**
 
 ```bash
-agentbreeder quickstart           # pulls rajits/agentbreeder-{api,dashboard}:latest from Docker Hub
+agentbreeder quickstart           # pulls agentbreeder/agentbreeder-{api,dashboard}:latest from Docker Hub
 agentbreeder quickstart --dev     # builds API + Dashboard images from your local source
 ```
 
@@ -246,7 +246,7 @@ Use `--dev` whenever you have changes in `api/`, `engine/`, `dashboard/src/`, or
 
 ```bash
 agentbreeder down
-docker rmi rajits/agentbreeder-dashboard:latest rajits/agentbreeder-api:latest 2>/dev/null
+docker rmi agentbreeder/agentbreeder-dashboard:latest agentbreeder/agentbreeder-api:latest 2>/dev/null
 docker compose -f deploy/docker-compose.quickstart.yml build --no-cache dashboard api
 agentbreeder quickstart --dev
 ```

--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -1,8 +1,8 @@
 # AgentBreeder Observability Sidecar
 # Issue #73: Auto-inject OTel observability sidecar
 #
-# Build:  docker build -f Dockerfile.sidecar -t rajits/agentbreeder-sidecar:latest .
-# Run:    docker run -p 8090:8090 rajits/agentbreeder-sidecar:latest
+# Build:  docker build -f Dockerfile.sidecar -t agentbreeder/agentbreeder-sidecar:latest .
+# Run:    docker run -p 8090:8090 agentbreeder/agentbreeder-sidecar:latest
 
 FROM python:3.11-slim
 

--- a/cli/commands/ui.py
+++ b/cli/commands/ui.py
@@ -53,7 +53,7 @@ services:
       retries: 5
 
   migrate:
-    image: rajits/agentbreeder-api:latest
+    image: agentbreeder/agentbreeder-api:latest
     command: ["alembic", "upgrade", "head"]
     environment:
       DATABASE_URL: postgresql+asyncpg://agentbreeder:agentbreeder@postgres:5432/agentbreeder
@@ -63,7 +63,7 @@ services:
     restart: "no"
 
   api:
-    image: rajits/agentbreeder-api:latest
+    image: agentbreeder/agentbreeder-api:latest
     ports:
       - "{api_port}:8000"
     environment:
@@ -89,7 +89,7 @@ services:
       start_period: 15s
 
   dashboard:
-    image: rajits/agentbreeder-dashboard:latest
+    image: agentbreeder/agentbreeder-dashboard:latest
     ports:
       - "{dashboard_port}:3001"
     depends_on:

--- a/deploy/docker-compose.quickstart.yml
+++ b/deploy/docker-compose.quickstart.yml
@@ -113,7 +113,7 @@ services:
   # ── AgentBreeder Platform ────────────────────────────────────────────
 
   migrate:
-    image: rajits/agentbreeder-api:latest
+    image: agentbreeder/agentbreeder-api:latest
     command: ["alembic", "upgrade", "head"]
     environment:
       DATABASE_URL: postgresql+asyncpg://agentbreeder:agentbreeder@postgres:5432/agentbreeder
@@ -123,7 +123,7 @@ services:
     restart: "no"
 
   api:
-    image: rajits/agentbreeder-api:latest
+    image: agentbreeder/agentbreeder-api:latest
     build:
       context: ..
       dockerfile: Dockerfile
@@ -167,7 +167,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   dashboard:
-    image: rajits/agentbreeder-dashboard:latest
+    image: agentbreeder/agentbreeder-dashboard:latest
     build:
       context: ../dashboard
       dockerfile: Dockerfile

--- a/deploy/docker-compose.standalone.yml
+++ b/deploy/docker-compose.standalone.yml
@@ -34,7 +34,7 @@ services:
       retries: 5
 
   migrate:
-    image: rajits/agentbreeder-api:latest
+    image: agentbreeder/agentbreeder-api:latest
     command: ["alembic", "upgrade", "head"]
     environment:
       DATABASE_URL: postgresql+asyncpg://agentbreeder:agentbreeder@postgres:5432/agentbreeder
@@ -44,7 +44,7 @@ services:
     restart: "no"
 
   api:
-    image: rajits/agentbreeder-api:latest
+    image: agentbreeder/agentbreeder-api:latest
     ports:
       - "8000:8000"
     environment:
@@ -69,7 +69,7 @@ services:
       start_period: 15s
 
   dashboard:
-    image: rajits/agentbreeder-dashboard:latest
+    image: agentbreeder/agentbreeder-dashboard:latest
     ports:
       - "3001:3001"
     depends_on:

--- a/docs/architecture/platform-v2.md
+++ b/docs/architecture/platform-v2.md
@@ -320,7 +320,7 @@ CLAUDE.md §"Sidecar Pattern (Planned)" describes this. v2 needs it real because
 
 ### Acceptance criteria
 - [ ] New top-level dir `sidecar/` with Go binary
-- [ ] Image published as `rajits/agentbreeder-sidecar:<version>`
+- [ ] Image published as `agentbreeder/agentbreeder-sidecar:<version>`
 - [ ] Auto-injected by deployers (ECS task def, Cloud Run multi-container, K8s pod, docker-compose) when `agent.yaml` has any of: `guardrails:`, `tools:` (with MCP), `a2a:`
 - [ ] OTel exporter configurable per workspace
 - [ ] Cost events written to `audit_log` and `costs` tables

--- a/engine/sidecar/__init__.py
+++ b/engine/sidecar/__init__.py
@@ -2,7 +2,7 @@
 
 Originated from issue #73 (OTel observability) — generalised in Track J of the
 v2 platform spec to handle tracing, cost, guardrails, A2A, and MCP in one Go
-binary (rajits/agentbreeder-sidecar).
+binary (agentbreeder/agentbreeder-sidecar).
 
 Usage from a deployer:
 

--- a/engine/sidecar/config.py
+++ b/engine/sidecar/config.py
@@ -12,7 +12,7 @@ from typing import Any
 
 # Single source of truth for the sidecar image — kept as a constant so deployers
 # never accidentally diverge.
-DEFAULT_SIDECAR_IMAGE = "rajits/agentbreeder-sidecar:latest"
+DEFAULT_SIDECAR_IMAGE = "agentbreeder/agentbreeder-sidecar:latest"
 
 # Valid port range for sidecar port-number fields.
 _MIN_PORT = 1

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -99,12 +99,12 @@ go build -o sidecar ./cmd/sidecar
 # Docker (multi-arch)
 docker buildx build \
   --platform linux/amd64,linux/arm64 \
-  --tag rajits/agentbreeder-sidecar:dev \
+  --tag agentbreeder/agentbreeder-sidecar:dev \
   --build-arg VERSION=dev \
   -f Dockerfile .
 
 # Tag matches the AgentBreeder release version in CI:
-# rajits/agentbreeder-sidecar:<version>
+# agentbreeder/agentbreeder-sidecar:<version>
 ```
 
 Final image is built `FROM gcr.io/distroless/static-debian12:nonroot` — < 20 MB, no shell, runs as non-root.
@@ -119,7 +119,7 @@ docker run --rm \
   -e AGENT_AUTH_TOKEN=dev-token \
   -e AGENTBREEDER_SIDECAR_AGENT_URL=http://host.docker.internal:8081 \
   -p 8080:8080 \
-  rajits/agentbreeder-sidecar:dev
+  agentbreeder/agentbreeder-sidecar:dev
 
 # Then verify:
 curl http://localhost:8080/health
@@ -159,4 +159,4 @@ To disable injection (local development), set `AGENTBREEDER_SIDECAR=disabled` in
 
 ## Versioning
 
-The sidecar binary version is independent of the AgentBreeder platform version. CI tags the image as `rajits/agentbreeder-sidecar:<release-version>` whenever the platform releases.
+The sidecar binary version is independent of the AgentBreeder platform version. CI tags the image as `agentbreeder/agentbreeder-sidecar:<release-version>` whenever the platform releases.

--- a/sidecar/examples/compose/docker-compose.yml
+++ b/sidecar/examples/compose/docker-compose.yml
@@ -12,7 +12,7 @@
 
 services:
   sidecar:
-    image: rajits/agentbreeder-sidecar:latest
+    image: agentbreeder/agentbreeder-sidecar:latest
     environment:
       AGENT_NAME: demo-agent
       AGENT_AUTH_TOKEN: ${AGENT_AUTH_TOKEN}
@@ -31,7 +31,7 @@ services:
     # Replace with your runtime image. Must:
     #  - listen on :8081 when AGENTBREEDER_SIDECAR_PORT=8081 is set;
     #  - validate AGENT_AUTH_TOKEN itself (defence in depth).
-    image: rajits/agentbreeder-runtime-langgraph:latest
+    image: agentbreeder/agentbreeder-runtime-langgraph:latest
     environment:
       AGENT_NAME: demo-agent
       AGENT_AUTH_TOKEN: ${AGENT_AUTH_TOKEN}

--- a/tests/unit/test_sidecar_validator.py
+++ b/tests/unit/test_sidecar_validator.py
@@ -50,7 +50,7 @@ def test_validate_accepts_minimal_valid_config() -> None:
         _cfg(
             {
                 "enabled": True,
-                "image": "rajits/agentbreeder-sidecar:latest",
+                "image": "agentbreeder/agentbreeder-sidecar:latest",
                 "guardrails": ["pii_detection"],
             }
         )
@@ -62,7 +62,7 @@ def test_validate_accepts_full_valid_config() -> None:
         _cfg(
             {
                 "enabled": False,
-                "image": "rajits/agentbreeder-sidecar:v2",
+                "image": "agentbreeder/agentbreeder-sidecar:v2",
                 "guardrails": ["pii_detection", "content_filter"],
                 "otel_endpoint": "http://otel:4318",
                 "cost_tracking": True,

--- a/tests/unit/test_ui_cmd.py
+++ b/tests/unit/test_ui_cmd.py
@@ -84,8 +84,8 @@ def test_write_compose_file_creates_file(tmp_path: Path):
         content = result_path.read_text()
         assert "8000:8000" in content
         assert "3001:3001" in content
-        assert "rajits/agentbreeder-api:latest" in content
-        assert "rajits/agentbreeder-dashboard:latest" in content
+        assert "agentbreeder/agentbreeder-api:latest" in content
+        assert "agentbreeder/agentbreeder-dashboard:latest" in content
     finally:
         ui_module._AGENTBREEDER_DIR = original_dir
         ui_module._COMPOSE_PATH = original_path

--- a/website/content/docs/faq.mdx
+++ b/website/content/docs/faq.mdx
@@ -166,7 +166,7 @@ agentbreeder quickstart --reset
 
 The container is up but the React app fails to render. Almost always one of two causes.
 
-**1. Stale `rajits/agentbreeder-dashboard:latest` image cached locally**
+**1. Stale `agentbreeder/agentbreeder-dashboard:latest` image cached locally**
 
 After a fresh release, your local Docker can still hold the previous image (which had a transient React-version mismatch fixed in [PR #350](https://github.com/agentbreeder/agentbreeder/pull/350)). Force a rebuild from local source:
 
@@ -174,7 +174,7 @@ After a fresh release, your local Docker can still hold the previous image (whic
 cd /path/to/agentbreeder
 git fetch upstream && git checkout upstream/main -- deploy/docker-compose.quickstart.yml dashboard/package.json dashboard/package-lock.json
 agentbreeder down
-docker rmi rajits/agentbreeder-dashboard:latest rajits/agentbreeder-api:latest 2>/dev/null
+docker rmi agentbreeder/agentbreeder-dashboard:latest agentbreeder/agentbreeder-api:latest 2>/dev/null
 docker compose -f deploy/docker-compose.quickstart.yml build --no-cache dashboard api
 agentbreeder quickstart --dev
 ```

--- a/website/content/docs/how-to.mdx
+++ b/website/content/docs/how-to.mdx
@@ -471,7 +471,7 @@ Full lifecycle for each: [MCP Servers](mcp-servers) · [Evaluations](evaluations
 
 ## CI/CD
 
-The `rajits/agentbreeder-cli` Docker image is the recommended way to run AgentBreeder in pipelines.
+The `agentbreeder/agentbreeder-cli` Docker image is the recommended way to run AgentBreeder in pipelines.
 
 <Tabs items={['GitHub Actions', 'GitLab CI']}>
   <Tab value="GitHub Actions">
@@ -486,14 +486,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: docker run --rm -v $PWD:/work -w /work rajits/agentbreeder-cli validate agents/support-agent/agent.yaml
-      - run: docker run --rm -v $PWD:/work -w /work -e GOOGLE_APPLICATION_CREDENTIALS=/work/sa.json rajits/agentbreeder-cli deploy agents/support-agent/agent.yaml --target cloud-run
+      - run: docker run --rm -v $PWD:/work -w /work agentbreeder/agentbreeder-cli validate agents/support-agent/agent.yaml
+      - run: docker run --rm -v $PWD:/work -w /work -e GOOGLE_APPLICATION_CREDENTIALS=/work/sa.json agentbreeder/agentbreeder-cli deploy agents/support-agent/agent.yaml --target cloud-run
 ```
   </Tab>
   <Tab value="GitLab CI">
 ```yaml
 deploy-agent:
-  image: rajits/agentbreeder-cli:latest
+  image: agentbreeder/agentbreeder-cli:latest
   script:
     - agentbreeder validate agents/support-agent/agent.yaml
     - agentbreeder deploy agents/support-agent/agent.yaml --target cloud-run
@@ -545,6 +545,6 @@ Default login: `admin@agentbreeder.local` / `plant`. **Change this before exposi
 | `Container build failed` | `docker info` to confirm runtime is up; `agentbreeder deploy --dry-run` to inspect generated Dockerfile. |
 | `Deploy rolled back` | The 8-step pipeline is atomic. `agentbreeder status <agent>` and `agentbreeder logs <agent>` to find the failed step. |
 | Dashboard won't start | Needs the API up first. `agentbreeder ui` or `docker compose up`. See [Quickstart](quickstart). |
-| Dashboard at `:3001` renders blank | Stale `rajits/agentbreeder-dashboard:latest` cached locally — `docker rmi` it then re-run with `agentbreeder quickstart --dev` to rebuild from source. See [FAQ](faq#dashboard-at-httplocalhost3001-shows-a-blank-page). |
+| Dashboard at `:3001` renders blank | Stale `agentbreeder/agentbreeder-dashboard:latest` cached locally — `docker rmi` it then re-run with `agentbreeder quickstart --dev` to rebuild from source. See [FAQ](faq#dashboard-at-httplocalhost3001-shows-a-blank-page). |
 | `migrate-1` exits immediately | Expected — it's a one-shot alembic job. Only a problem if exit code is non-zero. |
 | `Cannot connect to docker socket` after switching runtimes | Stale `DOCKER_HOST` env var pointing at a dead socket. `unset DOCKER_HOST` and remove the `export` line from your shell rc. |

--- a/website/content/docs/quickstart.mdx
+++ b/website/content/docs/quickstart.mdx
@@ -82,7 +82,7 @@ The 8-step deploy pipeline (parse → RBAC → resolve deps → build container 
 | Container daemon not running | Quickstart will tell you what to start (Docker Desktop, OrbStack, Colima, Podman, systemd, etc.) and re-detect after you confirm. |
 | Stack already up, ports stuck | `agentbreeder down --clean` then retry. |
 | No LLM provider | Quickstart prompts to install Ollama; or run `agentbreeder setup` separately for the full provider wizard. |
-| Dashboard at `:3001` is blank | Stale `rajits/agentbreeder-dashboard:latest` cached locally. `docker rmi` it, then `agentbreeder quickstart --dev` to rebuild from source. Full steps: [FAQ →](faq#dashboard-at-httplocalhost3001-shows-a-blank-page) |
+| Dashboard at `:3001` is blank | Stale `agentbreeder/agentbreeder-dashboard:latest` cached locally. `docker rmi` it, then `agentbreeder quickstart --dev` to rebuild from source. Full steps: [FAQ →](faq#dashboard-at-httplocalhost3001-shows-a-blank-page) |
 | `migrate-1` shows `Exited` | Expected — `migrate` is a one-shot job that runs `alembic upgrade head` and exits. Only worry if the exit code is non-zero. |
 | `DOCKER_HOST` points at a dead socket | Leftover from a previous Docker/Rancher install. `unset DOCKER_HOST` (and remove the `export` line from your shell rc). |
 

--- a/website/content/docs/sidecar.mdx
+++ b/website/content/docs/sidecar.mdx
@@ -20,7 +20,7 @@ One binary, every language, every wired-up deployer.
 
 ## When the sidecar is injected
 
-The deploy pipeline auto-injects `rajits/agentbreeder-sidecar:<version>` whenever your `agent.yaml` declares any of:
+The deploy pipeline auto-injects `agentbreeder/agentbreeder-sidecar:<version>` whenever your `agent.yaml` declares any of:
 
 - `guardrails:` — a list of egress rules (PII, content filter, custom)
 - MCP `tools:` — any `tools:` entry that resolves to an MCP server
@@ -238,7 +238,7 @@ docker run --rm \
   -e AGENT_AUTH_TOKEN=$(openssl rand -hex 16) \
   -e AGENTBREEDER_SIDECAR_AGENT_URL=http://host.docker.internal:8081 \
   -p 8080:8080 \
-  rajits/agentbreeder-sidecar:latest
+  agentbreeder/agentbreeder-sidecar:latest
 ```
 
 A complete docker-compose example lives at `sidecar/examples/compose/`.
@@ -259,8 +259,8 @@ go build -o sidecar ./cmd/sidecar
 # Multi-arch image
 docker buildx build \
   --platform linux/amd64,linux/arm64 \
-  --tag rajits/agentbreeder-sidecar:dev \
+  --tag agentbreeder/agentbreeder-sidecar:dev \
   -f Dockerfile .
 ```
 
-The sidecar binary is built in CI and published as `rajits/agentbreeder-sidecar:<version>` on each AgentBreeder platform release.
+The sidecar binary is built in CI and published as `agentbreeder/agentbreeder-sidecar:<version>` on each AgentBreeder platform release.


### PR DESCRIPTION
## Summary

Closes [HR-7 #408](https://github.com/agentbreeder/agentbreeder/issues/408). Renames every operational reference to the personal `rajits/` Docker Hub namespace to the org-owned `agentbreeder/` namespace.

Mechanical and symmetric: **+54 / -54** across 18 files. Historical records (CHANGELOG, ROADMAP, audit specs/plans) intentionally untouched so the migration narrative still reads correctly.

## Operational follow-ups (cannot ship from a code-only PR)

1. **Rotate CI push token** to a Docker Hub credential that can write under `agentbreeder/<image>`. Until this is in place, the release workflow will fail on the next tag.
2. **(Recommended) dual-publish for one release cycle.** Add a second `docker push` to the workflow for `agentbreeder/<image>` *and* `rajits/<image>` for one tag (the v2.3 cycle), then drop `rajits/` entirely.
3. **Release-notes banner** for users with `rajits/agentbreeder-*` literals in their local docker-compose / k8s manifests so they get a clear cut-over warning.

## Files updated (operational)

- `.github/workflows/release.yml`
- `deploy/docker-compose.quickstart.yml`, `deploy/docker-compose.standalone.yml`
- `Dockerfile.sidecar`
- `cli/commands/ui.py` (default image used by `agentbreeder ui`)
- `engine/sidecar/__init__.py`, `engine/sidecar/config.py` (sidecar image default)
- `sidecar/README.md`, `sidecar/examples/compose/docker-compose.yml`
- `tests/unit/test_sidecar_validator.py`, `tests/unit/test_ui_cmd.py`
- `website/content/docs/{faq,how-to,quickstart,sidecar}.mdx`
- `docs/architecture/platform-v2.md`
- `CONTRIBUTING.md`, `CLAUDE.md`

## Files intentionally NOT updated

- `CHANGELOG.md`, `ROADMAP.md` — historical record of releases that shipped to `rajits/`
- `docs/superpowers/specs/2026-05-18-platform-audit-design.md`, `docs/superpowers/plans/2026-05-18-platform-audit-wave-0-website.md` — narrate the migration plan itself; `rajits/` mentions are correct historically
- `homebrew/Formula/agentbreeder.rb`, `Formula/agentbreeder.rb` — reference `rajitsaha` (GitHub username), not the Docker Hub namespace; separate concern

## Test plan

- [x] `pytest tests/unit/test_ui_cmd.py tests/unit/test_sidecar_validator.py` — 34 pass
- [x] `ruff check` clean on every changed Python file
- [x] `grep -rln 'rajits/agentbreeder-' .` returns 0 operational matches (only historical files retain the string)
- [ ] After CI token rotation: verify next tag publishes successfully to `agentbreeder/<image>`
- [ ] Companion docs note in v2.3 release announcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)
