### PR TITLE
feat(deployments): Redis-backed idempotency + job stores (closes #449)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+### v2.4 — Redis-backed DeployJobService persistence (#449)
+
+- **Hardened** `DeployJobService` no longer keeps idempotency map + job records in process memory. Two new Protocols (`IdempotencyStore`, `JobStore`) in `api/services/deploy_stores.py` with in-memory implementations for tests and Redis-backed implementations for production.
+- **TTLs** idempotency entries: 24h (per the wizard spec §6); job records: 30d (audit-friendly window).
+- **Multi-replica safe** the API can now scale horizontally — the wizard's `Idempotency-Key` dedupe + `GET /api/v1/deployments/{job_id}` reads survive restarts and load-balanced replicas.
+- **Test** 9 new tests (`fakeredis`-backed) cover get/set round-trip, TTL assertions, and restart-safety simulations (two store instances over the same Redis backend).
+
 ### v2.4 — Deployment wizard E2E specs (#446)
 
 - **Test** Six Playwright specs at `dashboard/tests/e2e/deploy-wizard-*.spec.ts` cover the wizard's happy paths (GCP greenfield, AWS BYO), the validation-failure path (Azure BYO), approval-required flow (poll → SSE handoff), draft-resume from localStorage, and the stalled-deploy failure UI.

--- a/api/main.py
+++ b/api/main.py
@@ -120,9 +120,11 @@ async def _run_first_boot_seed() -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Startup and shutdown events."""
+    from api.database import _get_redis_pool
     from api.services.deploy_event_bus import DeployEventBus
     from api.services.deploy_jobs import DeployJobService
     from api.services.deploy_orchestrator import DeployOrchestrator
+    from api.services.deploy_stores import RedisIdempotencyStore, RedisJobStore
     from api.tasks.models_sync_cron import start_background_task as _start_models_sync_cron
 
     logger.info("AgentBreeder API starting up")
@@ -130,13 +132,18 @@ async def lifespan(app: FastAPI):
     await _run_first_boot_seed()
     models_sync_task = _start_models_sync_cron()
 
-    # Wire deployment services for the wizard (epic #378, #387)
+    # Wire deployment services for the wizard (epic #378, #387). Idempotency
+    # + job records live in Redis so a multi-replica API behind a load
+    # balancer doesn't fragment its state per process. TTLs (24h idempotency
+    # / 30d job records) are enforced by Redis EXPIRE.
+    redis = _get_redis_pool()
     app.state.deploy_event_bus = DeployEventBus()
     app.state.deploy_orchestrator = DeployOrchestrator(event_bus=app.state.deploy_event_bus)
     app.state.deploy_job_service = DeployJobService(
         event_bus=app.state.deploy_event_bus,
         orchestrator=app.state.deploy_orchestrator,
-        idempotency_store={},  # TODO: wire to Redis
+        idempotency_store=RedisIdempotencyStore(redis),
+        job_store=RedisJobStore(redis),
         agent_repo=None,  # TODO: wire to AgentService/AgentRepository
     )
 

--- a/api/services/deploy_jobs.py
+++ b/api/services/deploy_jobs.py
@@ -6,9 +6,9 @@ Owns:
 - get() — returns a job's current status (team-scoped).
 - destroy_partial() — delegates to orchestrator.destroy_partial(job_id).
 
-Persistence is in-memory for this PR; swap for SQLAlchemy in a follow-up.
-The idempotency store is a dict[(team_id, key), job_id] — operators wire
-this to Redis in production.
+Persistence is delegated to ``IdempotencyStore`` + ``JobStore`` (see
+``deploy_stores.py``). In production both are Redis-backed (multi-replica
++ restart-safe); tests use in-memory implementations.
 """
 
 from __future__ import annotations
@@ -21,6 +21,7 @@ from fastapi import HTTPException, status
 from pydantic import BaseModel, Field
 
 from api.models.deploy_events import DeployJobStatus
+from api.services.deploy_stores import IdempotencyStore, JobStore
 
 
 class EnvVar(BaseModel):
@@ -70,14 +71,15 @@ class DeployJobService:
         *,
         event_bus: Any,
         orchestrator: Any,
-        idempotency_store: dict[tuple[str, str], str],
+        idempotency_store: IdempotencyStore,
+        job_store: JobStore,
         agent_repo: Any,
     ) -> None:
         self._event_bus = event_bus
         self._orchestrator = orchestrator
         self._idempotency_store = idempotency_store
