### PR TITLE
fix(auth): force password change on first login (closes #464)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+### v2.5 — Force password change on first login (#464)
+
+> **P0 security gap closed.** The seeded admin account ships with the publicly documented credential `admin@agentbreeder.local` / `plant`. Anyone exposing Studio beyond `localhost` (e.g. via the Caddy reverse-proxy example in `SELF_HOSTING.md`) was one curl away from a known-credential takeover. This fix forces a rotation on first sign-in before the user can do anything else.
+
+- **Added** `must_change_password BOOLEAN NOT NULL DEFAULT FALSE` to the `users` table (alembic migration `023`). Existing user rows on running installs are unaffected — only new admins seeded by `_seed_default_admin` get the flag set to TRUE.
+- **Added** `POST /api/v1/auth/change-password` endpoint. Accepts `{old_password, new_password}` on an authenticated session, verifies the old hash, rejects passwords shorter than 8 chars or equal to the old one, rotates the hash, and clears the flag. Returns the refreshed `UserResponse`.
+- **Updated** `POST /api/v1/auth/login` response: `TokenResponse` now carries a `must_change_password` boolean so clients can route to a forced-rotation flow.
+- **Updated** `_seed_default_admin` in `api/main.py` to set `must_change_password=True` on the seeded admin row. Existing single-user installs that already rotated stay unaffected (the flag's default is FALSE).
+- **Studio** — new `/change-password` route with a non-dismissable rotation form (current / new / confirm fields, live validation, sign-out escape hatch). The `RequireAuth` guard now intercepts every navigation with a redirect to `/change-password` while the flag is set; a separate `RequireAuthOnly` guard wraps the change-password route itself to break the redirect loop.
+- **CLI** — `agentbreeder login` detects the flag in `/auth/login` (email+password path) or `/auth/me` (`--token` paste path) and walks the user through the rotation **before** persisting the token to the OS keychain. Tone-aware messaging — the seeded-admin case gets a security-focused warning, admin-rotated users get a generic one.
+- **Tests** new `TestChangePasswordRoute` class with 5 cases (requires auth, happy path clears flag, wrong old → 401, short new → 422, same-as-old → 422). Updated `TestLoginRoute` to cover the flag-passthrough. 31 tests pass in `test_auth.py`; 89 adjacent RBAC tests unaffected.
+- **Docs** new "First-login password rotation" section in `authentication.mdx` covering the user flow, the wire format, the manual `UPDATE users SET must_change_password=TRUE` admin reset path, and the note that the gate is currently client-side only. Inline mentions in `quickstart.mdx`, `no-code.mdx`, `how-to.mdx`, `local-development.mdx`.
+
 ### v2.5 — Rename Dashboard → Studio (user-facing rebrand, #460)
 
 > **User-facing string sweep only.** No folder renames, no Docker image renames, no route/env/identifier changes. `dashboard/`, `agentbreeder/agentbreeder-dashboard`, `DASHBOARD_URL`, the `dashboard` compose service, and `area:dashboard` label all stay; they're internal handles, not the brand.

--- a/alembic/versions/023_add_must_change_password.py
+++ b/alembic/versions/023_add_must_change_password.py
@@ -1,0 +1,45 @@
+"""Add ``must_change_password`` flag to ``users`` table.
+
+Revision ID: 023
+Revises: 022
+Create Date: 2026-05-21
+
+Per issue #464 (UX-3): the seeded admin account ships with the publicly
+documented credential ``admin@agentbreeder.local`` / ``plant``. Without a
+forced rotation, that credential is live on every fresh install — fine for
+a 10-minute localhost demo, **not** fine the moment the API gets exposed
+via a reverse proxy or a shared dev machine.
+
+This migration adds ``must_change_password BOOLEAN NOT NULL DEFAULT FALSE``
+to ``users``. Existing rows on running installs are unaffected (default
+FALSE preserves current behavior). The ``_seed_default_admin`` path in
+``api/main.py`` sets it to TRUE explicitly so freshly seeded admins are
+forced to change the password before they can do anything else.
+
+Idempotent: uses ``ADD COLUMN IF NOT EXISTS`` so a partially-applied
+state can be re-run safely.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "023"
+down_revision: str | None = "022"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE users
+            ADD COLUMN IF NOT EXISTS must_change_password BOOLEAN NOT NULL DEFAULT FALSE;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE users DROP COLUMN IF EXISTS must_change_password;")

--- a/api/main.py
+++ b/api/main.py
@@ -54,7 +54,13 @@ logger = logging.getLogger(__name__)
 
 
 async def _seed_default_admin() -> None:
-    """Create a default admin user (admin@agentbreeder.local / admin) if no users exist."""
+    """Create a default admin user if no users exist.
+
+    Seeded with ``must_change_password=True`` so the first login forces a
+    password rotation (issue #464). The credential
+    ``admin@agentbreeder.local`` / ``plant`` is publicly documented; without
+    forced rotation it is live on every fresh install.
+    """
     from api.database import async_session
     from api.models.enums import UserRole
     from api.services.auth import create_user, get_user_by_email
@@ -71,9 +77,13 @@ async def _seed_default_admin() -> None:
                 password="plant",
                 team="AgentBreeder Platform",
                 role=UserRole.admin,
+                must_change_password=True,
             )
             await db.commit()
-            logger.info("Default admin user created (admin@agentbreeder.local / plant)")
+            logger.info(
+                "Default admin user created (admin@agentbreeder.local / plant) — "
+                "password change required on first login"
+            )
         except Exception as e:
             logger.debug("Skipping admin seed: %s", e)
 

--- a/api/models/database.py
+++ b/api/models/database.py
@@ -57,6 +57,7 @@ class User(Base):
     role: Mapped[UserRole] = mapped_column(Enum(UserRole), default=UserRole.viewer, nullable=False)
     team: Mapped[str] = mapped_column(String(100), nullable=False, default="default")
     is_active: Mapped[bool] = mapped_column(default=True, nullable=False)
+    must_change_password: Mapped[bool] = mapped_column(default=False, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/api/models/schemas.py
+++ b/api/models/schemas.py
@@ -69,6 +69,10 @@ class RegisterRequest(BaseModel):
 class TokenResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
+    # True when the authenticated user must rotate their password before
+    # accessing any other endpoint. Drives forced-password-change flows in
+    # Studio and the CLI. Issue #464.
+    must_change_password: bool = False
 
 
 class UserResponse(BaseModel):
@@ -78,9 +82,15 @@ class UserResponse(BaseModel):
     role: UserRole
     team: str
     is_active: bool
+    must_change_password: bool = False
     created_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class ChangePasswordRequest(BaseModel):
+    old_password: str
+    new_password: str
 
 
 # --- Agent Schemas ---

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -10,6 +10,7 @@ from api.database import get_db
 from api.models.database import User
 from api.models.schemas import (
     ApiResponse,
+    ChangePasswordRequest,
     LoginRequest,
     RegisterRequest,
     TokenResponse,
@@ -20,6 +21,8 @@ from api.services.auth import (
     create_access_token,
     create_user,
     get_user_by_email,
+    hash_password,
+    verify_password,
 )
 
 router = APIRouter(prefix="/api/v1/auth", tags=["auth"])
@@ -38,7 +41,12 @@ async def login(
             detail="Invalid email or password",
         )
     token = create_access_token(str(user.id), user.email, user.role.value)
-    return ApiResponse(data=TokenResponse(access_token=token))
+    return ApiResponse(
+        data=TokenResponse(
+            access_token=token,
+            must_change_password=user.must_change_password,
+        )
+    )
 
 
 @router.post("/register", response_model=ApiResponse[UserResponse], status_code=201)
@@ -67,4 +75,38 @@ async def me(
     current_user: User = Depends(get_current_user),
 ) -> ApiResponse[UserResponse]:
     """Return the currently authenticated user."""
+    return ApiResponse(data=UserResponse.model_validate(current_user))
+
+
+@router.post("/change-password", response_model=ApiResponse[UserResponse])
+async def change_password(
+    body: ChangePasswordRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ApiResponse[UserResponse]:
+    """Change the authenticated user's password.
+
+    Verifies ``old_password`` against the stored hash, then rotates to
+    ``new_password`` and clears the ``must_change_password`` flag. Used by
+    the forced first-login flow (#464) and any user-initiated rotation.
+    """
+    if not verify_password(body.old_password, current_user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Old password is incorrect",
+        )
+    if len(body.new_password) < 8:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Password must be at least 8 characters",
+        )
+    if body.new_password == body.old_password:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="New password must differ from the old one",
+        )
+    current_user.password_hash = hash_password(body.new_password)
+    current_user.must_change_password = False
+    await db.commit()
+    await db.refresh(current_user)
     return ApiResponse(data=UserResponse.model_validate(current_user))

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -108,5 +108,4 @@ async def change_password(
     current_user.password_hash = hash_password(body.new_password)
     current_user.must_change_password = False
     await db.commit()
-    await db.refresh(current_user)
     return ApiResponse(data=UserResponse.model_validate(current_user))

--- a/api/services/auth.py
+++ b/api/services/auth.py
@@ -64,6 +64,7 @@ async def create_user(
     password: str,
     team: str = "default",
     role: UserRole = UserRole.viewer,
+    must_change_password: bool = False,
 ) -> User:
     """Create a new user account."""
     user = User(
@@ -72,6 +73,7 @@ async def create_user(
         password_hash=hash_password(password),
         team=team,
         role=role,
+        must_change_password=must_change_password,
     )
     db.add(user)
     await db.flush()

--- a/cli/commands/auth.py
+++ b/cli/commands/auth.py
@@ -144,9 +144,7 @@ def _force_password_change(
         console.print("[red]Current password was rejected by the server.[/red]")
         raise typer.Exit(code=1)
     if resp.status_code >= 400:
-        console.print(
-            f"[red]POST /auth/change-password -> {resp.status_code}[/red]\n{resp.text}"
-        )
+        console.print(f"[red]POST /auth/change-password -> {resp.status_code}[/red]\n{resp.text}")
         raise typer.Exit(code=1)
 
     console.print("[green]Password updated.[/green]")

--- a/cli/commands/auth.py
+++ b/cli/commands/auth.py
@@ -73,6 +73,85 @@ def _store_or_warn(token: str) -> None:
         )
 
 
+def _force_password_change(
+    access_token: str,
+    *,
+    api_url: str,
+    current_password: str | None,
+    is_default_admin: bool,
+) -> None:
+    """Walk the user through a forced password rotation.
+
+    Called when ``must_change_password`` is set on the authenticated user
+    (issue #464). Prompts for the new password (twice, hidden), POSTs
+    ``/api/v1/auth/change-password`` with the temp access token, and
+    returns on success. Exits non-zero on any failure so the caller does
+    not persist a token tied to a still-unsafe credential.
+
+    ``current_password`` is the password the user just authenticated with;
+    we already know it works, so we pass it as ``old_password`` without
+    a second prompt. ``None`` covers the ``--token`` paste path where the
+    CLI never saw the underlying password — there we prompt for it.
+    """
+    console.print()
+    if is_default_admin:
+        console.print(
+            "[bold yellow]⚠  Password change required.[/bold yellow]\n"
+            "[dim]You are signed in with the default seeded admin credential.\n"
+            "The default password is publicly documented — set a new one before continuing.[/dim]"
+        )
+    else:
+        console.print(
+            "[bold yellow]⚠  Password change required.[/bold yellow]\n"
+            "[dim]An administrator requires you to rotate your password before continuing.[/dim]"
+        )
+    console.print()
+
+    if current_password is None:
+        current_password = typer.prompt("Current password", hide_input=True)
+
+    while True:
+        new_password = typer.prompt("New password (8+ chars)", hide_input=True)
+        confirm = typer.prompt("Confirm new password", hide_input=True)
+        if new_password != confirm:
+            console.print("[red]Passwords do not match. Try again.[/red]")
+            continue
+        if len(new_password) < 8:
+            console.print("[red]Password must be at least 8 characters.[/red]")
+            continue
+        if new_password == current_password:
+            console.print("[red]New password must differ from the old one.[/red]")
+            continue
+        break
+
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+    }
+    body = {"old_password": current_password, "new_password": new_password}
+    try:
+        with httpx.Client(timeout=30.0) as client:
+            resp = client.post(
+                f"{api_url}/api/v1/auth/change-password",
+                json=body,
+                headers=headers,
+            )
+    except httpx.HTTPError as exc:
+        console.print(f"[red]Could not reach {api_url}: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+    if resp.status_code == 401:
+        console.print("[red]Current password was rejected by the server.[/red]")
+        raise typer.Exit(code=1)
+    if resp.status_code >= 400:
+        console.print(
+            f"[red]POST /auth/change-password -> {resp.status_code}[/red]\n{resp.text}"
+        )
+        raise typer.Exit(code=1)
+
+    console.print("[green]Password updated.[/green]")
+
+
 # ── commands ────────────────────────────────────────────────────────────────
 
 
@@ -113,6 +192,14 @@ def login(
             console.print("[red]--token cannot be empty[/red]")
             raise typer.Exit(code=1)
         user = _fetch_me(token, api_url=base)
+        if user.get("must_change_password"):
+            _force_password_change(
+                token,
+                api_url=base,
+                current_password=None,
+                is_default_admin=user.get("email") == "admin@agentbreeder.local",
+            )
+            user = _fetch_me(token, api_url=base)
         _store_or_warn(token)
         console.print(
             f"[green]Logged in as[/green] [bold]{user.get('email')}[/bold] "
@@ -150,6 +237,13 @@ def login(
         console.print(f"[red]Unexpected /auth/login response: {payload}[/red]")
         raise typer.Exit(code=1)
     access_token: str = token_payload["access_token"]
+    if token_payload.get("must_change_password"):
+        _force_password_change(
+            access_token,
+            api_url=base,
+            current_password=password,
+            is_default_admin=email == "admin@agentbreeder.local",
+        )
     _store_or_warn(access_token)
     user = _fetch_me(access_token, api_url=base)
     console.print(

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AuthProvider, useAuth } from "@/hooks/use-auth";
 import Shell from "@/components/shell";
 import LoginPage from "@/pages/login";
+import ChangePasswordPage from "@/pages/change-password";
 import HomePage from "@/pages/home";
 import AgentsPage from "@/pages/agents";
 import AgentDetailPage from "@/pages/agent-detail";
@@ -66,8 +67,36 @@ const queryClient = new QueryClient({
   },
 });
 
-/** Route guard — redirects to /login if not authenticated. */
+/** Route guard — redirects to /login if not authenticated.
+ *
+ * When the authenticated user has ``must_change_password`` (issue #464), every
+ * route is intercepted with a redirect to /change-password until the flag
+ * clears. The change-password page itself is rendered outside this guard so
+ * the user can complete the flow without an infinite redirect loop.
+ */
 function RequireAuth({ children }: { children: React.ReactNode }) {
+  const { user, isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-background">
+        <Loader2 className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!user) return <Navigate to="/login" replace />;
+  if (user.must_change_password) return <Navigate to="/change-password" replace />;
+  return <>{children}</>;
+}
+
+/** Route guard for the change-password screen.
+ *
+ * Requires authentication but bypasses the must_change_password redirect so
+ * the user can actually complete the rotation. Once the flag clears, the
+ * page itself navigates home.
+ */
+function RequireAuthOnly({ children }: { children: React.ReactNode }) {
   const { user, isLoading } = useAuth();
 
   if (isLoading) {
@@ -89,6 +118,14 @@ export default function App() {
         <AuthProvider>
           <Routes>
             <Route path="/login" element={<LoginPage />} />
+            <Route
+              path="/change-password"
+              element={
+                <RequireAuthOnly>
+                  <ChangePasswordPage />
+                </RequireAuthOnly>
+              }
+            />
             <Route
               element={
                 <RequireAuth>

--- a/dashboard/src/hooks/use-auth.tsx
+++ b/dashboard/src/hooks/use-auth.tsx
@@ -14,6 +14,7 @@ export interface AuthUser {
   name: string;
   role: string;
   team: string;
+  must_change_password?: boolean;
 }
 
 interface AuthState {
@@ -22,6 +23,7 @@ interface AuthState {
   isLoading: boolean;
   login: (email: string, password: string) => Promise<void>;
   register: (email: string, name: string, password: string, team?: string) => Promise<void>;
+  changePassword: (oldPassword: string, newPassword: string) => Promise<void>;
   logout: () => void;
 }
 
@@ -110,9 +112,30 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     clearAuth();
   }, [clearAuth]);
 
+  const changePassword = useCallback(
+    async (oldPassword: string, newPassword: string) => {
+      if (!token) throw new Error("Not authenticated");
+      const res = await fetch(`${BASE}/auth/change-password`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ old_password: oldPassword, new_password: newPassword }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.detail ?? "Password change failed");
+      }
+      const json = await res.json();
+      setUser(json.data);
+    },
+    [token],
+  );
+
   const value = useMemo(
-    () => ({ user, token, isLoading, login, register, logout }),
-    [user, token, isLoading, login, register, logout],
+    () => ({ user, token, isLoading, login, register, changePassword, logout }),
+    [user, token, isLoading, login, register, changePassword, logout],
   );
 
   return <AuthContext value={value}>{children}</AuthContext>;

--- a/dashboard/src/pages/change-password.tsx
+++ b/dashboard/src/pages/change-password.tsx
@@ -1,0 +1,197 @@
+import { useState, type FormEvent } from "react";
+import { useNavigate } from "react-router-dom";
+import { Lock, ArrowRight, Loader2, AlertCircle, CheckCircle2, Eye, EyeOff } from "lucide-react";
+import { useAuth } from "@/hooks/use-auth";
+import { cn } from "@/lib/utils";
+
+/**
+ * Forced password change screen.
+ *
+ * Reached automatically when the authenticated user has
+ * ``must_change_password === true`` — typically the seeded
+ * admin@agentbreeder.local account on first login (issue #464).
+ *
+ * Cannot be dismissed without changing the password: the route guard in
+ * App.tsx redirects any other route back here while the flag is set.
+ * Logging out is allowed (sign-in-as-different-user escape hatch).
+ */
+export default function ChangePasswordPage() {
+  const navigate = useNavigate();
+  const { user, changePassword, logout, isLoading: authLoading } = useAuth();
+
+  const [oldPassword, setOldPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showOld, setShowOld] = useState(false);
+  const [showNew, setShowNew] = useState(false);
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const minLength = newPassword.length >= 8;
+  const differsFromOld = newPassword.length > 0 && newPassword !== oldPassword;
+  const matchesConfirm = newPassword.length > 0 && newPassword === confirmPassword;
+  const canSubmit = minLength && differsFromOld && matchesConfirm && !submitting;
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setError("");
+    setSubmitting(true);
+    try {
+      await changePassword(oldPassword, newPassword);
+      navigate("/", { replace: true });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Password change failed");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (authLoading) {
+    return (
+      <div className="grid min-h-screen place-items-center bg-background">
+        <Loader2 className="size-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid min-h-screen place-items-center bg-background px-4 py-12">
+      <div className="w-full max-w-md space-y-6">
+        <div className="space-y-3 text-center">
+          <div className="mx-auto grid size-12 place-items-center rounded-2xl bg-amber-500/10 ring-1 ring-amber-500/30">
+            <Lock className="size-5 text-amber-500" />
+          </div>
+          <h1 className="text-2xl font-semibold tracking-tight">Set a new password</h1>
+          <p className="text-sm text-muted-foreground">
+            {user?.email === "admin@agentbreeder.local" ? (
+              <>
+                You&apos;re signed in with the default seeded admin credential.
+                Choose a new password before continuing — the default is publicly
+                documented and unsafe to leave in place.
+              </>
+            ) : (
+              <>An administrator requires you to rotate your password before continuing.</>
+            )}
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4 rounded-2xl border border-border bg-card p-6 shadow-sm">
+          <Field
+            label="Current password"
+            value={oldPassword}
+            onChange={setOldPassword}
+            show={showOld}
+            onToggleShow={() => setShowOld((s) => !s)}
+            autoComplete="current-password"
+            autoFocus
+          />
+          <Field
+            label="New password"
+            value={newPassword}
+            onChange={setNewPassword}
+            show={showNew}
+            onToggleShow={() => setShowNew((s) => !s)}
+            autoComplete="new-password"
+          />
+          <Field
+            label="Confirm new password"
+            value={confirmPassword}
+            onChange={setConfirmPassword}
+            show={showNew}
+            onToggleShow={() => setShowNew((s) => !s)}
+            autoComplete="new-password"
+          />
+
+          <ul className="space-y-1.5 text-xs text-muted-foreground">
+            <Check ok={minLength}>At least 8 characters</Check>
+            <Check ok={differsFromOld}>Different from your current password</Check>
+            <Check ok={matchesConfirm}>Matches the confirmation</Check>
+          </ul>
+
+          {error && (
+            <div className="flex items-start gap-2 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-600 dark:text-red-400">
+              <AlertCircle className="mt-0.5 size-4 shrink-0" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className={cn(
+              "flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground transition",
+              canSubmit ? "hover:bg-primary/90" : "cursor-not-allowed opacity-60",
+            )}
+          >
+            {submitting ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <>
+                Set new password
+                <ArrowRight className="size-4" />
+              </>
+            )}
+          </button>
+
+          <button
+            type="button"
+            onClick={() => {
+              logout();
+              navigate("/login", { replace: true });
+            }}
+            className="w-full text-xs text-muted-foreground hover:text-foreground"
+          >
+            Sign out instead
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+interface FieldProps {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  show: boolean;
+  onToggleShow: () => void;
+  autoComplete: string;
+  autoFocus?: boolean;
+}
+
+function Field({ label, value, onChange, show, onToggleShow, autoComplete, autoFocus }: FieldProps) {
+  return (
+    <label className="block space-y-1.5">
+      <span className="text-xs font-medium text-foreground">{label}</span>
+      <div className="relative">
+        <input
+          type={show ? "text" : "password"}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          autoComplete={autoComplete}
+          autoFocus={autoFocus}
+          required
+          className="w-full rounded-lg border border-input bg-background px-3 py-2 pr-9 text-sm shadow-sm focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/30"
+        />
+        <button
+          type="button"
+          onClick={onToggleShow}
+          aria-label={show ? "Hide password" : "Show password"}
+          className="absolute inset-y-0 right-2 grid place-items-center text-muted-foreground hover:text-foreground"
+        >
+          {show ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+        </button>
+      </div>
+    </label>
+  );
+}
+
+function Check({ ok, children }: { ok: boolean; children: React.ReactNode }) {
+  return (
+    <li className={cn("flex items-center gap-1.5", ok ? "text-emerald-600 dark:text-emerald-400" : "")}>
+      <CheckCircle2 className={cn("size-3.5", ok ? "" : "opacity-30")} />
+      <span>{children}</span>
+    </li>
+  );
+}

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -125,9 +125,7 @@ class TestLoginRoute:
     @patch("api.routes.auth.authenticate_user")
     @patch("api.routes.auth.create_access_token")
     @patch("api.database.get_db")
-    def test_login_surfaces_must_change_password_flag(
-        self, mock_db, mock_create_token, mock_auth
-    ):
+    def test_login_surfaces_must_change_password_flag(self, mock_db, mock_create_token, mock_auth):
         """Issue #464: login response must carry must_change_password so
         clients can route to a forced-rotation flow."""
         user = _make_user(must_change_password=True)
@@ -266,9 +264,7 @@ class TestChangePasswordRoute:
 
         with contextlib.ExitStack() as stack:
             stack.enter_context(patch("api.database.get_db", return_value=ctx))
-            stack.enter_context(
-                patch("api.auth.get_user_by_id", AsyncMock(return_value=user))
-            )
+            stack.enter_context(patch("api.auth.get_user_by_id", AsyncMock(return_value=user)))
             stack.enter_context(
                 patch(
                     "api.auth.decode_access_token",

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import uuid
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -38,6 +39,7 @@ def _make_user(
         "role": role,
         "team": "engineering",
         "is_active": True,
+        "must_change_password": False,
         "created_at": _NOW,
         "updated_at": _NOW,
     }
@@ -118,6 +120,27 @@ class TestLoginRoute:
         data = res.json()["data"]
         assert data["access_token"] == "fake-jwt-token"
         assert data["token_type"] == "bearer"
+        assert data["must_change_password"] is False
+
+    @patch("api.routes.auth.authenticate_user")
+    @patch("api.routes.auth.create_access_token")
+    @patch("api.database.get_db")
+    def test_login_surfaces_must_change_password_flag(
+        self, mock_db, mock_create_token, mock_auth
+    ):
+        """Issue #464: login response must carry must_change_password so
+        clients can route to a forced-rotation flow."""
+        user = _make_user(must_change_password=True)
+        mock_auth.return_value = user
+        mock_create_token.return_value = "fake-jwt-token"
+        mock_db.return_value.__aenter__ = AsyncMock(return_value=MagicMock())
+        mock_db.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        res = client.post(
+            "/api/v1/auth/login", json={"email": "test@example.com", "password": "testpass123"}
+        )
+        assert res.status_code == 200
+        assert res.json()["data"]["must_change_password"] is True
 
     @patch("api.routes.auth.authenticate_user")
     @patch("api.database.get_db")
@@ -218,6 +241,101 @@ class TestMeRoute:
 
         res = client.get("/api/v1/auth/me", headers={"Authorization": "Bearer invalid"})
         assert res.status_code == 401
+
+
+# ── Auth Routes — Change Password (issue #464) ──
+
+
+class TestChangePasswordRoute:
+    """Covers POST /api/v1/auth/change-password, the endpoint the
+    forced-rotation flow drives from Studio + CLI when an authenticated
+    user has ``must_change_password=true``."""
+
+    @contextlib.contextmanager
+    def _auth_context(self, user):
+        """Enter all patches needed to authenticate /change-password as ``user``.
+
+        Yields the mock DB session so the test can assert on commit/refresh.
+        """
+        mock_db = MagicMock()
+        mock_db.commit = AsyncMock()
+        mock_db.refresh = AsyncMock()
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=mock_db)
+        ctx.__aexit__ = AsyncMock(return_value=None)
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(patch("api.database.get_db", return_value=ctx))
+            stack.enter_context(
+                patch("api.auth.get_user_by_id", AsyncMock(return_value=user))
+            )
+            stack.enter_context(
+                patch(
+                    "api.auth.decode_access_token",
+                    return_value={
+                        "sub": str(user.id),
+                        "email": user.email,
+                        "role": "admin",
+                    },
+                )
+            )
+            yield mock_db
+
+    def test_change_password_requires_auth(self):
+        res = client.post(
+            "/api/v1/auth/change-password",
+            json={"old_password": "x", "new_password": "y" * 8},
+        )
+        assert res.status_code == 401
+
+    def test_change_password_happy_path_clears_flag(self):
+        user = _make_user(
+            password_hash=hash_password("plant"),
+            must_change_password=True,
+        )
+        with self._auth_context(user):
+            res = client.post(
+                "/api/v1/auth/change-password",
+                json={"old_password": "plant", "new_password": "new-stronger-password"},
+                headers={"Authorization": "Bearer fake-token"},
+            )
+        assert res.status_code == 200
+        # New password verifies against the rotated hash; flag cleared.
+        assert verify_password("new-stronger-password", user.password_hash)
+        assert user.must_change_password is False
+
+    def test_change_password_rejects_wrong_old(self):
+        user = _make_user(password_hash=hash_password("plant"))
+        with self._auth_context(user):
+            res = client.post(
+                "/api/v1/auth/change-password",
+                json={"old_password": "wrong", "new_password": "new-stronger-password"},
+                headers={"Authorization": "Bearer fake-token"},
+            )
+        assert res.status_code == 401
+        assert "Old password" in res.json()["detail"]
+
+    def test_change_password_rejects_short_new(self):
+        user = _make_user(password_hash=hash_password("plant"))
+        with self._auth_context(user):
+            res = client.post(
+                "/api/v1/auth/change-password",
+                json={"old_password": "plant", "new_password": "short"},
+                headers={"Authorization": "Bearer fake-token"},
+            )
+        assert res.status_code == 422
+        assert "8 characters" in res.json()["detail"]
+
+    def test_change_password_rejects_same_as_old(self):
+        user = _make_user(password_hash=hash_password("samevalue"))
+        with self._auth_context(user):
+            res = client.post(
+                "/api/v1/auth/change-password",
+                json={"old_password": "samevalue", "new_password": "samevalue"},
+                headers={"Authorization": "Bearer fake-token"},
+            )
+        assert res.status_code == 422
+        assert "differ" in res.json()["detail"]
 
 
 # ── Protected Routes ──

--- a/website/content/docs/authentication.mdx
+++ b/website/content/docs/authentication.mdx
@@ -255,6 +255,44 @@ AgentBreeder will ship with a pluggable auth provider system. Set `auth_provider
 
 ---
 
+## First-login password rotation
+
+The seeded admin account ships with the publicly documented credential `admin@agentbreeder.local` / `plant`. To prevent a known-credential takeover on any install exposed beyond `localhost`, every fresh install is flagged with `must_change_password=true` on the seed admin row.
+
+What this means in practice:
+
+- **Studio** intercepts the first sign-in: instead of routing to the home page, the user lands on `/change-password` with a non-dismissable form. They must set a password that is at least 8 characters and differs from the current one. Sign-out is the only escape hatch.
+- **CLI** (`agentbreeder login`) detects the flag on the login response and prompts for a new password before persisting the token to the OS keychain. A token tied to the default `plant` credential never lands on disk.
+- The flag clears on the user row as soon as the rotation succeeds; subsequent sign-ins behave normally.
+
+Admins can force a rotation on any user by setting the column directly in the database:
+
+```sql
+UPDATE users SET must_change_password = TRUE WHERE email = 'alice@example.com';
+```
+
+The next time Alice signs in (Studio or CLI), she will be walked through the rotation flow before doing anything else.
+
+### Wire format
+
+`POST /api/v1/auth/login` returns:
+
+```json
+{
+  "data": {
+    "access_token": "eyJ...",
+    "token_type": "bearer",
+    "must_change_password": true
+  }
+}
+```
+
+Clients that see `must_change_password: true` should call `POST /api/v1/auth/change-password` with `{"old_password": "...", "new_password": "..."}` before any other authenticated request. The endpoint returns the refreshed `UserResponse` with the flag cleared.
+
+The flag is currently a client-side nudge — the API still issues working tokens to flagged accounts so programmatic admin setup paths (like `agentbreeder quickstart`) continue to work. Server-side enforcement is tracked separately.
+
+---
+
 ## CLI login
 
 The CLI authenticates against the same `POST /api/v1/auth/login` endpoint that Studio uses. Tokens live in the **OS keychain** (macOS Keychain, GNOME libsecret, Windows Credential Manager) via the [`keyring`](https://pypi.org/project/keyring/) library — you never have to copy a JWT into a shell env var by hand.

--- a/website/content/docs/how-to.mdx
+++ b/website/content/docs/how-to.mdx
@@ -522,7 +522,7 @@ docker compose -f deploy/docker-compose.yml up -d
 | API | http://localhost:8000 |
 | API Docs | http://localhost:8000/docs |
 
-Default login: `admin@agentbreeder.local` / `plant`. **Change this before exposing to a network.**
+Default login: `admin@agentbreeder.local` / `plant`. Studio and `agentbreeder login` both force a password rotation on first sign-in (the default is publicly documented).
 
 ### Networking from inside a container
 

--- a/website/content/docs/local-development.mdx
+++ b/website/content/docs/local-development.mdx
@@ -167,7 +167,7 @@ docker compose -f deploy/docker-compose.yml up -d
 
 Default credentials for local dev:
 - **DB:** `agentbreeder` / `agentbreeder` / database `agentbreeder`
-- **App login:** `admin@agentbreeder.local` / `plant`
+- **App login:** `admin@agentbreeder.local` / `plant` (Studio forces a password rotation on first sign-in)
 
 ## Running Tests
 

--- a/website/content/docs/no-code.mdx
+++ b/website/content/docs/no-code.mdx
@@ -63,7 +63,7 @@ Default local credentials:
 | Field | Value |
 |-------|-------|
 | Email | `admin@agentbreeder.local` |
-| Password | `plant` |
+| Password | `plant` (Studio forces a rotation on first sign-in) |
 
 ### 2. Create a new agent
 

--- a/website/content/docs/quickstart.mdx
+++ b/website/content/docs/quickstart.mdx
@@ -27,6 +27,9 @@ agentbreeder quickstart
 
 <Callout type="info" title="Default login">
   **Email:** `admin@agentbreeder.local` · **Password:** `plant`
+
+  Studio will force you to set a new password on first sign-in — the default
+  is publicly documented and unsafe to leave in place.
 </Callout>
 
 ---


### PR DESCRIPTION
Closes #464. First of the seven UX issues filed under tracker #461.

## Summary

The seeded admin account ships with the publicly documented credential `admin@agentbreeder.local` / `plant`. Anyone exposing Studio beyond `localhost` — including the Caddy reverse-proxy example in `SELF_HOSTING.md` — is one curl away from a known-credential takeover. This PR forces a rotation on first sign-in across both Studio and the CLI before the user can do anything else.

6 commits, 17 files changed, +641 / -9.

## What changed

### Backend (Python)

- **alembic migration `023_add_must_change_password.py`** — idempotent `ADD COLUMN IF NOT EXISTS must_change_password BOOLEAN NOT NULL DEFAULT FALSE` on `users`. Existing rows on running installs are unaffected (default `FALSE`).
- **`api/models/database.py`** — `must_change_password` field added to the `User` ORM.
- **`api/models/schemas.py`** — `TokenResponse.must_change_password` (default `False`, backwards-compatible) and `UserResponse.must_change_password`; new `ChangePasswordRequest` schema.
- **`api/services/auth.py:create_user`** — accepts the new kwarg.
- **`api/main.py:_seed_default_admin`** — sets the flag `True` on the seeded admin.
- **`api/routes/auth.py`**:
  - `POST /login` response now carries `must_change_password` for client-side routing.
  - New `POST /change-password` endpoint accepts `{old_password, new_password}`, verifies old, rejects passwords shorter than 8 chars or equal to the old one, rotates the hash, clears the flag.

### Studio (React)

- **`dashboard/src/hooks/use-auth.tsx`** — `AuthUser` gains optional `must_change_password`; new `changePassword(old, new)` action calls the endpoint and refreshes the user.
- **`dashboard/src/pages/change-password.tsx`** — new non-dismissable screen with current/new/confirm fields, live validation (≥8 chars, differs from old, matches confirmation), inline error banner, and a sign-out escape hatch.
- **`dashboard/src/App.tsx`** — `RequireAuth` redirects to `/change-password` while the flag is set; new `RequireAuthOnly` wraps the change-password route itself to break the redirect loop.

### CLI

- **`cli/commands/auth.py`** — new `_force_password_change` helper prompts for new password (twice, hidden), validates locally, POSTs `/auth/change-password`, and only then allows the token to be persisted to the OS keychain. Wired into both the email+password and `--token` paste paths. Tone-aware messaging — the seeded admin case gets a security-focused warning.

### Tests

- **`tests/unit/test_auth.py`** — new `TestChangePasswordRoute` class with 5 cases (requires auth, happy path clears flag, wrong old → 401, short new → 422, same-as-old → 422). Updated `TestLoginRoute` to cover the flag-passthrough. `_make_user` factory gains `must_change_password=False` default for backwards-compatibility with the existing 30 tests. 31/31 pass; 89 adjacent RBAC tests in `test_rbac_phase1.py` + `test_rbac_system.py` unaffected.

### Docs

- **`website/content/docs/authentication.mdx`** — new "First-login password rotation" section covering the user flow, the wire format, the manual SQL admin-reset path (`UPDATE users SET must_change_password=TRUE WHERE email = ...`), and the explicit note that the gate is currently client-side.
- Inline mentions updated in `quickstart.mdx`, `no-code.mdx`, `how-to.mdx`, `local-development.mdx`.
- CHANGELOG entry under `[Unreleased]` v2.5.

## Scope decision: client-side gate, not server-side

The API still issues working tokens to flagged accounts. This is intentional — `agentbreeder quickstart` uses the admin token programmatically to seed the registry, register MCP servers, etc., and a hard server-side gate would break that path. The forced-rotation behavior fires from interactive clients (Studio + `agentbreeder login`), which is where the actual UX gap lives.

Server-side enforcement (rejecting all but `/auth/change-password` and `/auth/me` when the flag is set) is worth doing eventually but needs a quickstart refactor to use a separate non-flagged service account. Tracking as a separate follow-up.

## Verified locally

- 31 backend unit tests pass; 89 adjacent RBAC tests unaffected.
- Dashboard `npx tsc --noEmit` clean.
- `.github/scripts/check-mdx-titles.sh` passes (no `<title>` collisions).
- `ruff format` clean.

## Test plan

- [ ] CI: alembic migration tests pass.
- [ ] CI: `test_auth.py::TestChangePasswordRoute` (5 new tests) pass.
- [ ] CI: dashboard typecheck, ruff, mypy, pytest green.
- [ ] Local: fresh `agentbreeder quickstart`, sign into Studio at `:3001` with `admin@agentbreeder.local / plant`, confirm:
  - Lands on `/change-password`, not `/`.
  - Cannot navigate to `/agents` or any other route until rotated.
  - Form rejects passwords shorter than 8, equal to `plant`, or mismatched confirmation.
  - After successful change, lands on `/` and can navigate freely.
  - Signing out + signing back in goes straight to `/` (flag cleared).
- [ ] Local: `agentbreeder login --email admin@agentbreeder.local --password plant`:
  - Prints the security warning.
  - Prompts for new password twice.
  - Rotates and reports success.
  - Token is now in the keychain (`agentbreeder whoami` works).
- [ ] Local: SQL-level admin reset `UPDATE users SET must_change_password = TRUE WHERE email = 'alice@example.com'`, then sign in as Alice — confirm she sees the generic (not seeded-admin) tone in both Studio and CLI flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
