### PR TITLE
feat(cli): agentbreeder doctor preflight + quickstart wiring (#462)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 - **Docs** — `quickstart.mdx` step-2 description rewritten to name the three model-source options; new "Already have a cloud API key?" callout pointing at `--no-ollama`. `cli-reference.mdx` `quickstart` table updates the `--no-ollama` row, adds the model-source prompt to the "What it does" list, and adds the `--no-ollama` example.
 - **Tests** new `tests/unit/test_quickstart_model_source.py` — 9 cases covering the `--no-ollama` short-circuit, the non-TTY short-circuit (with and without the flag), each interactive branch (1 → Local, 2 → Cloud, 3 → Both), the default-on-Enter case, the invalid-input-then-retry case, and whitespace trimming.
 
+### v2.5 — `agentbreeder doctor` prerequisite preflight (#462)
+
+> **P2 UX gap closed.** A first-time user on a machine without Docker, Python ≥ 3.11, or 8 GiB free disk used to discover this *mid-`quickstart`* — sometimes after a 3-minute image pull. The new `doctor` command runs the same checks in under two seconds and prints platform-specific fix commands; `quickstart` now runs it as its first step.
+
+- **Added** `agentbreeder doctor` CLI command in `cli/commands/doctor.py`. Checks Python version, container runtime presence + daemon reachability (reuses the existing detection from `quickstart.py` so Docker / Podman / nerdctl all work), free disk on the working volume (≥ 8 GiB), and total RAM (≥ 4 GiB, best-effort via `os.sysconf` on Linux and `sysctl hw.memsize` on macOS — falls back to a warn-only check on platforms where RAM can't be detected without a new dependency). Each failed check renders a copy-pasteable platform-specific fix block. Exits `0` on pass, `1` on any blocker. Supports `--json` for scripts and CI.
+- **Wired** `doctor` into `agentbreeder quickstart` as the first step. Quickstart now bails in ~1.2 s on a machine without a running container runtime instead of running through the welcome panel and dying at "Step 1: Container Runtime" with a less actionable error. Bypassable via the new `--skip-doctor` flag for CI sandboxes that intentionally skip host checks.
+- **Updated** welcome panel in `cli/main.py` to surface `doctor` in the "Useful anytime" command list, alongside `list agents`, `chat`, `down`, and `--help`.
+- **Docs** added a "Before you start" callout at the top of `quickstart.mdx` listing the three concrete prerequisites and pointing at `doctor`; added a full `doctor` entry to `cli-reference.mdx` (above the `quickstart` entry so it reads in install order); added `--skip-doctor` to the quickstart options table in both docs.
+- **Tests** new `tests/unit/test_doctor.py` — 15 cases covering each check in isolation (Python floor, disk-low, runtime-missing, runtime-daemon-down, runtime-happy, RAM-undetectable, RAM-below-min) plus `has_blocker()`, the Typer command's exit codes for pass and fail, and the `--json` payload shape. All 15 pass.
+
 ### v2.5 — First-run guided tour + empty-state hero (#465)
 
 > **P1 UX gap closed.** After first sign-in the user used to land in Studio with a fully populated registry (5 sample agents seeded by quickstart) and zero guidance on what to click. The 4-step welcome tour fixes that, and the no-agents page now ships a hero CTA instead of a one-line text dead-end.

--- a/cli/commands/doctor.py
+++ b/cli/commands/doctor.py
@@ -1,0 +1,269 @@
+"""agentbreeder doctor — preflight check for prerequisites.
+
+Verifies that the local machine can run AgentBreeder before any image pulls or
+container starts happen. Designed to exit in well under 2 seconds when a
+prerequisite is missing, with copy-pasteable fix instructions per platform.
+
+Usage:
+    agentbreeder doctor
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+console = Console()
+
+MIN_PYTHON: tuple[int, int] = (3, 11)
+MIN_FREE_DISK_BYTES: int = 8 * 1024**3
+MIN_RAM_BYTES: int = 4 * 1024**3
+
+QUICKSTART_PORTS: tuple[tuple[int, str], ...] = (
+    (3001, "Studio"),
+    (8000, "API"),
+    (5432, "Postgres"),
+    (6379, "Redis"),
+    (8001, "ChromaDB"),
+    (7474, "Neo4j HTTP"),
+    (7687, "Neo4j Bolt"),
+    (4000, "LiteLLM gateway"),
+)
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str
+    blocker: bool = True
+    fix: tuple[str, ...] = field(default_factory=tuple)
+
+
+def _check_python() -> CheckResult:
+    v = sys.version_info
+    ok = (v.major, v.minor) >= MIN_PYTHON
+    detail = f"{v.major}.{v.minor}.{v.micro}"
+    fix: tuple[str, ...] = ()
+    if not ok:
+        fix = (
+            "Install Python ≥ 3.11 via pyenv (recommended):",
+            "  brew install pyenv",
+            "  pyenv install 3.11.9 && pyenv shell 3.11.9",
+            "  pipx install agentbreeder",
+        )
+    return CheckResult("Python ≥ 3.11", ok, detail, fix=fix)
+
+
+def _check_container_runtime() -> CheckResult:
+    # Late import so `agentbreeder --help` doesn't pay the quickstart cost.
+    from cli.commands.quickstart import (
+        _detect_runtime,
+        _install_instructions,
+        _runtime_is_running,
+    )
+
+    detected = _detect_runtime()
+    if detected is None:
+        return CheckResult(
+            "Container runtime",
+            False,
+            "not found (need Docker, Podman, or nerdctl)",
+            fix=tuple(_install_instructions()),
+        )
+    binary, compose = detected
+    if not _runtime_is_running(binary):
+        start_hints: tuple[str, ...]
+        system = platform.system()
+        if system == "Darwin":
+            start_hints = (
+                f"Start {binary}:",
+                "  open -a Docker        # Docker Desktop",
+                "  open -a OrbStack      # OrbStack",
+            )
+        elif system == "Linux":
+            start_hints = (
+                f"Start {binary} daemon:",
+                f"  sudo systemctl start {binary}",
+            )
+        else:
+            start_hints = (f"Start the {binary} daemon and re-run doctor.",)
+        return CheckResult(
+            "Container runtime",
+            False,
+            f"{binary} installed but daemon not reachable",
+            fix=start_hints,
+        )
+    return CheckResult("Container runtime", True, f"{binary} (via {compose})")
+
+
+def _check_disk() -> CheckResult:
+    cwd = os.getcwd()
+    free = shutil.disk_usage(cwd).free
+    ok = free >= MIN_FREE_DISK_BYTES
+    detail = f"{free / 1024**3:.1f} GiB free at {cwd}"
+    fix: tuple[str, ...] = ()
+    if not ok:
+        need_gib = MIN_FREE_DISK_BYTES // 1024**3
+        fix = (
+            f"Free up at least {need_gib} GiB on the volume containing {cwd}.",
+            "  Common offenders: stopped containers, dangling images, old logs.",
+            "  Try: docker system prune -a   (after backing up anything you need)",
+        )
+    return CheckResult(f"Free disk ≥ {MIN_FREE_DISK_BYTES // 1024**3} GiB", ok, detail, fix=fix)
+
+
+def _total_ram_bytes() -> int | None:
+    """Best-effort total RAM detection without adding a psutil dependency."""
+    try:
+        names = getattr(os, "sysconf_names", {})
+        if "SC_PAGE_SIZE" in names and "SC_PHYS_PAGES" in names:
+            return os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+    except (ValueError, OSError):
+        pass
+    if platform.system() == "Darwin":
+        try:
+            out = subprocess.run(
+                ["sysctl", "-n", "hw.memsize"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            if out.returncode == 0 and out.stdout.strip().isdigit():
+                return int(out.stdout.strip())
+        except (subprocess.SubprocessError, OSError):
+            pass
+    return None
+
+
+def _check_ram() -> CheckResult:
+    total = _total_ram_bytes()
+    need_gib = MIN_RAM_BYTES // 1024**3
+    if total is None:
+        # Undetectable — don't block, just note it.
+        return CheckResult(
+            f"RAM ≥ {need_gib} GiB",
+            ok=True,
+            detail="could not detect (best-effort)",
+            blocker=False,
+        )
+    ok = total >= MIN_RAM_BYTES
+    detail = f"{total / 1024**3:.1f} GiB total"
+    fix: tuple[str, ...] = ()
+    if not ok:
+        fix = (
+            f"AgentBreeder recommends ≥ {need_gib} GiB RAM; detected {total / 1024**3:.1f} GiB.",
+            "  Close memory-heavy apps, or run cloud-only with `--no-ollama`.",
+        )
+    return CheckResult(f"RAM ≥ {need_gib} GiB", ok, detail, fix=fix)
+
+
+CHECKS: tuple[Callable[[], CheckResult], ...] = (
+    _check_python,
+    _check_container_runtime,
+    _check_disk,
+    _check_ram,
+)
+
+
+def run_all_checks() -> list[CheckResult]:
+    return [check() for check in CHECKS]
+
+
+def has_blocker(results: list[CheckResult]) -> bool:
+    return any(not r.ok and r.blocker for r in results)
+
+
+def _render_table(results: list[CheckResult]) -> Table:
+    table = Table(title="AgentBreeder prerequisites", title_style="bold cyan")
+    table.add_column("Check", style="bold")
+    table.add_column("Status")
+    table.add_column("Detail", style="dim")
+    for r in results:
+        if r.ok:
+            status = "[green]✓ pass[/green]"
+        elif r.blocker:
+            status = "[red]✗ fail[/red]"
+        else:
+            status = "[yellow]! warn[/yellow]"
+        table.add_row(r.name, status, r.detail)
+    return table
+
+
+def render_report(results: list[CheckResult]) -> None:
+    console.print()
+    console.print(_render_table(results))
+
+    failed_blockers = [r for r in results if not r.ok and r.blocker]
+    if not failed_blockers:
+        console.print("\n[bold green]✓ All required prerequisites satisfied.[/bold green]")
+        console.print(
+            "[dim]Next: [bold]agentbreeder quickstart[/bold] to bootstrap the local stack.[/dim]\n"
+        )
+        return
+
+    lines: list[str] = []
+    for r in failed_blockers:
+        lines.append(f"[bold red]✗ {r.name}[/bold red] — {r.detail}")
+        if r.fix:
+            lines.extend(f"  {line}" for line in r.fix)
+            lines.append("")
+    body = "\n".join(lines).rstrip()
+    console.print()
+    console.print(
+        Panel(
+            body,
+            title="[bold red]Missing prerequisites[/bold red]",
+            border_style="red",
+            padding=(1, 2),
+        )
+    )
+    console.print()
+
+
+def doctor(
+    json_output: bool = typer.Option(False, "--json", help="Emit results as JSON."),
+) -> None:
+    """Check that this machine satisfies AgentBreeder's prerequisites.
+
+    Run before `agentbreeder quickstart` (or any time a command exits with a
+    missing-prerequisite error) to find out exactly what's missing and how to
+    fix it. Exits 0 when everything passes, 1 when a required check fails.
+
+    Examples:
+        agentbreeder doctor
+        agentbreeder doctor --json
+    """
+    results = run_all_checks()
+    if json_output:
+        import json as _json
+
+        payload = {
+            "ok": not has_blocker(results),
+            "checks": [
+                {
+                    "name": r.name,
+                    "ok": r.ok,
+                    "detail": r.detail,
+                    "blocker": r.blocker,
+                    "fix": list(r.fix),
+                }
+                for r in results
+            ],
+        }
+        typer.echo(_json.dumps(payload, indent=2))
+    else:
+        render_report(results)
+
+    if has_blocker(results):
+        raise typer.Exit(code=1)

--- a/cli/commands/quickstart.py
+++ b/cli/commands/quickstart.py
@@ -1619,6 +1619,11 @@ def quickstart(
             "supplied via env vars (OPENAI_API_KEY etc.) — --yes does not invent them."
         ),
     ),
+    skip_doctor: bool = typer.Option(
+        False,
+        "--skip-doctor",
+        help="Skip the prerequisite preflight (advanced; CI environments)",
+    ),
 ) -> None:
     """Full local platform bootstrap — one command to go from zero to running agents.
 
@@ -1683,6 +1688,19 @@ def quickstart(
             padding=(1, 3),
         )
     )
+
+    # Prerequisite preflight — fail fast before any image pulls happen.
+    if not skip_doctor:
+        from cli.commands.doctor import has_blocker, render_report, run_all_checks
+
+        doctor_results = run_all_checks()
+        if has_blocker(doctor_results):
+            render_report(doctor_results)
+            console.print(
+                "[dim]Re-run after fixing the issues above, or use "
+                "[bold]--skip-doctor[/bold] to bypass (not recommended).[/dim]\n"
+            )
+            raise typer.Exit(code=1)
 
     # Light pyenv recommendation (does not block — agentbreeder runs on any 3.11+)
     try:

--- a/cli/main.py
+++ b/cli/main.py
@@ -111,6 +111,7 @@ def _print_welcome() -> None:
             "  5. [bold cyan]agentbreeder studio[/bold cyan]"
             "     [dim]Open Studio at http://localhost:3001[/dim]\n\n"
             "[bold]Useful anytime:[/bold]\n"
+            "  [cyan]agentbreeder doctor[/cyan]         [dim]· check prerequisites (Python, Docker, disk)[/dim]\n"
             "  [cyan]agentbreeder list agents[/cyan]    [dim]· see what's registered[/dim]\n"
             "  [cyan]agentbreeder chat <name>[/cyan]    [dim]· talk to an agent[/dim]\n"
             "  [cyan]agentbreeder down[/cyan]           [dim]· stop the local stack[/dim]\n"
@@ -207,6 +208,9 @@ from cli.commands import (
     validate,
 )
 from cli.commands import (
+    doctor as doctor_cmd,
+)
+from cli.commands import (
     eval as eval_cmd,
 )
 
@@ -238,6 +242,7 @@ app = typer.Typer(
 )
 
 app.command(name="welcome")(_welcome_cmd)
+app.command(name="doctor")(doctor_cmd.doctor)
 app.command(name="login")(auth.login)
 app.command(name="logout")(auth.logout)
 app.command(name="whoami")(auth.whoami)

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -1,0 +1,171 @@
+"""Tests for `agentbreeder doctor` — prerequisite preflight (issue #462)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from cli.commands.doctor import (
+    MIN_FREE_DISK_BYTES,
+    MIN_RAM_BYTES,
+    CheckResult,
+    _check_container_runtime,
+    _check_disk,
+    _check_python,
+    _check_ram,
+    has_blocker,
+    run_all_checks,
+)
+from cli.main import app
+
+runner = CliRunner()
+
+
+class TestIndividualChecks:
+    def test_python_check_passes_on_current_interpreter(self) -> None:
+        result = _check_python()
+        assert result.ok is True
+        assert result.blocker is True
+        assert "." in result.detail
+
+    def test_python_check_fails_when_too_old(self) -> None:
+        # Raise the floor above the current interpreter to simulate "too old".
+        import sys
+
+        unreachable = (sys.version_info.major, sys.version_info.minor + 99)
+        with patch("cli.commands.doctor.MIN_PYTHON", unreachable):
+            result = _check_python()
+        assert result.ok is False
+        assert "pyenv" in " ".join(result.fix)
+
+    def test_disk_check_passes_when_enough_free(self) -> None:
+        with patch("cli.commands.doctor.shutil.disk_usage") as mock_du:
+            mock_du.return_value = type(
+                "DU", (), {"total": 0, "used": 0, "free": MIN_FREE_DISK_BYTES * 2}
+            )()
+            result = _check_disk()
+        assert result.ok is True
+
+    def test_disk_check_fails_when_low(self) -> None:
+        with patch("cli.commands.doctor.shutil.disk_usage") as mock_du:
+            mock_du.return_value = type("DU", (), {"total": 0, "used": 0, "free": 1024**3})()
+            result = _check_disk()
+        assert result.ok is False
+        assert "Free up" in " ".join(result.fix)
+
+    def test_runtime_check_missing_returns_install_instructions(self) -> None:
+        with patch("cli.commands.quickstart._detect_runtime", return_value=None):
+            with patch(
+                "cli.commands.quickstart._install_instructions",
+                return_value=["Install docker desktop"],
+            ):
+                result = _check_container_runtime()
+        assert result.ok is False
+        assert result.fix == ("Install docker desktop",)
+
+    def test_runtime_check_daemon_down(self) -> None:
+        with patch(
+            "cli.commands.quickstart._detect_runtime",
+            return_value=("docker", "docker compose"),
+        ):
+            with patch("cli.commands.quickstart._runtime_is_running", return_value=False):
+                result = _check_container_runtime()
+        assert result.ok is False
+        assert "daemon not reachable" in result.detail
+
+    def test_runtime_check_happy_path(self) -> None:
+        with patch(
+            "cli.commands.quickstart._detect_runtime",
+            return_value=("podman", "podman compose"),
+        ):
+            with patch("cli.commands.quickstart._runtime_is_running", return_value=True):
+                result = _check_container_runtime()
+        assert result.ok is True
+        assert "podman" in result.detail
+
+    def test_ram_check_undetectable_does_not_block(self) -> None:
+        with patch("cli.commands.doctor._total_ram_bytes", return_value=None):
+            result = _check_ram()
+        assert result.ok is True
+        assert result.blocker is False
+
+    def test_ram_check_below_minimum_blocks(self) -> None:
+        with patch("cli.commands.doctor._total_ram_bytes", return_value=MIN_RAM_BYTES // 2):
+            result = _check_ram()
+        assert result.ok is False
+        assert result.blocker is True
+
+
+class TestHasBlocker:
+    def test_returns_false_when_only_warnings_failed(self) -> None:
+        results = [
+            CheckResult("a", ok=True, detail="ok"),
+            CheckResult("b", ok=False, detail="warn", blocker=False),
+        ]
+        assert has_blocker(results) is False
+
+    def test_returns_true_on_failed_blocker(self) -> None:
+        results = [
+            CheckResult("a", ok=True, detail="ok"),
+            CheckResult("b", ok=False, detail="bad", blocker=True),
+        ]
+        assert has_blocker(results) is True
+
+
+class TestDoctorCommand:
+    def test_doctor_exits_zero_when_all_pass(self) -> None:
+        passing = [
+            CheckResult("Python ≥ 3.11", ok=True, detail="3.12"),
+            CheckResult("Container runtime", ok=True, detail="docker"),
+            CheckResult("Free disk ≥ 8 GiB", ok=True, detail="20 GiB"),
+            CheckResult("RAM ≥ 4 GiB", ok=True, detail="16 GiB"),
+        ]
+        with patch("cli.commands.doctor.run_all_checks", return_value=passing):
+            result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 0
+        assert "prerequisites satisfied" in result.output
+
+    def test_doctor_exits_one_on_blocker(self) -> None:
+        failing = [
+            CheckResult(
+                "Container runtime",
+                ok=False,
+                detail="not found",
+                fix=("Install docker",),
+            ),
+        ]
+        with patch("cli.commands.doctor.run_all_checks", return_value=failing):
+            result = runner.invoke(app, ["doctor"])
+        assert result.exit_code == 1
+        assert "Missing prerequisites" in result.output
+        assert "Install docker" in result.output
+
+    def test_doctor_json_output_shape(self) -> None:
+        results = [
+            CheckResult("Python ≥ 3.11", ok=True, detail="3.12"),
+            CheckResult(
+                "Container runtime",
+                ok=False,
+                detail="not found",
+                fix=("install x",),
+            ),
+        ]
+        with patch("cli.commands.doctor.run_all_checks", return_value=results):
+            result = runner.invoke(app, ["doctor", "--json"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["ok"] is False
+        assert len(payload["checks"]) == 2
+        assert payload["checks"][1]["fix"] == ["install x"]
+
+
+class TestRunAllChecks:
+    def test_returns_all_four_checks(self) -> None:
+        results = run_all_checks()
+        names = {r.name for r in results}
+        assert "Python ≥ 3.11" in names
+        assert "Container runtime" in names
+        assert any("disk" in n.lower() for n in names)
+        assert any("ram" in n.lower() for n in names)

--- a/website/content/docs/cli-reference.mdx
+++ b/website/content/docs/cli-reference.mdx
@@ -91,13 +91,42 @@ agentbreeder context clear            # Fall back to your primary team
 
 ---
 
+### `agentbreeder doctor`
+
+Check that this machine satisfies AgentBreeder's prerequisites. Run before `quickstart` (or any time a command exits with a missing-prerequisite error) to find out exactly what's missing and how to fix it.
+
+```
+agentbreeder doctor [--json]
+```
+
+Checks performed (each prints a copy-pasteable fix when it fails):
+
+| Check | Required |
+|---|---|
+| Python ≥ 3.11 | yes |
+| Container runtime installed and daemon reachable (Docker, Podman, or nerdctl) | yes |
+| Free disk ≥ 8 GiB in the current working directory | yes |
+| RAM ≥ 4 GiB (best-effort; warns on platforms where total RAM can't be detected) | yes when detectable |
+
+Exits `0` when every required check passes, `1` otherwise. Designed to return in well under two seconds.
+
+**Examples:**
+```bash
+agentbreeder doctor              # human-readable report
+agentbreeder doctor --json       # JSON for scripts and CI
+```
+
+`quickstart` runs the same checks at start and bails out fast if anything's missing. Use `agentbreeder quickstart --skip-doctor` to bypass (advanced; intended for CI sandboxes that intentionally skip the host checks).
+
+---
+
 ### `agentbreeder quickstart`
 
 Full local platform bootstrap — Docker, services, sample data, 5 sample agents, and Studio in one command.
 
 ```
 agentbreeder quickstart [--cloud TARGET] [--no-browser] [--skip-seed] [--dev] [--reset]
-                        [--no-ollama] [--ollama-model NAME] [--yes]
+                        [--no-ollama] [--ollama-model NAME] [--yes] [--skip-doctor]
 ```
 
 | Option | Default | Description |
@@ -110,6 +139,7 @@ agentbreeder quickstart [--cloud TARGET] [--no-browser] [--skip-seed] [--dev] [-
 | `--no-ollama` | Off | **Cloud-only setup.** Skip the Ollama install, daemon start, and model pull (saves ~1–2 min and a ~3 GB download). Equivalent to choosing **Cloud** at the interactive model-source prompt. |
 | `--ollama-model` | `gemma3` | Pull a different default model for Ollama (e.g. `llama3.2`, `phi4-mini`) |
 | `--yes`, `-y` | Off | **Non-interactive mode for CI / scripted runs.** Skip every yes/no prompt and use safe defaults: model-source falls back to the legacy "Both" path (or Cloud when `--no-ollama` is set), port conflicts get auto-killed, Ollama install/rebind/model-pull and Studio rebuild are auto-accepted. Blocking prompts that require human input (e.g. "press Enter once the daemon is up") exit fast instead of waiting. Does **not** auto-install Docker — runtime must already be present. Does **not** invent provider keys — export `OPENAI_API_KEY` (or equivalent) before running. |
+| `--skip-doctor` | Off | Skip the prerequisite preflight (advanced; CI environments — pairs naturally with `--yes`). |
 
 What it does:
 1. Detects Docker / Podman; shows OS-specific install instructions if neither is found

--- a/website/content/docs/quickstart.mdx
+++ b/website/content/docs/quickstart.mdx
@@ -14,6 +14,16 @@ pip3 install agentbreeder
 agentbreeder quickstart
 ```
 
+<Callout type="info" title="Before you start">
+  AgentBreeder needs three things on the machine:
+
+  - **Python 3.11+** (we recommend installing via `pyenv`)
+  - **One container runtime** — Docker Desktop, OrbStack, Colima, Podman, or nerdctl
+  - **macOS 12+ · Linux · or Windows 11 + WSL2** · ~8 GiB free disk · ~4 GiB RAM
+
+  Not sure? Run `agentbreeder doctor` after installing — it checks every prerequisite, exits in under two seconds, and prints copy-pasteable fix commands for whatever's missing.
+</Callout>
+
 <Callout type="info" title="What to expect">
   `agentbreeder quickstart` is an **interactive wizard**. It asks a handful of questions (container runtime, model source, API keys, port conflicts) and pulls ~3 GB if you choose local models. Expect ~3 minutes on a cold first run.
 
@@ -96,6 +106,7 @@ The 8-step deploy pipeline (parse → RBAC → resolve deps → build container 
 | `--skip-seed` | Skip seeding sample data (faster restart) |
 | `--reset` | Tear down all volumes and start fresh |
 | `--dev` | Build API/Studio images from source instead of Docker Hub |
+| `--skip-doctor` | Skip the prerequisite preflight (advanced; CI environments) |
 
 ---
 


### PR DESCRIPTION
## Summary

- New `agentbreeder doctor` CLI command — single-shot prerequisite preflight (Python ≥ 3.11, container runtime + daemon, ≥ 8 GiB free disk, ≥ 4 GiB RAM best-effort) with copy-pasteable platform-specific fix output and a `--json` mode for CI.
- Wired into `agentbreeder quickstart` as the first step (bypassable via `--skip-doctor`) so a machine without Docker bails in ~1.2 s instead of after the welcome panel and the deeper docker-compose path.
- Docs: "Before you start" callout at the top of `quickstart.mdx`; full `doctor` entry in `cli-reference.mdx`; `--skip-doctor` row added to the quickstart options tables in both docs.
- Tests: `tests/unit/test_doctor.py` — 15 cases (per-check, `has_blocker`, Typer command exit codes + JSON shape). All pass.

Closes #462 — the P2 ("drop-off prevention") item on tracker #461. Acceptance criteria from the issue are all met:

- [x] Running `quickstart` on a machine without Docker exits in <2s with a clear next-step command — measured 1.2 s locally.
- [x] `quickstart.mdx` shows prerequisites above the fold — new "Before you start" callout immediately under the two-command snippet.
- [x] `agentbreeder doctor` is a public command users can run any time — registered in `cli/main.py`, surfaced in the welcome panel.
- [x] No Docker image pulls happen before prereq check passes — `doctor` runs strictly before any compose / pull / seed.

## Design notes

- Container runtime detection is intentionally a thin wrapper around `cli.commands.quickstart._detect_runtime` / `_runtime_is_running` / `_install_instructions` — extracting them into a separate `cli/_preflight.py` would be cleaner long-term but I kept them in `quickstart.py` to avoid a touched-by-everything refactor in a UX PR. The doctor file's late `from cli.commands.quickstart import …` documents the dependency without paying its import cost on `agentbreeder --help`.
- RAM detection avoids a `psutil` dep: `os.sysconf` on Linux, `sysctl hw.memsize` on macOS, falls through to a warn-only check (`blocker=False`) on Windows / other platforms. Quickstart will still proceed when RAM is undetectable rather than block users.
- `--skip-doctor` is documented as "advanced / CI environments" so it's discoverable to CI authors without becoming the path of least resistance for end users.

## Out of scope (deliberately)

- Port-conflict pre-check: `_check_ports` already lives in quickstart and surfaces interactively later in the flow; the issue explicitly said ports should be "listed but not yet blocking" — there's a `QUICKSTART_PORTS` table in `doctor.py` reserved for surfacing this in a follow-up but it's not wired into the report yet.
- Windows + WSL2 detection: out of scope for this PR; will land with #466/#467.

## Test plan

- [x] `python3 -m pytest tests/unit/test_doctor.py tests/unit/test_cli.py -q` — 50 / 50 pass.
- [x] `python3 -m cli.main doctor` — daemon-down case renders the missing-prerequisites panel and exits 1.
- [x] `python3 -m cli.main doctor --json` — emits the documented shape, exits 1.
- [x] `python3 -m cli.main quickstart --skip-seed --no-browser` — bails at doctor in ~1.2 s.
- [x] `python3 -m cli.main quickstart --skip-doctor --no-browser --skip-seed` — bypasses doctor and proceeds (verified up to the next step's panel).
- [x] `ruff check` + `ruff format --check` + `mypy cli/commands/doctor.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
