### PR TITLE
feat(cli): login/logout/whoami + keychain token storage (closes #415)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+### v2.4 — CLI `login` / `logout` / `whoami` + keychain token storage (#415)
+
+- **Added** three new top-level commands — `agentbreeder login`, `agentbreeder logout`, `agentbreeder whoami` — plus an `agentbreeder auth` sub-app with the same commands for discoverability. Tokens are stored in the OS keychain (macOS Keychain, GNOME libsecret, Windows Credential Manager) via the existing `keyring>=24.0.0` dependency; the `AGENTBREEDER_API_TOKEN` env var still wins over the keychain so CI keeps working unchanged.
+- **Added** `agentbreeder context use <team>` / `show` / `clear` for users who belong to multiple teams. Active team is persisted to `~/.agentbreeder/context.json` and sent on every authenticated request as the `X-AgentBreeder-Team` header.
+- **Refactor** new `cli/_http.py` consolidates the duplicate `_auth_headers()` / `_api_base()` / `_post()` / `_get()` / `_post_multipart()` / `_request()` helpers that lived in `cli/commands/registry_cmd.py` and `cli/commands/model.py`. Both files now delegate to the shared module; behavior is unchanged for users.
+- **DX** the "no token" error now points to `agentbreeder login` instead of telling users to curl `/api/v1/auth/login` and `export` the response themselves. A 401 on any authenticated call surfaces a "your token has expired" hint with the same direction.
+- **Test** 36 new unit tests cover token storage (env-wins-over-keychain precedence, headless fallback, set/clear round-trips), `auth_headers()` composition, the `request()` helper's success/4xx/401 paths, and the user-facing `login` / `logout` / `whoami` / `context` flows via `typer.testing.CliRunner`.
+- **Docs** new "CLI login" section in `website/content/docs/authentication.mdx`; new `agentbreeder login` / `logout` / `whoami` / `context` entries in `website/content/docs/cli-reference.mdx`.
+
 ### v2.4 — DeployOrchestrator.destroy_partial wires to provisioner.destroy() (#450)
 
 - **Wired** the "Roll back" button in the deployment wizard now actually rolls back. `DeployOrchestrator.start()` persists the returned `InfraState` onto the job record after `provisioner.provision()`; `destroy_partial(job_id)` reloads it and calls `provisioner_for(state.cloud).destroy(state)`.

--- a/cli/_http.py
+++ b/cli/_http.py
@@ -1,0 +1,295 @@
+"""Shared HTTP client + token storage for the AgentBreeder CLI.
+
+Single source of truth for:
+
+* Resolving the API base URL (``AGENTBREEDER_URL`` → ``AGENTBREEDER_API_URL`` →
+  ``http://localhost:8000``).
+* Reading the bearer token from the OS keychain or the
+  ``AGENTBREEDER_API_TOKEN`` env var (env wins, for CI use).
+* Reading and writing the active team context from
+  ``~/.agentbreeder/context.json``.
+* Producing authenticated ``httpx`` clients (sync and async).
+* A ``request()`` convenience that replaces the per-file ``_post`` / ``_get`` /
+  ``_request`` helpers in ``cli/commands/registry_cmd.py`` and
+  ``cli/commands/model.py``.
+
+CLI commands should depend on this module instead of reading the env vars
+directly so that token storage can evolve in one place.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from contextlib import asynccontextmanager, contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import typer
+from rich.console import Console
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
+__all__ = [
+    "ENV_TOKEN",
+    "ENV_URL",
+    "ENV_URL_LEGACY",
+    "api_base",
+    "auth_headers",
+    "authenticated_client",
+    "authenticated_sync_client",
+    "clear_active_team",
+    "clear_token",
+    "context_path",
+    "get_active_team",
+    "get_token",
+    "request",
+    "require_token",
+    "set_active_team",
+    "set_token",
+]
+
+console = Console()
+
+ENV_TOKEN = "AGENTBREEDER_API_TOKEN"
+ENV_URL = "AGENTBREEDER_URL"
+ENV_URL_LEGACY = "AGENTBREEDER_API_URL"
+
+_KEYRING_SERVICE = "agentbreeder"
+_KEYRING_USERNAME = "api_token"
+_CONTEXT_DIR_ENV = "AGENTBREEDER_HOME"
+_DEFAULT_API_URL = "http://localhost:8000"
+
+
+# ── URL ──────────────────────────────────────────────────────────────────────
+
+
+def api_base() -> str:
+    """Return the API base URL with no trailing slash.
+
+    Honors ``AGENTBREEDER_URL`` first (the documented variable), then the
+    legacy ``AGENTBREEDER_API_URL`` for back-compat with v2.3 callers.
+    """
+    raw = os.getenv(ENV_URL) or os.getenv(ENV_URL_LEGACY) or _DEFAULT_API_URL
+    return raw.rstrip("/")
+
+
+# ── Keychain helpers ─────────────────────────────────────────────────────────
+
+
+def _try_keyring() -> Any | None:
+    """Return the ``keyring`` module if usable, else ``None``.
+
+    Headless environments (Docker, CI) commonly have no backend; we degrade to
+    env-var-only token storage silently.
+    """
+    try:
+        import keyring  # noqa: PLC0415 — optional, only used when present
+
+        keyring.get_keyring()  # raises NoKeyringError if no backend installed
+    except Exception:
+        return None
+    return keyring
+
+
+def get_token() -> str | None:
+    """Return the bearer token, or ``None`` if none is configured.
+
+    Priority: env var ``AGENTBREEDER_API_TOKEN`` (so CI can always override) →
+    OS keychain.
+    """
+    env = os.getenv(ENV_TOKEN, "").strip()
+    if env:
+        return env
+    kr = _try_keyring()
+    if kr is None:
+        return None
+    try:
+        value = kr.get_password(_KEYRING_SERVICE, _KEYRING_USERNAME)
+    except Exception:
+        return None
+    if not value:
+        return None
+    return str(value)
+
+
+def set_token(token: str) -> None:
+    """Store ``token`` in the OS keychain. Raises ``RuntimeError`` if unavailable."""
+    if not token.strip():
+        raise ValueError("token must not be empty")
+    kr = _try_keyring()
+    if kr is None:
+        raise RuntimeError(
+            "No OS keychain backend available. Install one (e.g. macOS Keychain, "
+            "GNOME libsecret) or export AGENTBREEDER_API_TOKEN instead."
+        )
+    kr.set_password(_KEYRING_SERVICE, _KEYRING_USERNAME, token.strip())
+
+
+def clear_token() -> bool:
+    """Delete the stored token. Returns ``True`` if one was removed."""
+    kr = _try_keyring()
+    if kr is None:
+        return False
+    try:
+        existing = kr.get_password(_KEYRING_SERVICE, _KEYRING_USERNAME)
+        if not existing:
+            return False
+        kr.delete_password(_KEYRING_SERVICE, _KEYRING_USERNAME)
+    except Exception:
+        return False
+    return True
+
+
+def require_token() -> str:
+    """Return the bearer token or exit with a friendly error if none is set."""
+    token = get_token()
+    if not token:
+        console.print(
+            f"[red]Not logged in.[/red] Run [bold]agentbreeder login[/bold] or set ${ENV_TOKEN}."
+        )
+        raise typer.Exit(code=1)
+    return token
+
+
+# ── Active team context ──────────────────────────────────────────────────────
+
+
+def context_path() -> Path:
+    """Return the path to the CLI context file (``~/.agentbreeder/context.json``)."""
+    base = os.getenv(_CONTEXT_DIR_ENV)
+    root = Path(base) if base else Path.home() / ".agentbreeder"
+    return root / "context.json"
+
+
+def _read_context() -> dict[str, Any]:
+    path = context_path()
+    if not path.exists():
+        return {}
+    try:
+        parsed = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return {}
+    if isinstance(parsed, dict):
+        return parsed
+    return {}
+
+
+def _write_context(data: dict[str, Any]) -> None:
+    path = context_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True))
+
+
+def get_active_team() -> str | None:
+    """Return the active team slug, or ``None`` if none is set."""
+    return _read_context().get("team")
+
+
+def set_active_team(team: str) -> None:
+    if not team.strip():
+        raise ValueError("team must not be empty")
+    data = _read_context()
+    data["team"] = team.strip()
+    _write_context(data)
+
+
+def clear_active_team() -> None:
+    data = _read_context()
+    data.pop("team", None)
+    _write_context(data)
+
+
+# ── HTTP helpers ─────────────────────────────────────────────────────────────
+
+
+def auth_headers(*, json_body: bool = True) -> dict[str, str]:
+    """Return headers with bearer token. Exits if no token is set."""
+    token = require_token()
+    headers = {"Authorization": f"Bearer {token}"}
+    if json_body:
+        headers["Content-Type"] = "application/json"
+    team = get_active_team()
+    if team:
+        headers["X-AgentBreeder-Team"] = team
+    return headers
+
+
+@contextmanager
+def authenticated_sync_client(*, timeout: float = 30.0) -> Iterator[httpx.Client]:
+    """Yield a sync ``httpx.Client`` with bearer + base URL pre-wired."""
+    headers = auth_headers()
+    with httpx.Client(base_url=api_base(), headers=headers, timeout=timeout) as client:
+        yield client
+
+
+@asynccontextmanager
+async def authenticated_client(*, timeout: float = 30.0) -> AsyncIterator[httpx.AsyncClient]:
+    """Yield an async ``httpx.AsyncClient`` with bearer + base URL pre-wired.
+
+    Use when streaming SSE or running concurrent requests (e.g. ``deploy
+    --remote``). For one-shot sync calls, prefer :func:`request`.
+    """
+    headers = auth_headers()
+    async with httpx.AsyncClient(base_url=api_base(), headers=headers, timeout=timeout) as client:
+        yield client
+
+
+def _handle_error(resp: httpx.Response, method: str, path: str) -> None:
+    if resp.status_code < 400:
+        return
+    if resp.status_code == 401:
+        console.print(
+            f"[red]{method} {path} -> 401 Unauthorized[/red] — "
+            "your token has expired or is invalid. "
+            "Run [bold]agentbreeder login[/bold]."
+        )
+    else:
+        console.print(f"[red]{method} {path} -> {resp.status_code}[/red]\n{resp.text}")
+    raise typer.Exit(code=1)
+
+
+def request(
+    method: str,
+    path: str,
+    *,
+    body: dict[str, Any] | None = None,
+    files: list[tuple[str, tuple[str, bytes, str]]] | None = None,
+    data: dict[str, str] | None = None,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Sync convenience for one-shot authenticated requests.
+
+    Returns the parsed JSON body on success; exits the CLI with a friendly
+    error message on any non-2xx response. Supports both JSON bodies (via
+    ``body=``) and multipart uploads (via ``files=``).
+    """
+    method_up = method.upper()
+    url = f"{api_base()}{path}"
+    if files is not None:
+        headers = auth_headers(json_body=False)
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.post(url, headers=headers, files=files, data=data or {})
+    else:
+        headers = auth_headers()
+        with httpx.Client(timeout=timeout) as client:
+            if method_up == "GET":
+                resp = client.get(url, headers=headers)
+            elif method_up == "POST":
+                resp = client.post(url, headers=headers, json=body or {})
+            elif method_up == "PUT":
+                resp = client.put(url, headers=headers, json=body or {})
+            elif method_up == "DELETE":
+                resp = client.delete(url, headers=headers)
+            else:
+                raise ValueError(f"Unsupported method: {method}")
+    _handle_error(resp, method_up, path)
+    try:
+        parsed = resp.json()
+    except ValueError:
+        return {"data": resp.text}
+    if isinstance(parsed, dict):
+        return parsed
+    return {"data": parsed}

--- a/cli/commands/auth.py
+++ b/cli/commands/auth.py
@@ -1,0 +1,192 @@
+"""agentbreeder login / logout / whoami — authentication commands.
+
+Replaces the previous workflow of "go to the dashboard, copy a JWT,
+``export AGENTBREEDER_API_TOKEN=...``". Tokens now live in the OS keychain;
+the env var still wins when set, so CI configurations keep working.
+
+Designed to compose with sibling work:
+
+* ``agentbreeder deploy --remote`` (#416) reads ``get_token()`` from
+  :mod:`cli._http` to authenticate POSTs to ``/api/v1/deploys``.
+* ``agentbreeder context use <team>`` (this module) sets the active team
+  that's surfaced by ``whoami`` and sent on every API call as the
+  ``X-AgentBreeder-Team`` header.
+"""
+
+from __future__ import annotations
+
+import json as _json
+from typing import Any
+
+import httpx
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from cli import _http
+
+console = Console()
+
+auth_app = typer.Typer(name="auth", help="Log in, log out, and inspect the current user.")
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _fetch_me(token: str, api_url: str | None = None) -> dict[str, Any]:
+    """Call ``GET /api/v1/auth/me`` with the given token.
+
+    Used by both ``login --token`` (to validate the pasted token) and by
+    ``whoami`` (to display profile info). Returns the user payload or exits
+    with a friendly error on auth failure.
+    """
+    base = (api_url or _http.api_base()).rstrip("/")
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    try:
+        with httpx.Client(timeout=30.0) as client:
+            resp = client.get(f"{base}/api/v1/auth/me", headers=headers)
+    except httpx.HTTPError as exc:
+        console.print(f"[red]Could not reach {base}: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    if resp.status_code == 401:
+        console.print("[red]Invalid or expired token.[/red]")
+        raise typer.Exit(code=1)
+    if resp.status_code >= 400:
+        console.print(f"[red]GET /auth/me -> {resp.status_code}[/red]\n{resp.text}")
+        raise typer.Exit(code=1)
+    payload = resp.json()
+    user = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(user, dict):
+        console.print(f"[red]Unexpected /auth/me response shape: {payload}[/red]")
+        raise typer.Exit(code=1)
+    return user
+
+
+def _store_or_warn(token: str) -> None:
+    """Persist ``token`` to keychain; warn but do not fail if unavailable."""
+    try:
+        _http.set_token(token)
+    except RuntimeError as exc:
+        console.print(
+            f"[yellow]Could not store token in keychain: {exc}[/yellow]\n"
+            f"Set [bold]{_http.ENV_TOKEN}[/bold] in your shell instead."
+        )
+
+
+# ── commands ────────────────────────────────────────────────────────────────
+
+
+@auth_app.command("login")
+def login(
+    email: str | None = typer.Option(None, "--email", "-e", help="Account email."),
+    password: str | None = typer.Option(
+        None,
+        "--password",
+        "-p",
+        help="Account password (prompted if omitted).",
+    ),
+    token: str | None = typer.Option(
+        None,
+        "--token",
+        help="Paste an existing JWT instead of using email/password.",
+    ),
+    api_url: str | None = typer.Option(
+        None, "--api-url", help="Override API URL (defaults to $AGENTBREEDER_URL)."
+    ),
+) -> None:
+    """Authenticate against the AgentBreeder API and store the resulting token.
+
+    Two modes:
+
+    * Interactive: prompts for email/password and POSTs ``/api/v1/auth/login``.
+    * ``--token``: validates the pasted JWT against ``/api/v1/auth/me``.
+
+    On success the token is written to the OS keychain. ``AGENTBREEDER_API_TOKEN``
+    in the environment still overrides keychain storage at request time, so CI
+    can short-circuit this command entirely.
+    """
+    base = (api_url or _http.api_base()).rstrip("/")
+
+    if token is not None:
+        token = token.strip()
+        if not token:
+            console.print("[red]--token cannot be empty[/red]")
+            raise typer.Exit(code=1)
+        user = _fetch_me(token, api_url=base)
+        _store_or_warn(token)
+        console.print(
+            f"[green]Logged in as[/green] [bold]{user.get('email')}[/bold] "
+            f"(team={user.get('team')}, role={user.get('role')})"
+        )
+        return
+
+    if not email:
+        email = typer.prompt("Email")
+    if not password:
+        password = typer.prompt("Password", hide_input=True)
+
+    body = {"email": email, "password": password}
+    try:
+        with httpx.Client(timeout=30.0) as client:
+            resp = client.post(
+                f"{base}/api/v1/auth/login",
+                json=body,
+                headers={"Content-Type": "application/json"},
+            )
+    except httpx.HTTPError as exc:
+        console.print(f"[red]Could not reach {base}: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+    if resp.status_code == 401:
+        console.print("[red]Invalid email or password.[/red]")
+        raise typer.Exit(code=1)
+    if resp.status_code >= 400:
+        console.print(f"[red]POST /auth/login -> {resp.status_code}[/red]\n{resp.text}")
+        raise typer.Exit(code=1)
+
+    payload = resp.json()
+    token_payload = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(token_payload, dict) or not token_payload.get("access_token"):
+        console.print(f"[red]Unexpected /auth/login response: {payload}[/red]")
+        raise typer.Exit(code=1)
+    access_token: str = token_payload["access_token"]
+    _store_or_warn(access_token)
+    user = _fetch_me(access_token, api_url=base)
+    console.print(
+        f"[green]Logged in as[/green] [bold]{user.get('email')}[/bold] "
+        f"(team={user.get('team')}, role={user.get('role')})"
+    )
+
+
+@auth_app.command("logout")
+def logout() -> None:
+    """Delete the stored token from the OS keychain."""
+    removed = _http.clear_token()
+    if removed:
+        console.print("[green]Logged out.[/green]")
+    else:
+        console.print("[yellow]No stored token to remove.[/yellow]")
+
+
+@auth_app.command("whoami")
+def whoami(
+    json_output: bool = typer.Option(False, "--json", help="Emit JSON."),
+) -> None:
+    """Show the authenticated user, role, team, and active team context."""
+    token = _http.require_token()
+    user = _fetch_me(token)
+    active_team = _http.get_active_team()
+    if json_output:
+        typer.echo(_json.dumps({**user, "active_team": active_team}, default=str, indent=2))
+        return
+
+    table = Table(show_header=False, box=None)
+    table.add_column("field", style="dim")
+    table.add_column("value")
+    table.add_row("email", str(user.get("email", "")))
+    table.add_row("name", str(user.get("name", "")))
+    table.add_row("role", str(user.get("role", "")))
+    table.add_row("team (primary)", str(user.get("team", "")))
+    table.add_row("active team", active_team or "[dim](unset — using primary)[/dim]")
+    table.add_row("id", str(user.get("id", "")))
+    console.print(table)

--- a/cli/commands/context.py
+++ b/cli/commands/context.py
@@ -1,0 +1,44 @@
+"""agentbreeder context — set or inspect the active team context.
+
+The active team is stored in ``~/.agentbreeder/context.json`` and is sent on
+every authenticated API call as the ``X-AgentBreeder-Team`` header. It lets a
+user who belongs to multiple teams say "act as team X for this session"
+without re-passing ``--team`` on every command.
+"""
+
+from __future__ import annotations
+
+import typer
+from rich.console import Console
+
+from cli import _http
+
+console = Console()
+
+context_app = typer.Typer(
+    name="context", help="Manage the active team context for subsequent commands."
+)
+
+
+@context_app.command("use")
+def use(team: str = typer.Argument(..., help="Team slug to activate.")) -> None:
+    """Set the active team for subsequent CLI calls."""
+    _http.set_active_team(team)
+    console.print(f"[green]Active team set to[/green] [bold]{team}[/bold]")
+
+
+@context_app.command("show")
+def show() -> None:
+    """Print the active team (or note that none is set)."""
+    team = _http.get_active_team()
+    if team:
+        console.print(f"Active team: [bold]{team}[/bold]")
+    else:
+        console.print("[dim]No active team set. Use `agentbreeder context use <team>`.[/dim]")
+
+
+@context_app.command("clear")
+def clear() -> None:
+    """Remove the active team override; fall back to the user's primary team."""
+    _http.clear_active_team()
+    console.print("[green]Active team cleared.[/green]")

--- a/cli/commands/model.py
+++ b/cli/commands/model.py
@@ -16,13 +16,13 @@ server-side.
 from __future__ import annotations
 
 import json as _json
-import os
 from typing import Any
 
-import httpx
 import typer
 from rich.console import Console
 from rich.table import Table
+
+from cli import _http
 
 console = Console()
 
@@ -37,37 +37,8 @@ model_app = typer.Typer(
 # ── HTTP helpers ────────────────────────────────────────────────────────────
 
 
-def _api_base() -> str:
-    return os.getenv("AGENTBREEDER_API_URL", "http://localhost:8000").rstrip("/")
-
-
-def _auth_headers() -> dict[str, str]:
-    token = os.getenv("AGENTBREEDER_API_TOKEN", "").strip()
-    if not token:
-        console.print(
-            "[red]AGENTBREEDER_API_TOKEN is not set.[/red] "
-            "Log in via /api/v1/auth/login and export the token first."
-        )
-        raise typer.Exit(code=1)
-    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
-
-
 def _request(method: str, path: str, body: dict | None = None) -> dict:
-    url = f"{_api_base()}{path}"
-    with httpx.Client(timeout=60.0) as client:
-        if method == "GET":
-            resp = client.get(url, headers=_auth_headers())
-        elif method == "POST":
-            resp = client.post(url, headers=_auth_headers(), json=body or {})
-        else:
-            raise ValueError(f"Unsupported method: {method}")
-    if resp.status_code >= 400:
-        console.print(f"[red]{method} {path} -> {resp.status_code}[/red]\n{resp.text}")
-        raise typer.Exit(code=1)
-    try:
-        return resp.json()
-    except ValueError:
-        return {"data": resp.text}
+    return _http.request(method, path, body=body, timeout=60.0)
 
 
 # ── Status badge rendering ──────────────────────────────────────────────────

--- a/cli/commands/registry_cmd.py
+++ b/cli/commands/registry_cmd.py
@@ -27,16 +27,16 @@ from __future__ import annotations
 import importlib
 import importlib.util
 import json
-import os
 import sys
 from pathlib import Path
 from typing import Any
 
-import httpx
 import typer
 import yaml
 from rich.console import Console
 from rich.table import Table
+
+from cli import _http
 
 console = Console()
 
@@ -56,28 +56,15 @@ registry_app.add_typer(rag_app, name="rag")
 
 
 def _api_base() -> str:
-    return os.getenv("AGENTBREEDER_API_URL", "http://localhost:8000").rstrip("/")
+    return _http.api_base()
 
 
 def _auth_headers() -> dict[str, str]:
-    token = os.getenv("AGENTBREEDER_API_TOKEN", "").strip()
-    if not token:
-        console.print(
-            "[red]AGENTBREEDER_API_TOKEN is not set.[/red] "
-            "Log in via /api/v1/auth/login and export the token first."
-        )
-        raise typer.Exit(code=1)
-    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    return _http.auth_headers()
 
 
 def _post(path: str, body: dict) -> dict:
-    url = f"{_api_base()}{path}"
-    with httpx.Client(timeout=30.0) as client:
-        resp = client.post(url, headers=_auth_headers(), json=body)
-        if resp.status_code >= 400:
-            console.print(f"[red]POST {path} -> {resp.status_code}[/red]\n{resp.text}")
-            raise typer.Exit(code=1)
-        return resp.json()
+    return _http.request("POST", path, body=body)
 
 
 def _post_multipart(
@@ -90,31 +77,11 @@ def _post_multipart(
     ``files`` is a list of ``(field, (filename, content, content_type))``.
     ``data`` is an optional dict of extra form fields posted alongside the files.
     """
-    url = f"{_api_base()}{path}"
-    token = os.getenv("AGENTBREEDER_API_TOKEN", "").strip()
-    if not token:
-        console.print(
-            "[red]AGENTBREEDER_API_TOKEN is not set.[/red] "
-            "Log in via /api/v1/auth/login and export the token first."
-        )
-        raise typer.Exit(code=1)
-    headers = {"Authorization": f"Bearer {token}"}
-    with httpx.Client(timeout=120.0) as client:
-        resp = client.post(url, headers=headers, files=files, data=data or {})
-        if resp.status_code >= 400:
-            console.print(f"[red]POST {path} -> {resp.status_code}[/red]\n{resp.text}")
-            raise typer.Exit(code=1)
-        return resp.json()
+    return _http.request("POST", path, files=files, data=data, timeout=120.0)
 
 
 def _get(path: str) -> dict:
-    url = f"{_api_base()}{path}"
-    with httpx.Client(timeout=30.0) as client:
-        resp = client.get(url, headers=_auth_headers())
-        if resp.status_code >= 400:
-            console.print(f"[red]GET {path} -> {resp.status_code}[/red]\n{resp.text}")
-            raise typer.Exit(code=1)
-        return resp.json()
+    return _http.request("GET", path)
 
 
 # ── prompts ────────────────────────────────────────────────────────────────

--- a/cli/main.py
+++ b/cli/main.py
@@ -175,8 +175,10 @@ def _welcome_cmd() -> None:
 
 
 from cli.commands import (
+    auth,
     chat,
     compliance,
+    context,
     deploy,
     describe,
     down,
@@ -236,6 +238,9 @@ app = typer.Typer(
 )
 
 app.command(name="welcome")(_welcome_cmd)
+app.command(name="login")(auth.login)
+app.command(name="logout")(auth.logout)
+app.command(name="whoami")(auth.whoami)
 app.command(name="quickstart")(quickstart.quickstart)
 app.command(name="seed")(seed.seed)
 app.command(name="setup")(setup.setup)
@@ -265,6 +270,8 @@ app.add_typer(template.template_app, name="template")
 app.add_typer(secret.secret_app, name="secret")
 app.add_typer(compliance.compliance_app, name="compliance")
 app.add_typer(registry_cmd.registry_app, name="registry")
+app.add_typer(auth.auth_app, name="auth")
+app.add_typer(context.context_app, name="context")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_cli_auth.py
+++ b/tests/unit/test_cli_auth.py
@@ -1,0 +1,411 @@
+"""Unit tests for cli/_http.py and the new auth/context commands (issue #415).
+
+Covers token storage (env vs keychain precedence), the shared authenticated
+HTTP helpers used by ``registry`` / ``model`` / future ``deploy --remote``,
+and the user-facing ``login`` / ``logout`` / ``whoami`` / ``context`` flows.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from cli import _http
+from cli.main import app
+
+# ── Fake keyring ────────────────────────────────────────────────────────────
+
+
+class _FakeKeyring:
+    """In-memory stand-in for the ``keyring`` module.
+
+    Mirrors ``get_password`` / ``set_password`` / ``delete_password`` /
+    ``get_keyring`` exactly enough for ``_http`` to behave as if a real OS
+    keychain is present.
+    """
+
+    def __init__(self) -> None:
+        self.store: dict[tuple[str, str], str] = {}
+
+    def get_keyring(self) -> object:
+        return self  # truthy → "backend present"
+
+    def get_password(self, service: str, user: str) -> str | None:
+        return self.store.get((service, user))
+
+    def set_password(self, service: str, user: str, value: str) -> None:
+        self.store[(service, user)] = value
+
+    def delete_password(self, service: str, user: str) -> None:
+        self.store.pop((service, user), None)
+
+
+@pytest.fixture
+def fake_keyring(monkeypatch: pytest.MonkeyPatch) -> _FakeKeyring:
+    fake = _FakeKeyring()
+    monkeypatch.setattr(_http, "_try_keyring", lambda: fake)
+    return fake
+
+
+@pytest.fixture(autouse=True)
+def isolated_context(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Redirect ``~/.agentbreeder/`` to a tmp dir for every test."""
+    monkeypatch.setenv("AGENTBREEDER_HOME", str(tmp_path))
+    monkeypatch.delenv(_http.ENV_TOKEN, raising=False)
+    monkeypatch.delenv(_http.ENV_URL, raising=False)
+    monkeypatch.delenv(_http.ENV_URL_LEGACY, raising=False)
+    return tmp_path
+
+
+runner = CliRunner()
+
+
+# ── api_base ────────────────────────────────────────────────────────────────
+
+
+class TestApiBase:
+    def test_defaults_to_localhost(self) -> None:
+        assert _http.api_base() == "http://localhost:8000"
+
+    def test_strips_trailing_slash(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_http.ENV_URL, "https://api.example.com/")
+        assert _http.api_base() == "https://api.example.com"
+
+    def test_new_env_var_wins_over_legacy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_http.ENV_URL, "https://new.example.com")
+        monkeypatch.setenv(_http.ENV_URL_LEGACY, "https://legacy.example.com")
+        assert _http.api_base() == "https://new.example.com"
+
+    def test_legacy_env_var_used_when_new_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_http.ENV_URL_LEGACY, "https://legacy.example.com")
+        assert _http.api_base() == "https://legacy.example.com"
+
+
+# ── Token storage ───────────────────────────────────────────────────────────
+
+
+class TestTokenStorage:
+    def test_get_token_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_http.ENV_TOKEN, "env-token")
+        assert _http.get_token() == "env-token"
+
+    def test_get_token_from_keychain(self, fake_keyring: _FakeKeyring) -> None:
+        fake_keyring.store[("agentbreeder", "api_token")] = "stored-token"
+        assert _http.get_token() == "stored-token"
+
+    def test_env_overrides_keychain(
+        self, fake_keyring: _FakeKeyring, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_keyring.store[("agentbreeder", "api_token")] = "stored-token"
+        monkeypatch.setenv(_http.ENV_TOKEN, "env-token")
+        assert _http.get_token() == "env-token"
+
+    def test_get_token_returns_none_without_keychain(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(_http, "_try_keyring", lambda: None)
+        assert _http.get_token() is None
+
+    def test_set_token_writes_to_keychain(self, fake_keyring: _FakeKeyring) -> None:
+        _http.set_token("new-token")
+        assert fake_keyring.store[("agentbreeder", "api_token")] == "new-token"
+
+    def test_set_token_rejects_empty(self, fake_keyring: _FakeKeyring) -> None:
+        with pytest.raises(ValueError):
+            _http.set_token("   ")
+
+    def test_set_token_raises_without_keychain(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(_http, "_try_keyring", lambda: None)
+        with pytest.raises(RuntimeError):
+            _http.set_token("x")
+
+    def test_clear_token_returns_true_when_present(self, fake_keyring: _FakeKeyring) -> None:
+        fake_keyring.store[("agentbreeder", "api_token")] = "x"
+        assert _http.clear_token() is True
+        assert ("agentbreeder", "api_token") not in fake_keyring.store
+
+    def test_clear_token_returns_false_when_absent(self, fake_keyring: _FakeKeyring) -> None:
+        assert _http.clear_token() is False
+
+
+# ── Active team context ─────────────────────────────────────────────────────
+
+
+class TestActiveTeam:
+    def test_round_trip(self) -> None:
+        assert _http.get_active_team() is None
+        _http.set_active_team("engineering")
+        assert _http.get_active_team() == "engineering"
+
+    def test_clear(self) -> None:
+        _http.set_active_team("ops")
+        _http.clear_active_team()
+        assert _http.get_active_team() is None
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(ValueError):
+            _http.set_active_team("  ")
+
+
+# ── auth_headers / require_token ────────────────────────────────────────────
+
+
+class TestAuthHeaders:
+    def test_require_token_exits_when_missing(self) -> None:
+        import typer
+
+        with pytest.raises(typer.Exit):
+            _http.require_token()
+
+    def test_auth_headers_includes_bearer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_http.ENV_TOKEN, "tok")
+        headers = _http.auth_headers()
+        assert headers["Authorization"] == "Bearer tok"
+        assert headers["Content-Type"] == "application/json"
+
+    def test_auth_headers_includes_team_when_active(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_http.ENV_TOKEN, "tok")
+        _http.set_active_team("ops")
+        headers = _http.auth_headers()
+        assert headers["X-AgentBreeder-Team"] == "ops"
+
+    def test_auth_headers_omits_content_type_for_multipart(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_http.ENV_TOKEN, "tok")
+        headers = _http.auth_headers(json_body=False)
+        assert "Content-Type" not in headers
+
+
+# ── request() ───────────────────────────────────────────────────────────────
+
+
+def _patched_client(handler: Any) -> Any:
+    """Return a context manager that swaps ``httpx.Client`` for one wired to a mock transport.
+
+    Captures the real ``httpx.Client`` reference before patching so the
+    factory we install can still instantiate a real Client (just with a
+    mock ``transport=`` injected).
+    """
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.Client
+
+    def factory(*args: Any, **kwargs: Any) -> httpx.Client:
+        kwargs["transport"] = transport
+        return real_client(*args, **kwargs)
+
+    return patch("httpx.Client", factory)
+
+
+class TestRequest:
+    def test_get_returns_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_http.ENV_TOKEN, "tok")
+        captured: dict[str, Any] = {}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            captured["url"] = str(req.url)
+            captured["auth"] = req.headers.get("authorization")
+            return httpx.Response(200, json={"ok": True})
+
+        with _patched_client(handler):
+            result = _http.request("GET", "/api/v1/foo")
+        assert result == {"ok": True}
+        assert captured["url"].endswith("/api/v1/foo")
+        assert captured["auth"] == "Bearer tok"
+
+    def test_401_exits_with_login_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import typer
+
+        monkeypatch.setenv(_http.ENV_TOKEN, "tok")
+        with _patched_client(lambda req: httpx.Response(401, text="bad token")):
+            with pytest.raises(typer.Exit):
+                _http.request("GET", "/api/v1/foo")
+
+    def test_500_exits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import typer
+
+        monkeypatch.setenv(_http.ENV_TOKEN, "tok")
+        with _patched_client(lambda req: httpx.Response(500, text="boom")):
+            with pytest.raises(typer.Exit):
+                _http.request("GET", "/api/v1/foo")
+
+
+# ── login command ───────────────────────────────────────────────────────────
+
+
+class TestLoginCommand:
+    def test_email_password_stores_token(
+        self, fake_keyring: _FakeKeyring, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def handler(req: httpx.Request) -> httpx.Response:
+            if req.url.path == "/api/v1/auth/login":
+                return httpx.Response(
+                    200, json={"data": {"access_token": "new-jwt", "token_type": "bearer"}}
+                )
+            if req.url.path == "/api/v1/auth/me":
+                assert req.headers["authorization"] == "Bearer new-jwt"
+                return httpx.Response(
+                    200,
+                    json={
+                        "data": {
+                            "id": "abc",
+                            "email": "alice@example.com",
+                            "name": "Alice",
+                            "team": "engineering",
+                            "role": "deployer",
+                        }
+                    },
+                )
+            return httpx.Response(404)
+
+        with _patched_client(handler):
+            result = runner.invoke(
+                app, ["login", "--email", "alice@example.com", "--password", "hunter2"]
+            )
+        assert result.exit_code == 0, result.output
+        assert fake_keyring.store[("agentbreeder", "api_token")] == "new-jwt"
+        assert "alice@example.com" in result.output
+
+    def test_invalid_credentials_exits(self, fake_keyring: _FakeKeyring) -> None:
+        with _patched_client(
+            lambda req: httpx.Response(401, json={"detail": "Invalid email or password"})
+        ):
+            result = runner.invoke(
+                app, ["login", "--email", "alice@example.com", "--password", "bad"]
+            )
+        assert result.exit_code == 1
+        assert ("agentbreeder", "api_token") not in fake_keyring.store
+
+    def test_with_token_flag_validates_via_me(self, fake_keyring: _FakeKeyring) -> None:
+        def handler(req: httpx.Request) -> httpx.Response:
+            assert req.url.path == "/api/v1/auth/me"
+            assert req.headers["authorization"] == "Bearer pasted-jwt"
+            return httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "id": "abc",
+                        "email": "alice@example.com",
+                        "name": "Alice",
+                        "team": "engineering",
+                        "role": "deployer",
+                    }
+                },
+            )
+
+        with _patched_client(handler):
+            result = runner.invoke(app, ["login", "--token", "pasted-jwt"])
+        assert result.exit_code == 0, result.output
+        assert fake_keyring.store[("agentbreeder", "api_token")] == "pasted-jwt"
+
+    def test_with_token_flag_rejects_bad_token(self, fake_keyring: _FakeKeyring) -> None:
+        with _patched_client(lambda req: httpx.Response(401, text="")):
+            result = runner.invoke(app, ["login", "--token", "bad-jwt"])
+        assert result.exit_code == 1
+        assert ("agentbreeder", "api_token") not in fake_keyring.store
+
+
+# ── logout / whoami ─────────────────────────────────────────────────────────
+
+
+class TestLogoutCommand:
+    def test_clears_stored_token(self, fake_keyring: _FakeKeyring) -> None:
+        fake_keyring.store[("agentbreeder", "api_token")] = "old"
+        result = runner.invoke(app, ["logout"])
+        assert result.exit_code == 0
+        assert ("agentbreeder", "api_token") not in fake_keyring.store
+        assert "Logged out" in result.output
+
+    def test_when_no_token_prints_yellow(self, fake_keyring: _FakeKeyring) -> None:
+        result = runner.invoke(app, ["logout"])
+        assert result.exit_code == 0
+        assert "No stored token" in result.output
+
+
+class TestWhoamiCommand:
+    def test_prints_user_info(
+        self, fake_keyring: _FakeKeyring, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_http.ENV_TOKEN, "tok")
+        with _patched_client(
+            lambda req: httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "id": "abc",
+                        "email": "alice@example.com",
+                        "name": "Alice",
+                        "team": "engineering",
+                        "role": "deployer",
+                    }
+                },
+            )
+        ):
+            result = runner.invoke(app, ["whoami"])
+        assert result.exit_code == 0, result.output
+        assert "alice@example.com" in result.output
+        assert "engineering" in result.output
+
+    def test_json_output_includes_active_team(
+        self, fake_keyring: _FakeKeyring, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_http.ENV_TOKEN, "tok")
+        _http.set_active_team("ops")
+        with _patched_client(
+            lambda req: httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "id": "abc",
+                        "email": "alice@example.com",
+                        "name": "Alice",
+                        "team": "engineering",
+                        "role": "deployer",
+                    }
+                },
+            )
+        ):
+            result = runner.invoke(app, ["whoami", "--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["email"] == "alice@example.com"
+        assert payload["active_team"] == "ops"
+
+    def test_exits_when_not_logged_in(self) -> None:
+        result = runner.invoke(app, ["whoami"])
+        assert result.exit_code == 1
+        assert "Not logged in" in result.output or "login" in result.output
+
+
+# ── context command ────────────────────────────────────────────────────────
+
+
+class TestContextCommand:
+    def test_use_sets_team(self) -> None:
+        result = runner.invoke(app, ["context", "use", "ops"])
+        assert result.exit_code == 0
+        assert _http.get_active_team() == "ops"
+        assert "ops" in result.output
+
+    def test_show_unset(self) -> None:
+        result = runner.invoke(app, ["context", "show"])
+        assert result.exit_code == 0
+        assert "No active team" in result.output
+
+    def test_show_set(self) -> None:
+        _http.set_active_team("ops")
+        result = runner.invoke(app, ["context", "show"])
+        assert result.exit_code == 0
+        assert "ops" in result.output
+
+    def test_clear(self) -> None:
+        _http.set_active_team("ops")
+        result = runner.invoke(app, ["context", "clear"])
+        assert result.exit_code == 0
+        assert _http.get_active_team() is None

--- a/website/content/docs/authentication.mdx
+++ b/website/content/docs/authentication.mdx
@@ -255,6 +255,75 @@ AgentBreeder will ship with a pluggable auth provider system. Set `auth_provider
 
 ---
 
+## CLI login
+
+The CLI authenticates against the same `POST /api/v1/auth/login` endpoint that the dashboard uses. Tokens live in the **OS keychain** (macOS Keychain, GNOME libsecret, Windows Credential Manager) via the [`keyring`](https://pypi.org/project/keyring/) library — you never have to copy a JWT into a shell env var by hand.
+
+### Logging in
+
+```bash
+# Interactive — prompts for email and (hidden) password
+agentbreeder login
+
+# Non-interactive
+agentbreeder login --email alice@example.com --password "$AB_PASSWORD"
+
+# Or paste a token issued by the dashboard
+agentbreeder login --token "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+```
+
+On success the token is written to the OS keychain. Subsequent commands (`agentbreeder whoami`, `agentbreeder registry agent list`, …) pick it up automatically.
+
+### whoami
+
+```bash
+agentbreeder whoami
+# email           alice@example.com
+# name            Alice Example
+# role            deployer
+# team (primary)  engineering
+# active team     ops
+# id              5b3e9c…
+
+agentbreeder whoami --json | jq .role
+```
+
+### Logging out
+
+```bash
+agentbreeder logout
+# Logged out.
+```
+
+`logout` deletes the keychain entry. It does **not** revoke the token server-side — the JWT remains valid until its expiry (24h by default). For server-side revocation see refresh-token issue [#395](https://github.com/agentbreeder/agentbreeder/issues/395).
+
+### Active team context
+
+If your account belongs to multiple teams, set the one you want to act as:
+
+```bash
+agentbreeder context use ops      # subsequent calls send X-AgentBreeder-Team: ops
+agentbreeder context show
+agentbreeder context clear        # falls back to your primary team
+```
+
+The active team is stored in `~/.agentbreeder/context.json` and is sent on every authenticated request as the `X-AgentBreeder-Team` header.
+
+### CI / non-interactive use
+
+In CI you typically don't have a keychain. Export `AGENTBREEDER_API_TOKEN` directly:
+
+```yaml
+- run: agentbreeder registry agent list
+  env:
+    AGENTBREEDER_API_TOKEN: ${{ secrets.AGENTBREEDER_DEPLOY_KEY }}
+    AGENTBREEDER_URL: https://api.example.com
+```
+
+The env var **always wins** over the keychain, so the same CLI binary works for laptops and CI without code changes.
+
+---
+
 ## Service principals
 
 Service principals are non-human identities for CI/CD pipelines, automated scripts, and agent-to-agent calls.

--- a/website/content/docs/cli-reference.mdx
+++ b/website/content/docs/cli-reference.mdx
@@ -34,6 +34,63 @@ agentbreeder [COMMAND] [OPTIONS]
 
 ## Commands
 
+### `agentbreeder login` / `logout` / `whoami`
+
+Authenticate against the AgentBreeder API. Tokens are stored in the **OS keychain** (macOS Keychain, GNOME libsecret, Windows Credential Manager). The `AGENTBREEDER_API_TOKEN` env var always wins over the keychain, so the same binary works on laptops and in CI.
+
+```
+agentbreeder login [--email EMAIL] [--password PWD] [--token JWT] [--api-url URL]
+agentbreeder logout
+agentbreeder whoami [--json]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--email`, `-e` | Account email. Prompted if omitted. |
+| `--password`, `-p` | Account password. Prompted (hidden) if omitted. |
+| `--token` | Paste an existing JWT (e.g. issued by the dashboard) instead of using email/password. |
+| `--api-url` | Override the API URL. Defaults to `$AGENTBREEDER_URL`, then `http://localhost:8000`. |
+
+**Examples:**
+```bash
+agentbreeder login                                              # Interactive
+agentbreeder login -e alice@example.com -p "$AB_PASSWORD"       # Non-interactive
+agentbreeder login --token "eyJhbGciOi…"                        # Paste a token from the dashboard
+
+agentbreeder whoami
+# email           alice@example.com
+# role            deployer
+# team (primary)  engineering
+# active team     ops
+
+agentbreeder logout                                             # Clears the keychain entry
+```
+
+`logout` deletes the keychain entry. It does **not** revoke the token server-side — the JWT remains valid until its 24h expiry. See refresh-token issue [#395](https://github.com/agentbreeder/agentbreeder/issues/395) for revocation support.
+
+---
+
+### `agentbreeder context`
+
+Set the active team context. The active team is sent on every authenticated request as the `X-AgentBreeder-Team` header and is shown by `agentbreeder whoami`.
+
+```
+agentbreeder context use TEAM
+agentbreeder context show
+agentbreeder context clear
+```
+
+The context lives in `~/.agentbreeder/context.json`.
+
+**Examples:**
+```bash
+agentbreeder context use ops          # Act as team "ops"
+agentbreeder context show             # Active team: ops
+agentbreeder context clear            # Fall back to your primary team
+```
+
+---
+
 ### `agentbreeder quickstart`
 
 Full local platform bootstrap — Docker, services, sample data, 5 sample agents, and dashboard in one command.


### PR DESCRIPTION
## Summary

Closes #415. Replaces the "copy a JWT from the dashboard, export `AGENTBREEDER_API_TOKEN`" workflow with first-class CLI auth commands backed by the OS keychain.

- New `agentbreeder login` / `logout` / `whoami` commands (also exposed under the `agentbreeder auth` sub-app for discoverability).
- New `agentbreeder context use/show/clear` for users who belong to multiple teams. Active team lives in `~/.agentbreeder/context.json` and is sent on every authenticated request as the `X-AgentBreeder-Team` header.
- New `cli/_http.py` consolidates the duplicated `_auth_headers` / `_api_base` / `_post` / `_get` / `_post_multipart` / `_request` helpers from `cli/commands/registry_cmd.py` and `cli/commands/model.py`. Both files now delegate to the shared module — behavior is unchanged for users.
- Tokens persist in the OS keychain (macOS Keychain, GNOME libsecret, Windows Credential Manager) via the existing `keyring>=24.0.0` dep. `AGENTBREEDER_API_TOKEN` in the environment still wins, so CI keeps working unchanged.
- 401s and "no token" errors now direct users to `agentbreeder login` instead of telling them to curl `/api/v1/auth/login` and `export` the response themselves.

## Stacked work

This is the first of three stacked PRs that close the CLI-side RBAC bypass flagged during Phase A:

1. **#415 (this PR)** — CLI login / keychain / shared HTTP module
2. **#416** — `agentbreeder deploy --remote` (POSTs to `/api/v1/deploys` instead of running the engine in-process)
3. **#414** — server-side: tighten `POST /api/v1/deploys` with `resource_team=` on `require_role` (HR-1 analogue for deploys)

## Out of scope

- OAuth2 / SAML / refresh-token issuance (covered by #394, #395, #396).
- Migration of `chat.py`, `publish.py`, `submit.py`, `review.py`, `orchestration.py`, `quickstart.py` to the shared module — those only use the unauthenticated `API_BASE` pattern and can be migrated in a future cleanup PR without changing behavior.

## Test plan

- [x] `pytest tests/unit/test_cli_auth.py` — 36 new tests, all pass
- [x] `pytest tests/unit/test_cli.py tests/unit/test_cli_commands_extended.py tests/unit/test_cli_coverage_boost.py` — 230 existing tests, all pass (no regression from the registry/model migration)
- [x] `ruff check cli/ tests/unit/test_cli_auth.py` — clean
- [x] `ruff format --check` — clean
- [x] `mypy cli/_http.py cli/commands/auth.py cli/commands/context.py cli/commands/registry_cmd.py cli/commands/model.py` — clean
- [ ] Manual smoke: `agentbreeder login --email <real-user> --password <pwd>` against a local API, then `agentbreeder whoami`, `agentbreeder logout`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