+        self._job_store = job_store
         self._agent_repo = agent_repo
-        self._jobs: dict[str, DeployJobRecord] = {}
 
     async def create(
         self,
@@ -86,37 +88,26 @@ class DeployJobService:
         team_id: str,
         idempotency_key: str,
     ) -> DeployJobCreateResult:
-        """Create a deployment job, handling idempotency and approval gating.
-
-        Args:
-            payload: Deployment configuration
-            team_id: Team creating the job
-            idempotency_key: Uniqueness key (team_id + key → deduped)
-
-        Returns:
-            DeployJobCreateResult with job_id and pending_approval flag
-
-        Raises:
-            HTTPException 404: Agent not found
-            HTTPException 403: Agent belongs to another team
-        """
-        # Check idempotency store first
-        existing_id = self._idempotency_store.get((team_id, idempotency_key))
+        """Create a deployment job, handling idempotency and approval gating."""
+        # Idempotency: same (team, key) -> same job_id.
+        existing_id = await self._idempotency_store.get(team_id, idempotency_key)
         if existing_id is not None:
-            existing = self._jobs[existing_id]
-            return DeployJobCreateResult(
-                job_id=existing.job_id,
-                pending_approval=existing.pending_approval,
-            )
+            existing = await self._job_store.get(existing_id)
+            if existing is not None:
+                return DeployJobCreateResult(
+                    job_id=existing.job_id,
+                    pending_approval=existing.pending_approval,
+                )
+            # Idempotency entry points at a job that's been TTL-evicted from the
+            # job store. Treat as expired: fall through to create a fresh job.
 
-        # Fetch agent and validate team ownership
+        # Fetch agent and validate team ownership.
         agent = await self._agent_repo.get(payload.agent_id)
         if agent is None:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
         if agent.team != team_id:
             raise HTTPException(status.HTTP_403_FORBIDDEN, "Agent belongs to another team")
 
-        # Check if approval is required
         requires_approval = bool(getattr(agent, "access", {}).get("require_approval"))
         job = await self._record(
             job_id=str(uuid4()),
@@ -127,9 +118,8 @@ class DeployJobService:
             ),
             pending_approval=requires_approval,
         )
-        self._idempotency_store[(team_id, idempotency_key)] = job.job_id
+        await self._idempotency_store.set(team_id, idempotency_key, job.job_id)
 
-        # Start orchestrator if no approval required
         if not requires_approval:
             await self._orchestrator.start(job=job, event_bus=self._event_bus)
 
@@ -139,20 +129,8 @@ class DeployJobService:
         )
 
     async def get(self, job_id: str, *, team_id: str) -> DeployJobRecord:
-        """Get a deployment job by ID.
-
-        Args:
-            job_id: The job ID to fetch
-            team_id: Team requesting access
-
-        Returns:
-            DeployJobRecord with current status
-
-        Raises:
-            HTTPException 404: Job not found
-            HTTPException 403: Job belongs to another team
-        """
-        job = self._jobs.get(job_id)
+        """Get a deployment job by ID. Raises 403/404."""
+        job = await self._job_store.get(job_id)
         if job is None:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "Job not found")
         if job.team_id != team_id:
@@ -160,15 +138,7 @@ class DeployJobService:
         return job
 
     async def destroy_partial(self, job_id: str, *, team_id: str) -> None:
-        """Destroy partially-provisioned infrastructure for a job.
-
-        Args:
-            job_id: The job ID to clean up
-            team_id: Team requesting cleanup
-
-        Raises:
-            HTTPException 403, 404: From get()
-        """
+        """Destroy partially-provisioned infrastructure for a job. Raises 403/404."""
         await self.get(job_id, team_id=team_id)
         await self._orchestrator.destroy_partial(job_id)
 
