### PR TITLE
fix(security): ignore disputed PYSEC-2025-183 in pip-audit (closes #452)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -81,11 +81,18 @@ jobs:
         # Ignore CVE-2026-3219 and CVE-2026-6357 (pip): vulnerabilities in
         # the pip tool itself as shipped by the CI runner image; not in our
         # application code.
+        # Ignore PYSEC-2025-183 (PyJWT): a *disputed* advisory about weak
+        # encryption with no fixed version. The actual concern is key choice
+        # in the consuming application — PyJWT itself accepts whatever key
+        # the caller gives it. Our usage in api/services/auth.py uses HS256
+        # with `settings.jwt_secret_key`; production deployments must set a
+        # strong secret (>=32 bytes of entropy). See #452 for the risk note.
         run: |
           pip-audit --skip-editable \
             --ignore-vuln CVE-2024-23342 \
             --ignore-vuln CVE-2026-3219 \
-            --ignore-vuln CVE-2026-6357
+            --ignore-vuln CVE-2026-6357 \
+            --ignore-vuln PYSEC-2025-183
 
   # ── npm dependency audit ────────────────────────────────────────────────────
   npm-audit:


### PR DESCRIPTION
## Summary

Closes #452. Adds `PYSEC-2025-183` to the pip-audit ignore list with a justifying comment. Unblocks `Dependency Audit (pip-audit)` on every open PR.

## Why ignore (not upgrade)

`PYSEC-2025-183` is a **[disputed](https://osv.dev/vulnerability/PYSEC-2025-183) advisory** with **no fixed version**:

- The maintainer disagrees with the classification.
- The actual concern is *key choice in the consuming application* — PyJWT itself accepts whatever key the caller gives it.
- There's nothing to upgrade to.

## Our usage

`api/services/auth.py` uses HS256 with `settings.jwt_secret_key`:

```python
return jwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
```

`jwt_algorithm` defaults to `HS256` in `api/config.py`. The advisory's "weak encryption" concern reduces to "set a strong secret in production." That's an operational responsibility, not a library bug.

The justifying comment in the workflow makes this trade-off explicit:

```yaml
# Ignore PYSEC-2025-183 (PyJWT): a *disputed* advisory about weak
# encryption with no fixed version. The actual concern is key choice
# in the consuming application — PyJWT itself accepts whatever key
# the caller gives it. Our usage in api/services/auth.py uses HS256
# with `settings.jwt_secret_key`; production deployments must set a
# strong secret (>=32 bytes of entropy). See #452 for the risk note.
```

## Test plan

- [x] `pip-audit` will now skip PYSEC-2025-183 — CI's "Dependency Audit (pip-audit)" job should turn green
- [ ] Pattern matches the existing CVE-2024-23342 / CVE-2026-3219 / CVE-2026-6357 ignores already in the workflow

## Risks

- We're explicitly accepting the responsibility to set a strong `jwt_secret_key` in production. The default value in `api/config.py` is `"change-me"` — anyone running the API without overriding that is already in trouble, regardless of this advisory.
- If the advisory ever gets a real fixed version, the ignore can be removed and we'd upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
