### PR TITLE
feat(cli): agentbreeder deploy --remote closes in-process RBAC bypass (closes #416)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+### v2.4 — `agentbreeder deploy --remote` closes in-process RBAC bypass (#416)
+
+- **Closed** the Phase A bypass where `agentbreeder deploy` ran `engine.builder.DeployEngine` in-process — RBAC, audit logging, and team-scoped credentials never fired for CLI deploys.
+- **Added** `--remote` and `--local` flags on `agentbreeder deploy`. `--remote` POSTs `/api/v1/deploys` and polls the detail endpoint until terminal; the bearer token comes from `cli/_http` (env var or OS keychain). `--local` keeps the in-process engine for dev / offline use.
+- **Default behavior** the CLI picks remote when `$AGENTBREEDER_URL` is set, otherwise local. Explicit flags always win over the env var. Production environments should set `$AGENTBREEDER_URL` so `agentbreeder deploy` defaults to the gated path.
+- **Polling** until SSE streaming lands in #387, remote mode polls `GET /api/v1/deploys/{job_id}` every 2 s for up to 30 min. Terminal statuses (`succeeded`/`failed`/`cancelled` from v2.3 plus `complete`/`error` from the v2.4 event bus) all map onto the same exit-code semantics.
+- **Tests** 15 new tests cover the mode-selection matrix (flag wins, env wins, mutual exclusion), the happy path (POST → poll → succeeded), the 403 team-scope path (which #414 will make load-bearing), 401 → login hint, terminal `failed` → exit 1, and that `--local` does not hit the API even when `$AGENTBREEDER_URL` is set.
+- **Docs** `website/content/docs/cli-reference.mdx` and `website/content/docs/deployment.mdx` describe the two modes and when to use each.
+
 ### v2.4 — CLI `login` / `logout` / `whoami` + keychain token storage (#415)
 
 - **Added** three new top-level commands — `agentbreeder login`, `agentbreeder logout`, `agentbreeder whoami` — plus an `agentbreeder auth` sub-app with the same commands for discoverability. Tokens are stored in the OS keychain (macOS Keychain, GNOME libsecret, Windows Credential Manager) via the existing `keyring>=24.0.0` dependency; the `AGENTBREEDER_API_TOKEN` env var still wins over the keychain so CI keeps working unchanged.

--- a/cli/commands/deploy.py
+++ b/cli/commands/deploy.py
@@ -1,17 +1,42 @@
 """agentbreeder deploy — the core command.
 
-Runs the full deploy pipeline with rich progress output.
+Two execution modes:
+
+* **local** (current behavior) — runs ``engine.builder.DeployEngine`` in-process
+  with rich step-by-step progress. RBAC and audit logging are *not* enforced.
+* **remote** — POSTs ``/api/v1/deploys`` against an API server and polls
+  ``GET /api/v1/deploys/{job_id}`` until the deploy terminates. This is the
+  mode that exercises the team-scoped RBAC gates (tightened in #414) and
+  writes audit-log entries; bearer token comes from :mod:`cli._http`.
+
+Mode selection (lowest to highest precedence):
+
+1. ``--local`` → local mode regardless of env
+2. ``--remote`` → remote mode regardless of env
+3. otherwise: remote when ``AGENTBREEDER_URL`` is set, else local
+
+This is the second half of closing the "shell access + local cloud creds is
+enough to deploy" bypass flagged during the Phase A audit. The first half
+(#415) added CLI login so a real bearer token is available; this PR makes
+``agentbreeder deploy`` actually use it. The third (#414) tightens the
+server-side gate so cross-team deploys 403 even with a valid token.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json as json_lib
+import os
+import sys
+import time
 from pathlib import Path
+from typing import Any
 
 import typer
 from rich.console import Console
 from rich.panel import Panel
 
+from cli import _http
 from engine.builder import DeployEngine, PipelineStep
 
 console = Console()
@@ -22,6 +47,26 @@ STEP_ICONS = {
     "completed": "[green]  [/green]",
     "failed": "[red]  [/red]",
 }
+
+_TERMINAL_STATUSES = {"succeeded", "failed", "cancelled", "completed", "error"}
+_POLL_INTERVAL_SECONDS = 2.0
+_POLL_TIMEOUT_SECONDS = 60 * 30  # 30 min ceiling per deploy
+
+
+def _resolve_mode(remote: bool, local: bool) -> bool:
+    """Return ``True`` for remote mode, ``False`` for local.
+
+    ``--remote`` and ``--local`` are mutually exclusive. If neither flag is
+    given, remote wins when ``AGENTBREEDER_URL`` (or its legacy alias) is set.
+    """
+    if remote and local:
+        console.print("[red]--remote and --local are mutually exclusive[/red]")
+        raise typer.Exit(code=2)
+    if remote:
+        return True
+    if local:
+        return False
+    return bool(os.getenv(_http.ENV_URL) or os.getenv(_http.ENV_URL_LEGACY))
 
 
 def deploy(
@@ -45,13 +90,44 @@ def deploy(
         "--json",
         help="Output as JSON (for CI/scripting)",
     ),
+    remote: bool = typer.Option(
+        False,
+        "--remote",
+        help=(
+            "Submit the deploy to the API server (RBAC + audit enforced). "
+            "Default when $AGENTBREEDER_URL is set."
+        ),
+    ),
+    local: bool = typer.Option(
+        False,
+        "--local",
+        help="Run the deploy engine in-process (no RBAC, dev/offline use only).",
+    ),
 ) -> None:
     """Deploy an agent from an agent.yaml configuration file."""
+    use_remote = _resolve_mode(remote, local)
+    if use_remote:
+        _deploy_remote(config_path, target, json_output)
+    else:
+        _deploy_local(config_path, target, json_output)
+
+
+# ── Local mode (preserved verbatim from the pre-#416 implementation) ────────
+
+
+def _deploy_local(config_path: Path, target: str, json_output: bool) -> None:
+    """Run the deploy engine in-process — same flow as before #416.
+
+    Kept for dev/offline use; explicitly bypasses every server-side gate
+    (RBAC, audit log, team-scoped credentials). Production deploys should
+    always go through ``--remote``.
+    """
     if not json_output:
         console.print()
         console.print(
             Panel(
-                f"[bold]Deploying[/bold] {config_path.name} → [cyan]{target}[/cyan]",
+                f"[bold]Deploying[/bold] {config_path.name} → [cyan]{target}[/cyan] "
+                "[dim](local mode — RBAC/audit bypassed)[/dim]",
                 title="AgentBreeder",
                 border_style="blue",
             )
@@ -66,7 +142,6 @@ def deploy(
             if step.status == "running":
                 console.print(f"  {icon} [blue]{step.name}...[/blue]")
             elif step.status == "completed":
-                # Move cursor up and overwrite
                 console.print(f"\033[A  {icon} {step.name}")
             elif step.status == "failed":
                 console.print(f"\033[A  {icon} [red]{step.name} — FAILED[/red]")
@@ -78,8 +153,6 @@ def deploy(
         result = asyncio.run(engine.deploy(config_path=config_path, target=target))
 
         if json_output:
-            import json as json_lib
-
             console.print(json_lib.dumps(result.model_dump(), indent=2))
         else:
             console.print()
@@ -100,10 +173,6 @@ def deploy(
 
     except Exception as e:
         if json_output:
-            import json as json_lib
-            import sys
-
-            # Write directly to stdout to avoid Rich formatting in JSON mode
             sys.stdout.write(json_lib.dumps({"error": str(e)}) + "\n")
         else:
             console.print()
@@ -116,3 +185,123 @@ def deploy(
             )
             console.print()
         raise typer.Exit(code=1) from None
+
+
+# ── Remote mode ─────────────────────────────────────────────────────────────
+
+
+def _read_yaml(config_path: Path) -> str:
+    try:
+        return config_path.read_text()
+    except OSError as exc:
+        console.print(f"[red]Could not read {config_path}: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+
+def _format_summary(detail: dict[str, Any]) -> str:
+    rows = [
+        ("Job ID", detail.get("id", "")),
+        ("Agent", detail.get("agent_name") or detail.get("agent_id") or "—"),
+        ("Target", detail.get("target", "")),
+        ("Status", detail.get("status", "")),
+    ]
+    return "\n".join(f"  {k:<10} {v}" for k, v in rows)
+
+
+def _deploy_remote(config_path: Path, target: str, json_output: bool) -> None:
+    """Submit the deploy through the API server.
+
+    Bearer token is resolved by :mod:`cli._http` (env var or OS keychain) —
+    if neither is present the user is exited with a "run agentbreeder login"
+    hint. After the POST we poll the detail endpoint until the job reaches
+    a terminal status; SSE streaming is the dedicated scope of #387.
+    """
+    base = _http.api_base()
+    yaml_text = _read_yaml(config_path)
+    body = {"config_yaml": yaml_text, "target": target}
+
+    if not json_output:
+        console.print()
+        console.print(
+            Panel(
+                f"[bold]Deploying[/bold] {config_path.name} → [cyan]{target}[/cyan]\n"
+                f"[dim]via {base} (remote mode — RBAC + audit enforced)[/dim]",
+                title="AgentBreeder",
+                border_style="blue",
+            )
+        )
+        console.print()
+
+    created = _http.request("POST", "/api/v1/deploys", body=body, timeout=60.0)
+    job = created.get("data") if isinstance(created, dict) else None
+    if not isinstance(job, dict) or not job.get("id"):
+        console.print(f"[red]Unexpected /deploys response: {created}[/red]")
+        raise typer.Exit(code=1)
+    job_id = str(job["id"])
+
+    if not json_output:
+        console.print(f"  Job [bold]{job_id}[/bold] submitted. Polling for completion…")
+        console.print()
+
+    detail = _poll_until_terminal(job_id, json_output=json_output)
+    status = str(detail.get("status", "")).lower()
+
+    if json_output:
+        console.print(json_lib.dumps(detail, indent=2, default=str))
+        if status not in {"succeeded", "completed"}:
+            raise typer.Exit(code=1)
+        return
+
+    if status in {"succeeded", "completed"}:
+        console.print(
+            Panel(
+                f"[bold green]Deploy successful![/bold green]\n\n{_format_summary(detail)}",
+                title="Deployed",
+                border_style="green",
+            )
+        )
+        console.print()
+        return
+
+    error_msg = detail.get("error_message") or status
+    console.print(
+        Panel(
+            f"[bold red]Deploy failed[/bold red]\n\n{_format_summary(detail)}\n\n"
+            f"  Reason:   {error_msg}",
+            title="Error",
+            border_style="red",
+        )
+    )
+    console.print()
+    raise typer.Exit(code=1)
+
+
+def _poll_until_terminal(job_id: str, *, json_output: bool) -> dict[str, Any]:
+    """Poll ``GET /api/v1/deploys/{job_id}`` until status is terminal.
+
+    Status terms map onto either side of the wizard/legacy split: the v2.3
+    ``deploys`` route exposes ``succeeded`` / ``failed`` / ``cancelled`` while
+    the v2.4 ``deployments`` event bus uses ``complete`` / ``error``. Both are
+    treated as stop conditions here so the same CLI works against either
+    surface during the migration.
+    """
+    deadline = time.monotonic() + _POLL_TIMEOUT_SECONDS
+    last_status: str | None = None
+    while time.monotonic() < deadline:
+        resp = _http.request("GET", f"/api/v1/deploys/{job_id}")
+        detail = resp.get("data") if isinstance(resp, dict) else None
+        if not isinstance(detail, dict):
+            console.print(f"[red]Unexpected /deploys/{job_id} response: {resp}[/red]")
+            raise typer.Exit(code=1)
+        status = str(detail.get("status", "")).lower()
+        if not json_output and status != last_status:
+            console.print(f"  status: [cyan]{status}[/cyan]")
+            last_status = status
+        if status in _TERMINAL_STATUSES:
+            return detail
+        time.sleep(_POLL_INTERVAL_SECONDS)
+    console.print(
+        f"[red]Timed out after {_POLL_TIMEOUT_SECONDS // 60} min waiting for "
+        f"job {job_id} to complete.[/red]"
+    )
+    raise typer.Exit(code=1)

--- a/tests/unit/test_cli_deploy_remote.py
+++ b/tests/unit/test_cli_deploy_remote.py
@@ -1,0 +1,341 @@
+"""Tests for ``agentbreeder deploy --remote`` (issue #416).
+
+The remote path POSTs ``/api/v1/deploys`` instead of running the deploy
+engine in-process, so the team-scoped RBAC gate (#414) and audit log fire
+end-to-end. These tests verify:
+
+* ``--remote`` / ``--local`` flag handling and the ``AGENTBREEDER_URL``
+  auto-detect rule.
+* The HTTP contract: POST body shape, polling cadence, success vs failure
+  exit codes, terminal-status detection.
+* The team-scope 403 path — the whole reason this issue exists.
+* That ``--local`` does NOT hit the API (the in-process pathway is
+  preserved as the dev/offline escape hatch).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from cli import _http
+from cli.commands import deploy as deploy_cmd
+from cli.main import app
+
+runner = CliRunner()
+
+
+VALID_YAML = """\
+name: test-agent
+version: 1.0.0
+team: engineering
+owner: test@example.com
+framework: langgraph
+model:
+  primary: gpt-4o
+deploy:
+  cloud: local
+"""
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def config_file(tmp_path: Path) -> Path:
+    p = tmp_path / "agent.yaml"
+    p.write_text(VALID_YAML)
+    return p
+
+
+@pytest.fixture(autouse=True)
+def isolated_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Clear auth/URL env vars and shrink the poll interval for fast tests."""
+    monkeypatch.setenv("AGENTBREEDER_HOME", str(tmp_path / "home"))
+    monkeypatch.delenv(_http.ENV_TOKEN, raising=False)
+    monkeypatch.delenv(_http.ENV_URL, raising=False)
+    monkeypatch.delenv(_http.ENV_URL_LEGACY, raising=False)
+    monkeypatch.setattr(deploy_cmd, "_POLL_INTERVAL_SECONDS", 0.0)
+    monkeypatch.setattr(_http, "_try_keyring", lambda: None)
+
+
+def _patched_client(handler: Any) -> Any:
+    """Wrap ``httpx.Client`` so any constructed Client uses ``handler``."""
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.Client
+
+    def factory(*args: Any, **kwargs: Any) -> httpx.Client:
+        kwargs["transport"] = transport
+        return real_client(*args, **kwargs)
+
+    return patch("httpx.Client", factory)
+
+
+# ── _resolve_mode ───────────────────────────────────────────────────────────
+
+
+class TestResolveMode:
+    def test_both_flags_exits(self) -> None:
+        import typer
+
+        with pytest.raises(typer.Exit):
+            deploy_cmd._resolve_mode(remote=True, local=True)
+
+    def test_remote_flag_wins(self) -> None:
+        assert deploy_cmd._resolve_mode(remote=True, local=False) is True
+
+    def test_local_flag_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_http.ENV_URL, "https://api.example.com")
+        assert deploy_cmd._resolve_mode(remote=False, local=True) is False
+
+    def test_url_env_triggers_remote(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_http.ENV_URL, "https://api.example.com")
+        assert deploy_cmd._resolve_mode(remote=False, local=False) is True
+
+    def test_legacy_url_env_triggers_remote(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_http.ENV_URL_LEGACY, "https://api.example.com")
+        assert deploy_cmd._resolve_mode(remote=False, local=False) is True
+
+    def test_no_url_no_flags_means_local(self) -> None:
+        assert deploy_cmd._resolve_mode(remote=False, local=False) is False
+
+
+# ── Remote mode: happy path ─────────────────────────────────────────────────
+
+
+class TestRemoteHappyPath:
+    def test_posts_yaml_and_polls_until_succeeded(
+        self, config_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_http.ENV_TOKEN, "test-tok")
+        captured: dict[str, Any] = {"posts": [], "gets": []}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            if req.method == "POST" and req.url.path == "/api/v1/deploys":
+                captured["posts"].append(req)
+                return httpx.Response(
+                    200,
+                    json={
+                        "data": {
+                            "id": "job-123",
+                            "agent_id": "agent-abc",
+                            "agent_name": "test-agent",
+                            "status": "running",
+                            "target": "local",
+                            "error_message": None,
+                            "started_at": "2026-05-20T00:00:00Z",
+                            "completed_at": None,
+                        }
+                    },
+                )
+            if req.method == "GET" and req.url.path == "/api/v1/deploys/job-123":
+                captured["gets"].append(req)
+                # First poll: still running; second poll: succeeded
+                status = "succeeded" if len(captured["gets"]) >= 2 else "running"
+                return httpx.Response(
+                    200,
+                    json={
+                        "data": {
+                            "id": "job-123",
+                            "agent_id": "agent-abc",
+                            "agent_name": "test-agent",
+                            "status": status,
+                            "target": "local",
+                        }
+                    },
+                )
+            return httpx.Response(404, text=f"unexpected {req.method} {req.url.path}")
+
+        with _patched_client(handler):
+            result = runner.invoke(app, ["deploy", str(config_file), "--remote"])
+
+        assert result.exit_code == 0, result.output
+        assert len(captured["posts"]) == 1
+        post_body = captured["posts"][0].read().decode()
+        assert "test-agent" in post_body  # yaml made it into the request body
+        assert captured["posts"][0].headers["authorization"] == "Bearer test-tok"
+        assert len(captured["gets"]) >= 2
+        assert "Deploy successful" in result.output
+
+    def test_passes_target_to_api(
+        self, config_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_http.ENV_TOKEN, "test-tok")
+        bodies: list[str] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            if req.method == "POST":
+                bodies.append(req.read().decode())
+                return httpx.Response(200, json={"data": {"id": "j1", "status": "succeeded"}})
+            return httpx.Response(
+                200, json={"data": {"id": "j1", "status": "succeeded", "target": "cloud-run"}}
+            )
+
+        with _patched_client(handler):
+            result = runner.invoke(
+                app, ["deploy", str(config_file), "--remote", "--target", "cloud-run"]
+            )
+        assert result.exit_code == 0, result.output
+        assert any("cloud-run" in b for b in bodies), bodies
+
+
+# ── Remote mode: failure paths ──────────────────────────────────────────────
+
+
+class TestRemoteFailures:
+    def test_403_from_team_scope_exits_with_message(
+        self, config_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The whole point of #416 — when #414's resource_team= says no, we exit."""
+        monkeypatch.setenv(_http.ENV_TOKEN, "test-tok")
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                403,
+                json={"detail": "deployer role required for team other-team"},
+            )
+
+        with _patched_client(handler):
+            result = runner.invoke(app, ["deploy", str(config_file), "--remote"])
+        assert result.exit_code == 1
+        assert "403" in result.output
+
+    def test_401_exits_with_login_hint(
+        self, config_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_http.ENV_TOKEN, "expired-tok")
+
+        with _patched_client(lambda req: httpx.Response(401, text="expired")):
+            result = runner.invoke(app, ["deploy", str(config_file), "--remote"])
+        assert result.exit_code == 1
+        assert "login" in result.output.lower()
+
+    def test_no_token_exits(self, config_file: Path) -> None:
+        with _patched_client(lambda req: httpx.Response(200, json={})):
+            result = runner.invoke(app, ["deploy", str(config_file), "--remote"])
+        assert result.exit_code == 1
+        assert "login" in result.output.lower() or "Not logged in" in result.output
+
+    def test_terminal_failed_status_exits_nonzero(
+        self, config_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_http.ENV_TOKEN, "tok")
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            if req.method == "POST":
+                return httpx.Response(200, json={"data": {"id": "j", "status": "running"}})
+            return httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "id": "j",
+                        "status": "failed",
+                        "error_message": "container build crashed",
+                        "target": "local",
+                    }
+                },
+            )
+
+        with _patched_client(handler):
+            result = runner.invoke(app, ["deploy", str(config_file), "--remote"])
+        assert result.exit_code == 1
+        assert "container build crashed" in result.output
+
+
+# ── Mutually exclusive flags ────────────────────────────────────────────────
+
+
+class TestModeFlags:
+    def test_remote_and_local_both_set_exits(
+        self, config_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(_http.ENV_TOKEN, "tok")
+        result = runner.invoke(app, ["deploy", str(config_file), "--remote", "--local"])
+        assert result.exit_code == 2
+        assert "mutually exclusive" in result.output
+
+
+# ── Local mode preserved ────────────────────────────────────────────────────
+
+
+class TestLocalPathPreserved:
+    def test_explicit_local_skips_api_even_with_url_env(
+        self,
+        config_file: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Production users with AGENTBREEDER_URL set still get local on demand.
+
+        ``--local`` is the explicit dev/offline escape hatch — it must NOT call
+        the API even when the env says we should.
+        """
+        monkeypatch.setenv(_http.ENV_URL, "https://api.example.com")
+
+        called: dict[str, bool] = {"engine": False, "http": False}
+
+        class FakeEngine:
+            def __init__(self, *, on_step: Any) -> None:
+                self.on_step = on_step
+
+            async def deploy(self, *, config_path: Any, target: str) -> Any:
+                called["engine"] = True
+                from types import SimpleNamespace
+
+                ns = SimpleNamespace(
+                    agent_name="test-agent",
+                    version="1.0.0",
+                    endpoint_url="http://local",
+                )
+                ns.model_dump = lambda: {  # type: ignore[method-assign]
+                    "agent_name": "test-agent",
+                    "version": "1.0.0",
+                    "endpoint_url": "http://local",
+                }
+                return ns
+
+        def fail_handler(req: httpx.Request) -> httpx.Response:
+            called["http"] = True
+            return httpx.Response(500)
+
+        with (
+            patch("cli.commands.deploy.DeployEngine", FakeEngine),
+            _patched_client(fail_handler),
+        ):
+            result = runner.invoke(app, ["deploy", str(config_file), "--local"])
+
+        assert result.exit_code == 0, result.output
+        assert called["engine"] is True
+        assert called["http"] is False  # explicit-local path must not hit the API
+
+    def test_no_flags_no_url_uses_local(
+        self,
+        config_file: Path,
+    ) -> None:
+        called = {"engine": False}
+
+        class FakeEngine:
+            def __init__(self, *, on_step: Any) -> None:
+                self.on_step = on_step
+
+            async def deploy(self, *, config_path: Any, target: str) -> Any:
+                called["engine"] = True
+                from types import SimpleNamespace
+
+                ns = SimpleNamespace(agent_name="x", version="1", endpoint_url="http://local")
+                ns.model_dump = lambda: {  # type: ignore[method-assign]
+                    "agent_name": "x",
+                    "version": "1",
+                    "endpoint_url": "http://local",
+                }
+                return ns
+
+        with patch("cli.commands.deploy.DeployEngine", FakeEngine):
+            result = runner.invoke(app, ["deploy", str(config_file)])
+
+        assert result.exit_code == 0, result.output
+        assert called["engine"] is True

--- a/website/content/docs/cli-reference.mdx
+++ b/website/content/docs/cli-reference.mdx
@@ -252,13 +252,29 @@ agentbreeder init --type mcp-server --lang python tools    # Python MCP server
 Deploy an agent from an `agent.yaml` configuration file.
 
 ```
-agentbreeder deploy CONFIG_PATH [--target TARGET] [--json]
+agentbreeder deploy CONFIG_PATH [--target TARGET] [--json] [--remote | --local]
 ```
 
 | Argument / Option | Required | Default | Description |
 |-------------------|----------|---------|-------------|
 | `CONFIG_PATH` | Yes | — | Path to `agent.yaml` |
 | `--target`, `-t` | No | `local` | Deploy target. See supported values below. |
+| `--remote` | No | Auto | POST to the API server (RBAC + audit enforced). Auto-enabled when `$AGENTBREEDER_URL` is set. |
+| `--local` | No | Auto | Run the deploy engine in-process. Use for dev / offline work; bypasses RBAC + audit. |
+| `--json` | No | Off | Emit JSON to stdout (for CI/scripting). |
+
+**Remote vs. local mode**
+
+`agentbreeder deploy` has two execution paths:
+
+* **Remote** (recommended for production) — POSTs `/api/v1/deploys` against the API server identified by `$AGENTBREEDER_URL`, then polls the job until it terminates. The bearer token comes from `agentbreeder login` (OS keychain) or `$AGENTBREEDER_API_TOKEN`. Team-scoped RBAC, audit logging, and team-scoped cloud credentials all fire on this path.
+* **Local** — runs the deploy engine in the CLI process. Useful for offline development and for the `local` Docker Compose target. It explicitly bypasses every server-side gate, so it should never be used to deploy production agents from a developer laptop.
+
+Mode is picked by these rules, in order:
+
+1. `--local` → local mode regardless of env
+2. `--remote` → remote mode regardless of env
+3. otherwise: remote when `$AGENTBREEDER_URL` is set, else local
 
 **Supported `--target` values:**
 

--- a/website/content/docs/deployment.mdx
+++ b/website/content/docs/deployment.mdx
@@ -346,6 +346,32 @@ done
 
 ---
 
+## CLI: `--remote` vs `--local`
+
+`agentbreeder deploy` runs in one of two modes:
+
+* **Remote** (production) — POSTs `/api/v1/deploys` against `$AGENTBREEDER_URL`. The bearer token comes from `agentbreeder login` (OS keychain) or `$AGENTBREEDER_API_TOKEN`. Team-scoped RBAC, audit logging, and team-scoped cloud credentials are all enforced.
+* **Local** (dev / offline) — runs the deploy engine in-process. Bypasses every server-side gate; intended for laptop development and the `local` Docker Compose target.
+
+```bash
+# Production — talks to the API
+export AGENTBREEDER_URL=https://api.example.com
+agentbreeder login
+agentbreeder deploy ./agent.yaml --target cloud-run    # remote mode (auto)
+
+# Force remote even without the env var
+agentbreeder deploy ./agent.yaml --target cloud-run --remote
+
+# Force local even when AGENTBREEDER_URL is set
+agentbreeder deploy ./agent.yaml --target local --local
+```
+
+Mode resolution: `--local` wins over `--remote` wins over the env var. Without flags or env, the CLI defaults to local mode.
+
+`--remote` is what makes the team-scope RBAC gate fire — without it, a developer with shell access + cloud creds can run the deploy engine in-process and skip the gate entirely. Production environments should set `$AGENTBREEDER_URL` so that `agentbreeder deploy` defaults to the gated path.
+
+---
+
 ## Run the deploy
 
 ```bash


### PR DESCRIPTION
## Summary

Closes #416. Stacked on **#415** (PR #456).

Before this change `agentbreeder deploy` ran `engine.builder.DeployEngine` in-process — the API server's RBAC middleware on `POST /api/v1/deploys`, the audit log, and team-scoped cloud credentials never fired for CLI deploys. Shell access + local cloud creds was enough to deploy.

- New `--remote` flag POSTs `/api/v1/deploys` with the bearer token from `cli/_http` (added in #415) and polls the detail endpoint until the job terminates.
- New `--local` flag preserves the in-process engine path for dev / offline work. It bypasses RBAC + audit but is now *explicit* about doing so.
- **Mode resolution:** `--local` > `--remote` > `$AGENTBREEDER_URL` set → remote > local. Production environments should set `$AGENTBREEDER_URL` so `agentbreeder deploy` defaults to the gated path.
- SSE streaming is out of scope here — it's the dedicated scope of #387. This PR polls every 2 s for up to 30 min until terminal.

## Why this matters

This is the second of three stacked PRs that close the CLI-side RBAC bypass flagged during Phase A:

1. **#415** (merged candidate, PR #456) — CLI login / keychain / shared HTTP module
2. **#416 (this PR)** — `agentbreeder deploy --remote`
3. **#414** — server-side: tighten `POST /api/v1/deploys` with `resource_team=` on `require_role` (HR-1 analogue for deploys)

The 403 test in this PR exercises the role check that **#414** will tighten further. Today `require_role("deployer")` only checks that the caller is a `deployer` *somewhere*; #414 will make it team-specific. The CLI path is ready for either.

## Test plan

- [x] `pytest tests/unit/test_cli_deploy_remote.py` — 15 new tests, all pass
- [x] `pytest tests/unit/test_cli*.py` — 171 CLI tests total, all pass
- [x] `ruff check cli/commands/deploy.py tests/unit/test_cli_deploy_remote.py` — clean
- [x] `ruff format --check` — clean
- [x] `mypy cli/commands/deploy.py` — clean
- [ ] Manual smoke: `AGENTBREEDER_URL=https://api.example.com agentbreeder deploy ./agent.yaml --target local` against a local API server, verify 401 → "run agentbreeder login" hint, then login + retry → green
- [ ] Manual smoke: `agentbreeder deploy ./agent.yaml --local` against a fresh shell with `AGENTBREEDER_URL` unset — should still work offline

## Docs

- `website/content/docs/cli-reference.mdx` — new `--remote` / `--local` flag rows, full mode-resolution rules
- `website/content/docs/deployment.mdx` — new "CLI: `--remote` vs `--local`" section before the gcloud script section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