@@ -181,18 +151,7 @@ class DeployJobService:
         status: DeployJobStatus,
         pending_approval: bool = False,
     ) -> DeployJobRecord:
-        """Record a job in the in-memory store.
-
-        Args:
-            job_id: Unique job identifier
-            payload: Deployment configuration
-            team_id: Owning team
-            status: Initial status
-            pending_approval: Whether approval is pending
-
-        Returns:
-            DeployJobRecord
-        """
+        """Record a job in the job store and return it."""
         job = DeployJobRecord(
             job_id=job_id,
             team_id=team_id,
@@ -204,5 +163,5 @@ class DeployJobService:
             created_at=datetime.now(UTC),
             payload=payload,
         )
-        self._jobs[job_id] = job
+        await self._job_store.put(job)
         return job

--- a/api/services/deploy_stores.py
+++ b/api/services/deploy_stores.py
@@ -1,0 +1,122 @@
+"""Persistence stores for DeployJobService — idempotency map + job records.
+
+Two seams so the service is testable without Redis:
+
+- ``IdempotencyStore`` — ``(team_id, idempotency_key) -> job_id``, 24h TTL.
+- ``JobStore`` — ``job_id -> DeployJobRecord``, 30d TTL.
+
+Production uses the Redis-backed implementations (multi-replica + restart-safe).
+Tests use the in-memory implementations, which preserve the same semantics in
+a single-process dict.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import redis.asyncio as aioredis
+
+    from api.services.deploy_jobs import DeployJobRecord
+
+
+class IdempotencyStore(Protocol):
+    """Maps (team_id, idempotency_key) -> job_id with a 24h TTL."""
+
+    async def get(self, team_id: str, key: str) -> str | None: ...
+    async def set(self, team_id: str, key: str, job_id: str) -> None: ...
+
+
+class JobStore(Protocol):
+    """Maps job_id -> DeployJobRecord with a 30d TTL."""
+
+    async def get(self, job_id: str) -> DeployJobRecord | None: ...
+    async def put(self, job: DeployJobRecord) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# In-memory implementations (tests, single-process dev)
+# ---------------------------------------------------------------------------
+
+
+class InMemoryIdempotencyStore:
+    def __init__(self) -> None:
+        self._d: dict[tuple[str, str], str] = {}
+
+    async def get(self, team_id: str, key: str) -> str | None:
+        return self._d.get((team_id, key))
+
+    async def set(self, team_id: str, key: str, job_id: str) -> None:
+        self._d[(team_id, key)] = job_id
+
+
+class InMemoryJobStore:
+    def __init__(self) -> None:
+        self._d: dict[str, DeployJobRecord] = {}
+
+    async def get(self, job_id: str) -> DeployJobRecord | None:
+        return self._d.get(job_id)
+
+    async def put(self, job: DeployJobRecord) -> None:
+        self._d[job.job_id] = job
+
+
+# ---------------------------------------------------------------------------
+# Redis-backed implementations (production)
+# ---------------------------------------------------------------------------
+
+_IDEMPOTENCY_TTL_SECONDS = 24 * 3600  # 24h
+_JOB_TTL_SECONDS = 30 * 24 * 3600  # 30d (audit-friendly window)
+_IDEMPOTENCY_KEY_TPL = "deploy_idempotency:{team_id}:{key}"
+_JOB_KEY_TPL = "deploy_job:{job_id}"
+
+
+class RedisIdempotencyStore:
+    """Stores ``(team_id, key) -> job_id`` in Redis with a 24h TTL.
+
+    Key shape: ``deploy_idempotency:{team_id}:{key}``. The value is the raw
+    ``job_id`` string. We rely on Redis's per-key TTL to expire stale entries
+    — the spec calls for 24h.
+    """
+
+    def __init__(self, redis: aioredis.Redis) -> None:
+        self._redis = redis
+
+    async def get(self, team_id: str, key: str) -> str | None:
+        return await self._redis.get(_IDEMPOTENCY_KEY_TPL.format(team_id=team_id, key=key))
+
+    async def set(self, team_id: str, key: str, job_id: str) -> None:
+        await self._redis.set(
+            _IDEMPOTENCY_KEY_TPL.format(team_id=team_id, key=key),
+            job_id,
+            ex=_IDEMPOTENCY_TTL_SECONDS,
+        )
+
+
+class RedisJobStore:
+    """Stores DeployJobRecord JSON in Redis with a 30-day TTL.
+
+    Key shape: ``deploy_job:{job_id}``. Value is ``model_dump_json()``. A 30d
+    TTL gives operators a generous window for post-incident debugging without
+    keeping records forever — Postgres persistence is a separate follow-up.
+    """
+
+    def __init__(self, redis: aioredis.Redis) -> None:
+        self._redis = redis
+
+    async def get(self, job_id: str) -> DeployJobRecord | None:
+        # Import here to avoid a circular at module load (deploy_jobs imports
+        # back into types defined elsewhere).
+        from api.services.deploy_jobs import DeployJobRecord
+
+        raw = await self._redis.get(_JOB_KEY_TPL.format(job_id=job_id))
+        if raw is None:
+            return None
+        return DeployJobRecord.model_validate_json(raw)
+
+    async def put(self, job: DeployJobRecord) -> None:
+        await self._redis.set(
+            _JOB_KEY_TPL.format(job_id=job.job_id),
+            job.model_dump_json(),
+            ex=_JOB_TTL_SECONDS,
+        )

--- a/tests/integration/test_deployments_create_job.py
+++ b/tests/integration/test_deployments_create_job.py
@@ -33,11 +33,14 @@ def _stub_services():
         )
     )
 
+    from api.services.deploy_stores import InMemoryIdempotencyStore, InMemoryJobStore
+
     bus = DeployEventBus()
     svc = DeployJobService(
         event_bus=bus,
         orchestrator=orchestrator,
-        idempotency_store={},
+        idempotency_store=InMemoryIdempotencyStore(),
+        job_store=InMemoryJobStore(),
         agent_repo=agent_repo,
     )
     app.state.deploy_event_bus = bus

--- a/tests/integration/test_deployments_sse_stream.py
+++ b/tests/integration/test_deployments_sse_stream.py
@@ -32,11 +32,14 @@ def _stub_services():
         return_value=MagicMock(team="engineering", access={"require_approval": False})
     )
 
+    from api.services.deploy_stores import InMemoryIdempotencyStore, InMemoryJobStore
+
     bus = DeployEventBus()
     svc = DeployJobService(
         event_bus=bus,
         orchestrator=orchestrator,
-        idempotency_store={},
+        idempotency_store=InMemoryIdempotencyStore(),
+        job_store=InMemoryJobStore(),
         agent_repo=agent_repo,
     )
 

--- a/tests/unit/test_deploy_jobs_service.py
+++ b/tests/unit/test_deploy_jobs_service.py
@@ -27,16 +27,26 @@ def orchestrator() -> MagicMock:
 
 
 @pytest.fixture
-def idempotency_store() -> dict:
-    return {}
+def idempotency_store():
+    from api.services.deploy_stores import InMemoryIdempotencyStore
+
+    return InMemoryIdempotencyStore()
 
 
 @pytest.fixture
-def service(event_bus, orchestrator, idempotency_store) -> DeployJobService:
+def job_store():
+    from api.services.deploy_stores import InMemoryJobStore
+
+    return InMemoryJobStore()
+
+
+@pytest.fixture
+def service(event_bus, orchestrator, idempotency_store, job_store) -> DeployJobService:
     return DeployJobService(
         event_bus=event_bus,
         orchestrator=orchestrator,
         idempotency_store=idempotency_store,
+        job_store=job_store,
         agent_repo=AsyncMock(),
     )
 

--- a/tests/unit/test_deploy_stores.py
+++ b/tests/unit/test_deploy_stores.py
@@ -1,0 +1,143 @@
+"""DeployStores: in-memory + Redis idempotency / job stores (#449)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from api.models.deploy_events import DeployJobStatus
+from api.services.deploy_jobs import DeployJobCreate, DeployJobRecord
+from api.services.deploy_stores import (
+    InMemoryIdempotencyStore,
+    InMemoryJobStore,
+    RedisIdempotencyStore,
+    RedisJobStore,
+)
+
+
+def _record(job_id: str = "j-1", team_id: str = "t1") -> DeployJobRecord:
+    return DeployJobRecord(
+        job_id=job_id,
+        team_id=team_id,
+        agent_id="a-1",
+        cloud="gcp",
+        region="us-central1",
+        status=DeployJobStatus.pending,
+        pending_approval=False,
+        created_at=datetime.now(UTC),
+        payload=DeployJobCreate.model_validate(
+            {
+                "agent_id": "a-1",
+                "cloud": "gcp",
+                "region": "us-central1",
+                "infra_mode": "provision",
+                "byo_fields": {},
+                "env_vars": [],
+                "secrets": [],
+                "scaling": {"min": 1, "max": 3, "cpu_target_pct": 70},
+                "db_tier": None,
+            }
+        ),
+    )
+
+
+# -- In-memory ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inmemory_idempotency_get_set_roundtrip() -> None:
+    store = InMemoryIdempotencyStore()
+    assert await store.get("t1", "k1") is None
+    await store.set("t1", "k1", "j-1")
+    assert await store.get("t1", "k1") == "j-1"
+
+
+@pytest.mark.asyncio
+async def test_inmemory_idempotency_per_team_isolation() -> None:
+    store = InMemoryIdempotencyStore()
+    await store.set("t1", "k1", "j-1")
+    await store.set("t2", "k1", "j-2")
+    assert await store.get("t1", "k1") == "j-1"
+    assert await store.get("t2", "k1") == "j-2"
+
+
+@pytest.mark.asyncio
+async def test_inmemory_job_store_put_get() -> None:
+    store = InMemoryJobStore()
+    assert await store.get("j-1") is None
+    job = _record()
+    await store.put(job)
+    fetched = await store.get("j-1")
+    assert fetched is not None
+    assert fetched.job_id == "j-1"
+    assert fetched.team_id == "t1"
+
+
+# -- Redis-backed (via fakeredis) -------------------------------------------
+
+
+@pytest.fixture
+def fake_redis():
+    fakeredis = pytest.importorskip("fakeredis.aioredis")
+    return fakeredis.FakeRedis(decode_responses=True)
+
+
+@pytest.mark.asyncio
+async def test_redis_idempotency_get_set_roundtrip(fake_redis) -> None:
+    store = RedisIdempotencyStore(fake_redis)
+    assert await store.get("t1", "k1") is None
+    await store.set("t1", "k1", "j-1")
+    assert await store.get("t1", "k1") == "j-1"
+
+
+@pytest.mark.asyncio
+async def test_redis_idempotency_24h_ttl(fake_redis) -> None:
+    store = RedisIdempotencyStore(fake_redis)
+    await store.set("t1", "k1", "j-1")
+    # Confirm the TTL was set (not -1 = no TTL, not -2 = key absent).
+    ttl = await fake_redis.ttl("deploy_idempotency:t1:k1")
+    # Allow ±60s wiggle for fakeredis clock; 24h = 86400s.
+    assert 86000 < ttl <= 86400
+
+
+@pytest.mark.asyncio
+async def test_redis_job_store_put_get(fake_redis) -> None:
+    store = RedisJobStore(fake_redis)
+    assert await store.get("j-1") is None
+    await store.put(_record())
+    fetched = await store.get("j-1")
+    assert fetched is not None
+    assert fetched.job_id == "j-1"
+    assert fetched.status == DeployJobStatus.pending
+
+
+@pytest.mark.asyncio
+async def test_redis_job_store_30d_ttl(fake_redis) -> None:
+    store = RedisJobStore(fake_redis)
+    await store.put(_record())
+    ttl = await fake_redis.ttl("deploy_job:j-1")
+    # 30d = 2_592_000s
+    assert 2_591_000 < ttl <= 2_592_000
+
+
+@pytest.mark.asyncio
+async def test_redis_stores_survive_service_restart_simulation(fake_redis) -> None:
+    """Round-trip across two 'instances' of the store backed by the same Redis."""
+    write_store = RedisJobStore(fake_redis)
+    await write_store.put(_record(job_id="j-survive"))
+
+    # New store instance — simulates a freshly-restarted API replica.
+    read_store = RedisJobStore(fake_redis)
+    fetched = await read_store.get("j-survive")
+    assert fetched is not None
+    assert fetched.job_id == "j-survive"
+
+
+@pytest.mark.asyncio
+async def test_redis_idempotency_survives_restart(fake_redis) -> None:
+    write_store = RedisIdempotencyStore(fake_redis)
+    await write_store.set("t1", "k-survive", "j-survive")
+
+    read_store = RedisIdempotencyStore(fake_redis)
+    assert await read_store.get("t1", "k-survive") == "j-survive"


### PR DESCRIPTION
## Summary

Closes #449. Moves `DeployJobService`'s idempotency map and job records out of process memory and into Redis. Unblocks running the API on more than one replica behind a load balancer (today's in-memory state would diverge per process and break idempotency).

## What changed

### `api/services/deploy_stores.py` (new, 122 LOC)

Two thin Protocols + four implementations:

```python
class IdempotencyStore(Protocol):
    async def get(self, team_id: str, key: str) -> str | None: ...
    async def set(self, team_id: str, key: str, job_id: str) -> None: ...

class JobStore(Protocol):
    async def get(self, job_id: str) -> DeployJobRecord | None: ...
    async def put(self, job: DeployJobRecord) -> None: ...
```

- `InMemoryIdempotencyStore`, `InMemoryJobStore` — single-process dicts; for tests
- `RedisIdempotencyStore` — `deploy_idempotency:{team_id}:{key}` → `job_id`, **24h TTL**
- `RedisJobStore` — `deploy_job:{job_id}` → `model_dump_json()`, **30d TTL** (audit-friendly window)

### `api/services/deploy_jobs.py`

- `DeployJobService.__init__` now takes `idempotency_store: IdempotencyStore` + `job_store: JobStore` instead of a raw `dict` + a hand-rolled `self._jobs` dict.
- All accessors are `await`-ed. Behaviour unchanged: same idempotency dedupe, same 403/404 semantics, same approval-gating.
- Defensive: if an idempotency entry points at a job that's been TTL-evicted from the job store, we treat it as expired and create a fresh job rather than returning a stale reference.

### `api/main.py`

Lifespan startup now uses `_get_redis_pool()` (the existing helper in `api/database.py`) to construct `RedisIdempotencyStore` + `RedisJobStore`. No new env vars — `settings.redis_url` is already required.

### Tests

- `tests/unit/test_deploy_stores.py` (new, 9 tests):
  - In-memory get/set/put round-trip + per-team isolation
  - Redis (via `fakeredis`) get/set/put round-trip
  - **24h TTL** assertion via `redis.ttl()` after set
  - **30d TTL** assertion for job records
  - **Restart-safety:** two store instances over the same Redis backend — write with one, read with the other — confirms cross-replica state.
- `tests/unit/test_deploy_jobs_service.py` — fixtures now wire the in-memory stores. 7 existing tests still pass.
- `tests/integration/test_deployments_create_job.py` + `test_deployments_sse_stream.py` — same fixture swap.

**24/24 tests pass locally.** mypy clean, ruff clean, format clean.

## Risks

- **Redis dependency is now hard for production.** It was already required by `api/database.py`'s session middleware, so this isn't a new ask, but worth flagging.
- **Job records live in Redis for 30 days** then TTL-expire. Audit trail beyond that window depends on the `audit_log` table (separate concern) and the per-job SSE ring buffer (lives in memory, 30-min TTL — by design).
- The defensive "idempotency points at expired job → treat as fresh" branch could mask a Redis bug if you ever see *new* job_ids returned for repeated `Idempotency-Key` headers. Flag and investigate; don't suppress.

## Followup

- #450 — `DeployOrchestrator.destroy_partial` real wiring (sibling TODO from #447, in flight next).
- A future PR moves `DeployJobRecord` from Redis-only to Postgres-backed (`alembic` migration + dual-write during cutover). Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
