### PR TITLE
feat(api): tighten /deploys with team-scoped RBAC (closes #414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+### v2.4 — Tighten `/api/v1/deploys` with team-scoped RBAC (#414)
+
+- **Closed** the HR-1 analogue gap for deploys. Before this change, a user with the `deployer` role in team A could `POST /api/v1/deploys` against an agent owned by team B — `require_role("deployer")` was applied **without** `resource_team=`, so the middleware only verified deployer-anywhere.
+- **Two-layer gate** the route now stacks `require_role("deployer")` (fast-rejects users who aren't a deployer in any team) with a new `enforce_team_role(user, agent.team, "deployer")` call (refines the check after the agent's team is resolved). Defense in depth, and the v2.3 viewer-rejection behavior is preserved.
+- **Resolution** team is read from `agent.team` when the request carries an `agent_id`, and from the YAML's `team:` field when the request is a builder-mode `config_yaml`. Builder payloads without a `team:` field now return 400 instead of falling through to a less-helpful error.
+- **Lifecycle parity** the same team-scope check now gates `DELETE /api/v1/deploys/{id}` (cancel) and `POST /api/v1/deploys/{id}/rollback`. Both look up the job's agent to find the team.
+- **Audit log** every deploy lifecycle action (`deploy.create` / `deploy.cancel` / `deploy.rollback`) now emits an `AuditService.log_event` entry tagged with the agent's team and the caller's email + IP.
+- **Platform admin bypass** unchanged — admins still pass for any team.
+- **Test** 8 new tests cover the cross-team 403 path (POST agent_id, POST config_yaml, DELETE, POST /rollback), the same-team 200 path, the YAML-missing-team 400 path, and the platform-admin escape hatch. Six existing tests in `test_api_routes_extended.py` now override `get_db` to mock the new agent/job lookups that the team-scope check requires.
+- **Cross-repo** `agentbreeder-cloud` does not consume `/api/v1/deploys`; no companion PR needed.
+
 ### v2.4 — `agentbreeder deploy --remote` closes in-process RBAC bypass (#416)
 
 - **Closed** the Phase A bypass where `agentbreeder deploy` ran `engine.builder.DeployEngine` in-process — RBAC, audit logging, and team-scoped credentials never fired for CLI deploys.

--- a/api/middleware/rbac.py
+++ b/api/middleware/rbac.py
@@ -78,6 +78,45 @@ def require_role(min_role: str, resource_team: str | None = None) -> Callable:
     return check
 
 
+async def enforce_team_role(user: User, team_id: str, min_role: str) -> None:
+    """Imperative analogue of ``require_role(min_role, resource_team=team_id)``.
+
+    Use this from inside a route handler when the resource team is only known
+    after fetching the resource — e.g. ``POST /api/v1/deploys`` resolves the
+    team from ``agent.team`` (looked up by ``request.agent_id``) or from
+    ``config_yaml``'s ``team:`` field, neither of which are available to a
+    ``Depends(require_role(...))`` evaluated at dependency-resolution time.
+
+    Raises 403 if the user is not a member of ``team_id`` or lacks the
+    required role within it. Platform admins are exempt — they pass for any
+    team.
+    """
+    from api.services.team_service import ROLE_HIERARCHY
+
+    if min_role not in ROLE_HIERARCHY:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Invalid role requirement: {min_role}",
+        )
+
+    if hasattr(user, "role") and str(user.role) == "admin":
+        return
+
+    user_role = await TeamService.get_user_role_in_team(str(user.id), team_id)
+    if user_role is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"You are not a member of team {team_id}",
+        )
+    required_level = ROLE_HIERARCHY[min_role]
+    user_level = ROLE_HIERARCHY.get(user_role, 0)
+    if user_level < required_level:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Requires {min_role} role for team {team_id}, you have {user_role}",
+        )
+
+
 async def get_user_team_role(
     team_id: str,
     user: User = Depends(get_current_user),

--- a/api/routes/deploys.py
+++ b/api/routes/deploys.py
@@ -12,13 +12,13 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.auth import get_current_user
 from api.database import get_db
-from api.middleware.rbac import require_role
-from api.models.database import User
+from api.middleware.rbac import enforce_team_role, require_role
+from api.models.database import Agent, DeployJob, User
 from api.models.enums import DeployJobStatus
 from api.models.schemas import (
     ApiMeta,
@@ -27,6 +27,7 @@ from api.models.schemas import (
     DeployJobResponse,
     DeployRequest,
 )
+from api.services.audit_service import AuditService
 from api.services.deploy_service import DeployService
 from registry.deploys import DeployRegistry
 
@@ -41,17 +42,88 @@ def _enrich(job) -> DeployJobResponse:
     return resp
 
 
+def _team_from_yaml(yaml_content: str) -> str | None:
+    """Pull the top-level ``team:`` slug out of an agent.yaml.
+
+    Used to enforce team-scoped RBAC on the builder-mode POST (``config_yaml``
+    path) before the deploy pipeline runs. Mirrors the parser in
+    ``DeployService._parse_yaml`` but only extracts the one field we need —
+    no point parsing the whole config just to fail at the gate.
+    """
+    for raw_line in yaml_content.splitlines():
+        line = raw_line.rstrip()
+        if not line.startswith(" ") and not line.startswith("\t"):
+            stripped = line.strip()
+            if stripped.startswith("#") or not stripped:
+                continue
+            if stripped.startswith("team:"):
+                val = stripped.split(":", 1)[1].strip().strip('"').strip("'")
+                return val or None
+    return None
+
+
+async def _resolve_deploy_team(body: DeployRequest, db: AsyncSession) -> tuple[str, Agent | None]:
+    """Return the (team_id, agent_or_none) implied by a DeployRequest.
+
+    Raises 400 if neither ``agent_id`` nor ``config_yaml`` is supplied, 404
+    if ``agent_id`` doesn't resolve, and 400 if a builder-mode payload omits
+    the required ``team:`` field. Returning the Agent (when known) lets the
+    caller skip a second DB round-trip in the success path.
+    """
+    if body.agent_id:
+        agent = await db.get(Agent, body.agent_id)
+        if agent is None:
+            raise HTTPException(status_code=404, detail="Agent not found")
+        return agent.team, agent
+    if body.config_yaml:
+        team = _team_from_yaml(body.config_yaml)
+        if not team:
+            raise HTTPException(
+                status_code=400,
+                detail="agent.yaml must include a top-level 'team:' field",
+            )
+        return team, None
+    raise HTTPException(status_code=400, detail="Either agent_id or config_yaml is required")
+
+
+async def _resolve_job_team(job_id: uuid.UUID, db: AsyncSession) -> str:
+    """Return the team that owns ``job_id`` via its agent relationship.
+
+    Used by the lifecycle routes (cancel, rollback) so they can run the
+    same team-scoped check as create. 404 if the job (or its agent) is
+    missing — the same shape the existing handlers already return.
+    """
+    job = await db.get(DeployJob, job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Deploy job not found")
+    agent = await db.get(Agent, job.agent_id)
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Deploy job's agent not found")
+    return agent.team
+
+
 @router.post("", response_model=ApiResponse[DeployJobResponse])
 async def create_deploy(
     body: DeployRequest,
-    _user: User = Depends(require_role("deployer")),
+    request: Request,
+    user: User = Depends(require_role("deployer")),
     db: AsyncSession = Depends(get_db),
 ) -> ApiResponse[DeployJobResponse]:
     """Trigger a new deployment.
 
     Accepts either an existing agent_id or raw config_yaml (from the builder).
-    Starts the 8-step deploy pipeline asynchronously.
+    Starts the 8-step deploy pipeline asynchronously. The deployer role is
+    required **for the agent's team specifically** (HR-1 analogue, #414) — a
+    user with deployer in team A cannot deploy an agent owned by team B.
+
+    Two-layer gate: ``require_role("deployer")`` fast-rejects users who
+    aren't a deployer in *any* team; then ``enforce_team_role`` adds the
+    team-specific refinement after the agent's team is known. Defense in
+    depth and back-compat with the v2.3 viewer-rejection behavior.
     """
+    team_id, _agent = await _resolve_deploy_team(body, db)
+    await enforce_team_role(user, team_id, "deployer")
+
     try:
         if body.agent_id:
             job = await DeployService.create_deploy(
@@ -60,21 +132,26 @@ async def create_deploy(
                 target=body.target,
                 config_yaml=body.config_yaml,
             )
-            return ApiResponse(data=_enrich(job))
-        elif body.config_yaml:
-            _agent, job = await DeployService.create_agent_and_deploy(
-                db,
-                yaml_content=body.config_yaml,
-                target=body.target,
-            )
-            return ApiResponse(data=_enrich(job))
         else:
-            raise HTTPException(
-                status_code=400,
-                detail="Either agent_id or config_yaml is required",
+            _new_agent, job = await DeployService.create_agent_and_deploy(
+                db,
+                yaml_content=body.config_yaml or "",
+                target=body.target,
             )
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
+
+    await AuditService.log_event(
+        actor=user.email,
+        action="deploy.create",
+        resource_type="deploy_job",
+        resource_name=str(job.id),
+        resource_id=str(job.id),
+        team=team_id,
+        details={"agent_id": str(job.agent_id), "target": body.target},
+        ip_address=request.client.host if request.client else None,
+    )
+    return ApiResponse(data=_enrich(job))
 
 
 @router.get("", response_model=ApiResponse[list[DeployJobResponse]])
@@ -112,27 +189,53 @@ async def get_deploy(
 @router.delete("/{job_id}", response_model=ApiResponse[dict])
 async def cancel_deploy(
     job_id: uuid.UUID,
-    _user: User = Depends(require_role("deployer")),
+    request: Request,
+    user: User = Depends(require_role("deployer")),
     db: AsyncSession = Depends(get_db),
 ) -> ApiResponse[dict]:
-    """Cancel an in-progress deployment."""
+    """Cancel an in-progress deployment. Requires deployer role for the job's team."""
+    team_id = await _resolve_job_team(job_id, db)
+    await enforce_team_role(user, team_id, "deployer")
+
     success = await DeployService.cancel_deploy(db, job_id)
     if not success:
         raise HTTPException(status_code=404, detail="Deploy job not found or not active")
+    await AuditService.log_event(
+        actor=user.email,
+        action="deploy.cancel",
+        resource_type="deploy_job",
+        resource_name=str(job_id),
+        resource_id=str(job_id),
+        team=team_id,
+        ip_address=request.client.host if request.client else None,
+    )
     return ApiResponse(data={"cancelled": True, "job_id": str(job_id)})
 
 
 @router.post("/{job_id}/rollback", response_model=ApiResponse[dict])
 async def rollback_deploy(
     job_id: uuid.UUID,
-    _user: User = Depends(require_role("deployer")),
+    request: Request,
+    user: User = Depends(require_role("deployer")),
     db: AsyncSession = Depends(get_db),
 ) -> ApiResponse[dict]:
-    """Rollback a failed deployment."""
+    """Rollback a failed deployment. Requires deployer role for the job's team."""
+    team_id = await _resolve_job_team(job_id, db)
+    await enforce_team_role(user, team_id, "deployer")
+
     success = await DeployService.rollback_deploy(db, job_id)
     if not success:
         raise HTTPException(
             status_code=400,
             detail="Deploy job not found or not in failed state",
         )
+    await AuditService.log_event(
+        actor=user.email,
+        action="deploy.rollback",
+        resource_type="deploy_job",
+        resource_name=str(job_id),
+        resource_id=str(job_id),
+        team=team_id,
+        ip_address=request.client.host if request.client else None,
+    )
     return ApiResponse(data={"rolled_back": True, "job_id": str(job_id)})

--- a/tests/unit/test_api_routes_extended.py
+++ b/tests/unit/test_api_routes_extended.py
@@ -382,6 +382,41 @@ class TestGetDeploy:
         assert resp.status_code == 404
 
 
+def _override_deploys_db(agent=None, job=None):
+    """Override ``get_db`` so the team-scope checks on ``deploys`` routes resolve.
+
+    Since #414 each deploys route does its own ``db.get(Agent, ...)`` and/or
+    ``db.get(DeployJob, ...)`` to read the team before the role gate. The
+    existing tests in this module didn't need a session mock — they do now.
+    The returned object should be used as a context manager.
+    """
+    from contextlib import contextmanager
+
+    from api.database import get_db
+
+    mock_db = AsyncMock()
+
+    async def fake_get(model, pk):
+        if model.__name__ == "DeployJob":
+            return job
+        return agent
+
+    mock_db.get = fake_get
+
+    async def _override():
+        return mock_db
+
+    @contextmanager
+    def _ctx():
+        app.dependency_overrides[get_db] = _override
+        try:
+            yield
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    return _ctx()
+
+
 class TestCancelDeploy:
     @patch(
         "api.routes.deploys.DeployService.cancel_deploy",
@@ -390,7 +425,10 @@ class TestCancelDeploy:
     def test_cancel_success(self, mock_cancel) -> None:
         mock_cancel.return_value = True
         job_id = uuid.uuid4()
-        resp = client.delete(f"/api/v1/deploys/{job_id}")
+        agent = _make_agent()
+        job = _make_deploy_job(id=job_id, agent_id=agent.id)
+        with _override_deploys_db(agent=agent, job=job):
+            resp = client.delete(f"/api/v1/deploys/{job_id}")
         assert resp.status_code == 200
         assert resp.json()["data"]["cancelled"] is True
 
@@ -400,7 +438,11 @@ class TestCancelDeploy:
     )
     def test_cancel_not_found(self, mock_cancel) -> None:
         mock_cancel.return_value = False
-        resp = client.delete(f"/api/v1/deploys/{uuid.uuid4()}")
+        job_id = uuid.uuid4()
+        agent = _make_agent()
+        job = _make_deploy_job(id=job_id, agent_id=agent.id)
+        with _override_deploys_db(agent=agent, job=job):
+            resp = client.delete(f"/api/v1/deploys/{job_id}")
         assert resp.status_code == 404
 
 
@@ -412,7 +454,10 @@ class TestRollbackDeploy:
     def test_rollback_success(self, mock_rb) -> None:
         mock_rb.return_value = True
         job_id = uuid.uuid4()
-        resp = client.post(f"/api/v1/deploys/{job_id}/rollback")
+        agent = _make_agent()
+        job = _make_deploy_job(id=job_id, agent_id=agent.id)
+        with _override_deploys_db(agent=agent, job=job):
+            resp = client.post(f"/api/v1/deploys/{job_id}/rollback")
         assert resp.status_code == 200
         assert resp.json()["data"]["rolled_back"] is True
 
@@ -422,7 +467,11 @@ class TestRollbackDeploy:
     )
     def test_rollback_not_failed(self, mock_rb) -> None:
         mock_rb.return_value = False
-        resp = client.post(f"/api/v1/deploys/{uuid.uuid4()}/rollback")
+        job_id = uuid.uuid4()
+        agent = _make_agent()
+        job = _make_deploy_job(id=job_id, agent_id=agent.id)
+        with _override_deploys_db(agent=agent, job=job):
+            resp = client.post(f"/api/v1/deploys/{job_id}/rollback")
         assert resp.status_code == 400
 
 
@@ -433,15 +482,17 @@ class TestCreateDeploy:
     )
     def test_create_with_agent_id(self, mock_create) -> None:
         agent_id = uuid.uuid4()
+        agent = _make_agent(id=agent_id)
         job = _make_deploy_job(agent_id=agent_id)
         mock_create.return_value = job
-        resp = client.post(
-            "/api/v1/deploys",
-            json={
-                "agent_id": str(agent_id),
-                "target": "local",
-            },
-        )
+        with _override_deploys_db(agent=agent):
+            resp = client.post(
+                "/api/v1/deploys",
+                json={
+                    "agent_id": str(agent_id),
+                    "target": "local",
+                },
+            )
         assert resp.status_code == 200
 
     def test_create_missing_both(self) -> None:
@@ -457,13 +508,14 @@ class TestCreateDeploy:
     )
     def test_create_agent_not_found(self, mock_create) -> None:
         mock_create.side_effect = ValueError("Agent not found")
-        resp = client.post(
-            "/api/v1/deploys",
-            json={
-                "agent_id": str(uuid.uuid4()),
-                "target": "local",
-            },
-        )
+        with _override_deploys_db(agent=None):
+            resp = client.post(
+                "/api/v1/deploys",
+                json={
+                    "agent_id": str(uuid.uuid4()),
+                    "target": "local",
+                },
+            )
         assert resp.status_code == 404
 
 

--- a/tests/unit/test_deploys_team_scope.py
+++ b/tests/unit/test_deploys_team_scope.py
@@ -1,0 +1,393 @@
+"""Tests for the team-scoped RBAC gate on /api/v1/deploys (issue #414).
+
+The HR-1 analogue for deploys: ``require_role("deployer")`` without
+``resource_team=`` lets a user with ``deployer`` in team A trigger a deploy
+that targets an agent owned by team B. These tests verify the tightened
+gate added in #414:
+
+* POST /api/v1/deploys with ``agent_id`` → 403 when the caller is a
+  deployer in a different team than the agent.
+* POST /api/v1/deploys with ``config_yaml`` → 403 when the caller is a
+  deployer in a different team than the YAML's ``team:`` field.
+* DELETE /api/v1/deploys/{id} and POST /api/v1/deploys/{id}/rollback →
+  403 when caller is a deployer in a different team than the job's agent.
+* Same-team deployer is allowed.
+* Platform admins pass regardless of team.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.database import get_db
+from api.main import app
+from api.models.enums import UserRole
+from api.services.auth import create_access_token
+
+# Opt every test in this module out of the conftest's auto-auth admin override
+# — we need to test what happens when the *caller's* role doesn't satisfy the
+# team-scope gate, so we can't have an autouse fixture handing every test a
+# platform-admin user.
+pytestmark = pytest.mark.no_auto_auth
+
+client = TestClient(app)
+
+
+# ── Test doubles ────────────────────────────────────────────────────────────
+
+
+def _make_user(team: str, role: UserRole) -> MagicMock:
+    mock = MagicMock()
+    mock.id = uuid.uuid4()
+    mock.email = f"{role.value}@{team}.example.com"
+    mock.name = f"Test {role.value}"
+    mock.role = role
+    mock.team = team
+    mock.is_active = True
+    return mock
+
+
+def _bearer(user: MagicMock) -> dict[str, str]:
+    token = create_access_token(str(user.id), user.email, str(user.role.value))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_agent(team: str, agent_id: uuid.UUID | None = None) -> MagicMock:
+    mock = MagicMock()
+    mock.id = agent_id or uuid.uuid4()
+    mock.name = f"agent-in-{team}"
+    mock.team = team
+    return mock
+
+
+def _make_job(agent_id: uuid.UUID, job_id: uuid.UUID | None = None) -> SimpleNamespace:
+    """Build a DeployJob stand-in that survives Pydantic ``model_validate``.
+
+    ``_enrich`` in api/routes/deploys.py validates the job against
+    ``DeployJobResponse`` — the schema rejects MagicMock attribute proxies,
+    so each field has to be a real value of the right type. SimpleNamespace
+    gives us a plain object with concrete attributes.
+    """
+    from datetime import UTC, datetime
+
+    return SimpleNamespace(
+        id=job_id or uuid.uuid4(),
+        agent_id=agent_id,
+        agent_name=None,
+        status="pending",
+        target="local",
+        error_message=None,
+        started_at=datetime.now(tz=UTC),
+        completed_at=None,
+        agent=None,
+    )
+
+
+@contextmanager
+def _override_db(get_side_effect: Any) -> Iterator[None]:
+    """Override the ``get_db`` dependency with a mock session.
+
+    ``get_side_effect`` is wired onto the session's ``.get()`` method so the
+    test can return whatever ORM row each handler is looking up (Agent,
+    DeployJob, …).
+    """
+    session = MagicMock()
+    session.get = AsyncMock(side_effect=get_side_effect)
+
+    async def _stub_db() -> Any:
+        return session
+
+    app.dependency_overrides[get_db] = _stub_db
+    try:
+        yield
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+
+def _patch_membership(user_id: str, team: str, role: str) -> list[Any]:
+    """Patch TeamService so the user has ``role`` in ``team`` only.
+
+    Returns a list of patches because the route's two-layer gate calls both
+    ``get_user_teams`` (the global ``require_role("deployer")`` pre-check
+    walks the user's teams) and ``get_user_role_in_team`` (the
+    ``enforce_team_role`` refinement asks about one team specifically).
+    """
+
+    async def fake_role(uid: str, tid: str) -> str | None:
+        if str(uid) == str(user_id) and tid == team:
+            return role
+        return None
+
+    team_obj = MagicMock()
+    team_obj.id = team
+    team_obj.name = team
+
+    async def fake_teams(uid: str) -> list[Any]:
+        if str(uid) == str(user_id):
+            return [team_obj]
+        return []
+
+    return [
+        patch(
+            "api.services.team_service.TeamService.get_user_role_in_team",
+            new=AsyncMock(side_effect=fake_role),
+        ),
+        patch(
+            "api.services.team_service.TeamService.get_user_teams",
+            new=AsyncMock(side_effect=fake_teams),
+        ),
+    ]
+
+
+def _patch_auth(user: MagicMock) -> list[Any]:
+    return [
+        patch("api.auth.decode_access_token", return_value={"sub": str(user.id)}),
+        patch("api.auth.get_user_by_id", new_callable=AsyncMock, return_value=user),
+    ]
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def deployer_a() -> MagicMock:
+    return _make_user(team="team-a", role=UserRole.deployer)
+
+
+@pytest.fixture
+def admin_user() -> MagicMock:
+    return _make_user(team="team-a", role=UserRole.admin)
+
+
+# ── POST /deploys with agent_id ────────────────────────────────────────────
+
+
+class TestCreateDeployCrossTeam:
+    def test_403_when_agent_team_differs_from_user_team(self, deployer_a: MagicMock) -> None:
+        agent = _make_agent(team="team-b")
+        stack = _patch_auth(deployer_a) + _patch_membership(
+            str(deployer_a.id), team="team-a", role="deployer"
+        )
+        with _override_db(lambda model, pk: agent):
+            for p in stack:
+                p.start()
+            try:
+                resp = client.post(
+                    "/api/v1/deploys",
+                    json={"agent_id": str(agent.id), "target": "local"},
+                    headers=_bearer(deployer_a),
+                )
+            finally:
+                for p in stack:
+                    p.stop()
+        assert resp.status_code == 403, resp.text
+        assert "team-b" in resp.text
+
+    def test_200_when_agent_team_matches_user_team(self, deployer_a: MagicMock) -> None:
+        agent = _make_agent(team="team-a")
+        job = _make_job(agent_id=agent.id)
+        job.target = "local"
+        job.status = "pending"
+        job.error_message = None
+        job.started_at = "2026-05-20T00:00:00Z"
+        job.completed_at = None
+        job.agent = agent
+
+        stack = (
+            _patch_auth(deployer_a)
+            + _patch_membership(str(deployer_a.id), team="team-a", role="deployer")
+            + [
+                patch(
+                    "api.services.deploy_service.DeployService.create_deploy",
+                    new_callable=AsyncMock,
+                    return_value=job,
+                ),
+            ]
+        )
+        with _override_db(lambda model, pk: agent):
+            for p in stack:
+                p.start()
+            try:
+                resp = client.post(
+                    "/api/v1/deploys",
+                    json={"agent_id": str(agent.id), "target": "local"},
+                    headers=_bearer(deployer_a),
+                )
+            finally:
+                for p in stack:
+                    p.stop()
+        assert resp.status_code == 200, resp.text
+
+    def test_404_when_agent_id_unknown(self, deployer_a: MagicMock) -> None:
+        stack = _patch_auth(deployer_a) + _patch_membership(
+            str(deployer_a.id), team="team-a", role="deployer"
+        )
+        with _override_db(lambda model, pk: None):
+            for p in stack:
+                p.start()
+            try:
+                resp = client.post(
+                    "/api/v1/deploys",
+                    json={"agent_id": str(uuid.uuid4()), "target": "local"},
+                    headers=_bearer(deployer_a),
+                )
+            finally:
+                for p in stack:
+                    p.stop()
+        assert resp.status_code == 404, resp.text
+
+
+# ── POST /deploys with config_yaml ─────────────────────────────────────────
+
+
+YAML_TEAM_B = """\
+name: x
+version: 1.0.0
+team: team-b
+owner: x@example.com
+framework: langgraph
+model:
+  primary: gpt-4o
+deploy:
+  cloud: local
+"""
+
+YAML_NO_TEAM = """\
+name: x
+version: 1.0.0
+owner: x@example.com
+framework: langgraph
+"""
+
+
+class TestCreateDeployYamlCrossTeam:
+    def test_403_when_yaml_team_differs(self, deployer_a: MagicMock) -> None:
+        stack = _patch_auth(deployer_a) + _patch_membership(
+            str(deployer_a.id), team="team-a", role="deployer"
+        )
+        with _override_db(lambda model, pk: None):
+            for p in stack:
+                p.start()
+            try:
+                resp = client.post(
+                    "/api/v1/deploys",
+                    json={"config_yaml": YAML_TEAM_B, "target": "local"},
+                    headers=_bearer(deployer_a),
+                )
+            finally:
+                for p in stack:
+                    p.stop()
+        assert resp.status_code == 403, resp.text
+
+    def test_400_when_yaml_missing_team(self, deployer_a: MagicMock) -> None:
+        stack = _patch_auth(deployer_a) + _patch_membership(
+            str(deployer_a.id), team="team-a", role="deployer"
+        )
+        with _override_db(lambda model, pk: None):
+            for p in stack:
+                p.start()
+            try:
+                resp = client.post(
+                    "/api/v1/deploys",
+                    json={"config_yaml": YAML_NO_TEAM, "target": "local"},
+                    headers=_bearer(deployer_a),
+                )
+            finally:
+                for p in stack:
+                    p.stop()
+        assert resp.status_code == 400, resp.text
+
+
+# ── Lifecycle: cancel + rollback ────────────────────────────────────────────
+
+
+class TestLifecycleCrossTeam:
+    def test_cancel_403_cross_team(self, deployer_a: MagicMock) -> None:
+        agent = _make_agent(team="team-b")
+        job = _make_job(agent_id=agent.id)
+
+        def _get(model: Any, pk: Any) -> Any:
+            return job if model.__name__ == "DeployJob" else agent
+
+        stack = _patch_auth(deployer_a) + _patch_membership(
+            str(deployer_a.id), team="team-a", role="deployer"
+        )
+        with _override_db(_get):
+            for p in stack:
+                p.start()
+            try:
+                resp = client.delete(
+                    f"/api/v1/deploys/{job.id}",
+                    headers=_bearer(deployer_a),
+                )
+            finally:
+                for p in stack:
+                    p.stop()
+        assert resp.status_code == 403, resp.text
+
+    def test_rollback_403_cross_team(self, deployer_a: MagicMock) -> None:
+        agent = _make_agent(team="team-b")
+        job = _make_job(agent_id=agent.id)
+
+        def _get(model: Any, pk: Any) -> Any:
+            return job if model.__name__ == "DeployJob" else agent
+
+        stack = _patch_auth(deployer_a) + _patch_membership(
+            str(deployer_a.id), team="team-a", role="deployer"
+        )
+        with _override_db(_get):
+            for p in stack:
+                p.start()
+            try:
+                resp = client.post(
+                    f"/api/v1/deploys/{job.id}/rollback",
+                    headers=_bearer(deployer_a),
+                )
+            finally:
+                for p in stack:
+                    p.stop()
+        assert resp.status_code == 403, resp.text
+
+
+# ── Platform admin escape hatch ─────────────────────────────────────────────
+
+
+class TestPlatformAdminBypass:
+    def test_admin_can_deploy_any_team(self, admin_user: MagicMock) -> None:
+        agent = _make_agent(team="team-b")
+        job = _make_job(agent_id=agent.id)
+        job.target = "local"
+        job.status = "pending"
+        job.error_message = None
+        job.started_at = "2026-05-20T00:00:00Z"
+        job.completed_at = None
+        job.agent = agent
+
+        stack = _patch_auth(admin_user) + [
+            patch(
+                "api.services.deploy_service.DeployService.create_deploy",
+                new_callable=AsyncMock,
+                return_value=job,
+            ),
+        ]
+        with _override_db(lambda model, pk: agent):
+            for p in stack:
+                p.start()
+            try:
+                resp = client.post(
+                    "/api/v1/deploys",
+                    json={"agent_id": str(agent.id), "target": "local"},
+                    headers=_bearer(admin_user),
+                )
+            finally:
+                for p in stack:
+                    p.stop()
+        assert resp.status_code == 200, resp.text


### PR DESCRIPTION
## Summary

Closes #414. Stacked on **#416** (PR #457) which is stacked on **#415** (PR #456). HR-1 analogue for deploys — closes the gap where a deployer in team A could `POST /api/v1/deploys` against an agent owned by team B.

- New `enforce_team_role(user, team_id, min_role)` helper in `api/middleware/rbac.py` for use inside handlers where the team is only known after fetching the resource. Same admin-bypass semantics as `require_role`.
- `POST /api/v1/deploys` now stacks `require_role("deployer")` (fast-rejects non-deployers anywhere) with `enforce_team_role` on the agent's team. Defense in depth; preserves the v2.3 viewer-rejection behavior.
- Team resolution: `agent.team` for `agent_id` payloads; the YAML's top-level `team:` field for builder-mode `config_yaml` payloads. Builder payloads without `team:` now return 400 with a clear message.
- `DELETE /api/v1/deploys/{id}` (cancel) and `POST /api/v1/deploys/{id}/rollback` get the same team-scope check, with team resolved via the job's agent.
- Every lifecycle action now emits an `AuditService.log_event` entry tagged with the agent's team plus the caller's email and IP.

## Why this completes the v2.3 stack

This is the third of three stacked PRs that close the CLI-side RBAC bypass flagged during Phase A:

1. **#415** (PR #456) — CLI login / keychain / shared HTTP module
2. **#416** (PR #457) — `agentbreeder deploy --remote`
3. **#414 (this PR)** — server-side team-scope refinement

With all three merged, `agentbreeder deploy --remote` from team A's deployer against team B's agent → 403 (was: 200).

## Cross-repo sync

Per CLAUDE.md rule: `agentbreeder-cloud` does not consume `/api/v1/deploys` (grep returned no hits). No companion PR needed.

## Test plan

- [x] `pytest tests/unit/test_deploys_team_scope.py` — 8 new tests, all pass
- [x] `pytest tests/unit/test_rbac_phase1.py tests/unit/test_api_routes_extended.py tests/unit/test_deploys_team_scope.py` — 155 tests, all pass (incl. updated existing tests that needed `db.get` mocks)
- [x] `pytest tests/unit/ --ignore=tests/unit/test_cli_coverage_boost.py` — 3401/3402 pass; one pre-existing AWS-cred flake on `test_provisioners.py::test_provision_destroy_raise_not_implemented_for_now` exists on `main` and is not affected by this PR
- [x] `ruff check api/routes/deploys.py api/middleware/rbac.py tests/unit/test_deploys_team_scope.py tests/unit/test_api_routes_extended.py` — clean
- [x] `ruff format --check` — clean
- [x] `mypy api/routes/deploys.py api/middleware/rbac.py` — clean
- [ ] Manual smoke: with a real deployer-in-team-A token, POST /api/v1/deploys for an agent in team-B → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)
