### PR TITLE
feat(cli,docs): pipx-first install + welcome PATH hint (#463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,17 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 - **Docs** added a "Before you start" callout at the top of `quickstart.mdx` listing the three concrete prerequisites and pointing at `doctor`; added a full `doctor` entry to `cli-reference.mdx` (above the `quickstart` entry so it reads in install order); added `--skip-doctor` to the quickstart options table in both docs.
 - **Tests** new `tests/unit/test_doctor.py` — 15 cases covering each check in isolation (Python floor, disk-low, runtime-missing, runtime-daemon-down, runtime-happy, RAM-undetectable, RAM-below-min) plus `has_blocker()`, the Typer command's exit codes for pass and fail, and the `--json` payload shape. All 15 pass.
 
+### v2.5 — Install path discovery + pip/pipx standardization (#463)
+
+> **P2 UX gap closed.** The #1 entry in `quickstart.mdx`'s troubleshooting table is `agentbreeder: command not found` after `pip install` — pip's script directory often isn't on `PATH`. Docs now recommend `pipx install agentbreeder` as the primary path (pipx adds the binary to a directory that's already on `PATH` everywhere), with `python3 -m pip install agentbreeder` as the alternative (works regardless of whether `pip`/`pip3` is on `PATH`).
+
+- **Added** install-path hint to the welcome panel (`cli/main.py`). When pip's script directory isn't on `PATH`, `agentbreeder welcome` and the first-run banner now print a yellow panel showing the scripts dir (`sysconfig.get_path('scripts')`), the active shell, and the exact line to append to the user's shell rc (zsh / bash / fish / PowerShell). Suppressed when the scripts dir is already on `PATH`, so pipx and venv users see no noise.
+- **Updated** `quickstart.mdx` two-command snippet to `pipx install agentbreeder` (with a callout pointing at `python3 -m pip install agentbreeder` for users without pipx). Same change in the troubleshooting row for `command not found`.
+- **Updated** `how-to.mdx` Install section to lead with `pipx install agentbreeder`, then fall back to `python3 -m pip install agentbreeder`. Removed `pip3 install ...` lines.
+- **Updated** `faq.mdx` "command not found" section to recommend `pipx` first, then the manual PATH-edit instructions, with the section header switched to `python3 -m pip install agentbreeder`.
+- **Standardized** install commands across `full-code.mdx`, `low-code.mdx`, all five `migrations/from-*.mdx` checklists, and `migrations/overview.mdx`. Every user-facing install line now reads `pipx install agentbreeder` (or `python3 -m pip install agentbreeder`) — no more `pip` vs `pip3` ambiguity in docs. Blog posts and CI examples (where `pip install` is idiomatic for the platform) are intentionally untouched.
+- **Tests** new `tests/unit/test_cli_install_path.py` — 12 cases covering `_scripts_dir()`, `_scripts_dir_on_path()` happy/empty/unrelated PATH cases, `_shell_rc_hint()` for zsh / fish / bash-default / Windows PowerShell, and the welcome command's panel-shown / panel-hidden branches.
+
 ### v2.5 — First-run guided tour + empty-state hero (#465)
 
 > **P1 UX gap closed.** After first sign-in the user used to land in Studio with a fully populated registry (5 sample agents seeded by quickstart) and zero guidance on what to click. The 4-step welcome tour fixes that, and the no-agents page now ships a hero CTA instead of a one-line text dead-end.

--- a/cli/main.py
+++ b/cli/main.py
@@ -107,10 +107,18 @@ def _scripts_dir_on_path() -> bool:
     return target in _path_entries()
 
 
+def _is_windows() -> bool:
+    """Wrap the ``os.name == 'nt'`` check so tests can patch it without
+    globally mutating ``os.name`` — which would make ``pathlib.Path()`` try
+    to instantiate ``WindowsPath`` on a non-Windows test host and crash.
+    """
+    return os.name == "nt"
+
+
 def _shell_rc_hint() -> tuple[str, str]:
     """Return ``(label, line-to-append)`` for the user's most likely shell."""
     scripts = _scripts_dir()
-    if os.name == "nt":
+    if _is_windows():
         return ("PowerShell ($PROFILE)", f'$env:PATH = "{scripts};$env:PATH"')
     shell = os.environ.get("SHELL", "")
     if "zsh" in shell:

--- a/cli/main.py
+++ b/cli/main.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import subprocess
 import sys
+import sysconfig
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
@@ -67,6 +68,87 @@ def _print_pyenv_warning() -> None:
             "[dim]This is a recommendation, not a hard requirement — "
             "AgentBreeder will continue to work in any Python ≥ 3.11.[/dim]",
             title="[bold yellow]Python Environment[/bold yellow]",
+            border_style="yellow",
+            padding=(1, 2),
+        )
+    )
+
+
+# ── Install location / PATH discovery ──────────────────────────────────────
+# The #1 quickstart.mdx troubleshooting entry is "agentbreeder: command not
+# found" after `pip install agentbreeder` — pip's script directory isn't on
+# PATH. We can't fix that for users who haven't reached `agentbreeder` yet,
+# but we can surface the relevant paths for next-tool-they-install and
+# nudge toward `pipx install agentbreeder` which sidesteps the problem.
+
+
+def _scripts_dir() -> Path:
+    """Where pip would install console scripts for the active interpreter."""
+    return Path(sysconfig.get_path("scripts"))
+
+
+def _path_entries() -> list[Path]:
+    out: list[Path] = []
+    for entry in os.environ.get("PATH", "").split(os.pathsep):
+        if not entry:
+            continue
+        try:
+            out.append(Path(entry).resolve())
+        except OSError:
+            continue
+    return out
+
+
+def _scripts_dir_on_path() -> bool:
+    try:
+        target = _scripts_dir().resolve()
+    except OSError:
+        return False
+    return target in _path_entries()
+
+
+def _shell_rc_hint() -> tuple[str, str]:
+    """Return ``(label, line-to-append)`` for the user's most likely shell."""
+    scripts = _scripts_dir()
+    if os.name == "nt":
+        return ("PowerShell ($PROFILE)", f'$env:PATH = "{scripts};$env:PATH"')
+    shell = os.environ.get("SHELL", "")
+    if "zsh" in shell:
+        return ("zsh (~/.zshrc)", f'export PATH="{scripts}:$PATH"')
+    if "fish" in shell:
+        return (
+            "fish (~/.config/fish/config.fish)",
+            f'fish_add_path "{scripts}"',
+        )
+    # Default to bash for unknown POSIX shells — same syntax as zsh.
+    return ("bash (~/.bashrc)", f'export PATH="{scripts}:$PATH"')
+
+
+def _print_install_path_hint() -> None:
+    """Show where pip installs scripts and how to add that dir to PATH.
+
+    Suppressed when the scripts dir is already on ``PATH`` (typical for users
+    who installed via ``pipx`` or inside a venv) so the welcome banner stays
+    quiet for the happy path.
+    """
+    if _scripts_dir_on_path():
+        return
+    from rich.console import Console
+    from rich.panel import Panel
+
+    label, line = _shell_rc_hint()
+    Console().print(
+        Panel(
+            f"[yellow]pip's script directory isn't on your PATH.[/yellow]\n\n"
+            f"  Scripts dir: [dim]{_scripts_dir()}[/dim]\n"
+            f"  Active shell: [dim]{label}[/dim]\n\n"
+            "If you ever hit [bold]agentbreeder: command not found[/bold] after\n"
+            "[cyan]python3 -m pip install agentbreeder[/cyan], append this line to\n"
+            "your shell rc and reload it:\n\n"
+            f"  [cyan]{line}[/cyan]\n\n"
+            "[dim]Easier next time: [bold]pipx install agentbreeder[/bold] — pipx puts\n"
+            "the binary in a directory that's already on PATH on most systems.[/dim]",
+            title="[bold yellow]Install path[/bold yellow]",
             border_style="yellow",
             padding=(1, 2),
         )
@@ -143,6 +225,7 @@ def _maybe_show_welcome() -> None:
         pass
 
     _print_pyenv_warning()
+    _print_install_path_hint()
     _print_welcome()
 
     # Auto-launch quickstart on first run if STDIN is a TTY.
@@ -172,6 +255,7 @@ def _maybe_show_welcome() -> None:
 
 def _welcome_cmd() -> None:
     """Show the AgentBreeder Getting Started guide."""
+    _print_install_path_hint()
     _print_welcome()
 
 

--- a/tests/unit/test_cli_install_path.py
+++ b/tests/unit/test_cli_install_path.py
@@ -64,13 +64,16 @@ class TestShellRcHint:
 
     def test_bash_default_for_unknown_posix_shell(self) -> None:
         with patch.dict(os.environ, {"SHELL": "/bin/ksh"}, clear=False):
-            with patch("cli.main.os.name", "posix"):
+            with patch("cli.main._is_windows", return_value=False):
                 label, line = _shell_rc_hint()
         assert "bash" in label
         assert line.startswith('export PATH="')
 
     def test_windows_emits_powershell(self) -> None:
-        with patch("cli.main.os.name", "nt"):
+        # Patch the helper (not ``os.name`` itself) — globally mutating
+        # ``os.name`` would make ``pathlib.Path()`` try to instantiate
+        # ``WindowsPath`` on a non-Windows test host and raise.
+        with patch("cli.main._is_windows", return_value=True):
             label, line = _shell_rc_hint()
         assert "PowerShell" in label
         assert line.startswith("$env:PATH = ")

--- a/tests/unit/test_cli_install_path.py
+++ b/tests/unit/test_cli_install_path.py
@@ -1,0 +1,103 @@
+"""Tests for the install-path / PATH discovery helpers (issue #463)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from cli.main import (
+    _path_entries,
+    _scripts_dir,
+    _scripts_dir_on_path,
+    _shell_rc_hint,
+    app,
+)
+
+runner = CliRunner()
+
+
+class TestScriptsDir:
+    def test_scripts_dir_returns_existing_path(self) -> None:
+        path = _scripts_dir()
+        # sysconfig.get_path('scripts') always returns a non-empty path.
+        assert isinstance(path, Path)
+        assert str(path)
+
+
+class TestPathDetection:
+    def test_returns_true_when_scripts_dir_on_path(self) -> None:
+        scripts = _scripts_dir().resolve()
+        with patch.dict(os.environ, {"PATH": f"/usr/bin{os.pathsep}{scripts}"}):
+            assert _scripts_dir_on_path() is True
+
+    def test_returns_false_when_path_empty(self) -> None:
+        with patch.dict(os.environ, {"PATH": ""}):
+            assert _scripts_dir_on_path() is False
+
+    def test_returns_false_when_only_unrelated_entries(self) -> None:
+        with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}):
+            assert _scripts_dir_on_path() is False
+
+    def test_path_entries_skips_blanks(self) -> None:
+        with patch.dict(os.environ, {"PATH": f"/usr/bin{os.pathsep}{os.pathsep}/bin"}):
+            entries = _path_entries()
+        assert Path("/usr/bin").resolve() in entries
+        assert Path("/bin").resolve() in entries
+
+
+class TestShellRcHint:
+    def test_zsh_emits_zshrc_export(self) -> None:
+        with patch.dict(os.environ, {"SHELL": "/bin/zsh"}):
+            label, line = _shell_rc_hint()
+        assert "zsh" in label
+        assert line.startswith('export PATH="')
+        assert ':$PATH"' in line
+
+    def test_fish_emits_fish_add_path(self) -> None:
+        with patch.dict(os.environ, {"SHELL": "/usr/local/bin/fish"}):
+            label, line = _shell_rc_hint()
+        assert "fish" in label
+        assert line.startswith("fish_add_path ")
+
+    def test_bash_default_for_unknown_posix_shell(self) -> None:
+        with patch.dict(os.environ, {"SHELL": "/bin/ksh"}, clear=False):
+            with patch("cli.main.os.name", "posix"):
+                label, line = _shell_rc_hint()
+        assert "bash" in label
+        assert line.startswith('export PATH="')
+
+    def test_windows_emits_powershell(self) -> None:
+        with patch("cli.main.os.name", "nt"):
+            label, line = _shell_rc_hint()
+        assert "PowerShell" in label
+        assert line.startswith("$env:PATH = ")
+
+
+class TestPrintInstallPathHint:
+    def test_silent_when_scripts_dir_on_path(self) -> None:
+        """Happy path (pipx / venv users) must stay quiet."""
+        with patch("cli.main._scripts_dir_on_path", return_value=True):
+            from cli.main import _print_install_path_hint
+
+            # Should not raise and not print anything we can capture via stdout
+            # — the function returns early without instantiating Console.
+            _print_install_path_hint()
+
+    def test_welcome_shows_hint_when_scripts_dir_off_path(self) -> None:
+        """`agentbreeder welcome` surfaces the hint when PATH is misconfigured."""
+        with patch("cli.main._scripts_dir_on_path", return_value=False):
+            with patch.dict(os.environ, {"SHELL": "/bin/zsh"}):
+                result = runner.invoke(app, ["welcome"])
+        assert result.exit_code == 0
+        assert "Install path" in result.output
+        assert "pipx install agentbreeder" in result.output
+        assert "python3 -m pip install agentbreeder" in result.output
+
+    def test_welcome_hides_hint_on_happy_path(self) -> None:
+        with patch("cli.main._scripts_dir_on_path", return_value=True):
+            result = runner.invoke(app, ["welcome"])
+        assert result.exit_code == 0
+        assert "Install path" not in result.output

--- a/website/content/docs/faq.mdx
+++ b/website/content/docs/faq.mdx
@@ -125,19 +125,31 @@ podman run --rm --add-host=host.docker.internal:host-gateway alpine \
   wget -qO- http://host.docker.internal:11434/api/tags
 ```
 
-### `agentbreeder: command not found` after `pip install agentbreeder`
+### `agentbreeder: command not found` after `python3 -m pip install agentbreeder`
 
-Pip's script directory isn't on your `PATH`. Find it and add it to your shell rc:
+Pip's script directory isn't on your `PATH`. Two ways to fix it:
+
+**Easiest — reinstall with `pipx`:**
+
+```bash
+pipx install agentbreeder
+```
+
+pipx installs into an isolated environment and puts the executable on `PATH` automatically — no shell-rc edits required.
+
+**Or, keep your `pip` install and add the scripts dir to `PATH`:**
 
 ```bash
 python3 -c "import sysconfig; print(sysconfig.get_path('scripts'))"
 ```
 
-Add the printed path to your `~/.zshrc` (or equivalent):
+Prepend the printed path to `PATH` in your shell rc (`~/.zshrc`, `~/.bashrc`, `~/.config/fish/config.fish`, or PowerShell `$PROFILE`):
 
 ```bash
-export PATH="$PATH:/path/printed/above"
+export PATH="/path/printed/above:$PATH"
 ```
+
+Once `agentbreeder` is on `PATH`, running `agentbreeder welcome` will print the same hint for you on any future machine.
 
 ### Port conflict (`:5432 already in use`, `:6379`, `:8000`, …)
 

--- a/website/content/docs/full-code.mdx
+++ b/website/content/docs/full-code.mdx
@@ -19,7 +19,7 @@ Build agents entirely in code with the AgentBreeder SDK. Full type safety, custo
 <Tabs items={['Python', 'TypeScript']}>
   <Tab value="Python">
 ```bash
-pip install agentbreeder-sdk
+pipx install agentbreeder-sdk      # or: python3 -m pip install agentbreeder-sdk
 ```
   </Tab>
   <Tab value="TypeScript">

--- a/website/content/docs/how-to.mdx
+++ b/website/content/docs/how-to.mdx
@@ -18,9 +18,18 @@ Recipes for everything that isn't covered by `agentbreeder quickstart`. Each sec
 
 ## Install
 
+We recommend `pipx` — it installs `agentbreeder` into an isolated environment and puts the executable on your `PATH` automatically:
+
 ```bash
-pip3 install agentbreeder          # full CLI + API server + engine
-pip3 install agentbreeder-sdk      # lightweight SDK only
+pipx install agentbreeder            # full CLI + API server + engine
+pipx install agentbreeder-sdk        # lightweight SDK only (uncommon — usually you want the full install)
+```
+
+No pipx? Use the standard installer instead:
+
+```bash
+python3 -m pip install agentbreeder          # works regardless of whether pip / pip3 is on PATH
+python3 -m pip install agentbreeder-sdk
 ```
 
 Requires Python 3.11+. `brew` and `npx` support coming soon. macOS users hitting `command not found` — see [Troubleshooting](#troubleshooting).

--- a/website/content/docs/low-code.mdx
+++ b/website/content/docs/low-code.mdx
@@ -51,7 +51,7 @@ Set `deploy.cloud` and optionally `deploy.runtime`.
 ### 1. Install
 
 ```bash
-pip install agentbreeder
+pipx install agentbreeder    # or: python3 -m pip install agentbreeder
 ```
 
 ### 2. Initialize a project

--- a/website/content/docs/migrations/from-autogen.mdx
+++ b/website/content/docs/migrations/from-autogen.mdx
@@ -17,7 +17,7 @@ description: Migrate an existing AutoGen project to AgentBreeder.
 - [ ] Your agent code uses `autogen-agentchat` (v0.2+) or `pyautogen`
 - [ ] Python 3.11+ is installed
 - [ ] Docker is installed and running
-- [ ] You have installed AgentBreeder: `pip install agentbreeder`
+- [ ] You have installed AgentBreeder: `pipx install agentbreeder` (or `python3 -m pip install agentbreeder`)
 
 ---
 

--- a/website/content/docs/migrations/from-crewai.mdx
+++ b/website/content/docs/migrations/from-crewai.mdx
@@ -17,7 +17,7 @@ description: Migrate an existing CrewAI agent to AgentBreeder.
 - [ ] Your agent code is in a directory with `agent.py` and `requirements.txt`
 - [ ] Python 3.11+ is installed
 - [ ] Docker is installed and running
-- [ ] You have installed AgentBreeder: `pip install agentbreeder`
+- [ ] You have installed AgentBreeder: `pipx install agentbreeder` (or `python3 -m pip install agentbreeder`)
 
 ---
 

--- a/website/content/docs/migrations/from-custom.mdx
+++ b/website/content/docs/migrations/from-custom.mdx
@@ -17,7 +17,7 @@ description: Migrate a custom agent implementation to AgentBreeder.
 - [ ] Your agent can accept a text input and return a text output
 - [ ] Python 3.11+ is installed
 - [ ] Docker is installed and running
-- [ ] You have installed AgentBreeder: `pip install agentbreeder`
+- [ ] You have installed AgentBreeder: `pipx install agentbreeder` (or `python3 -m pip install agentbreeder`)
 
 ---
 

--- a/website/content/docs/migrations/from-langgraph.mdx
+++ b/website/content/docs/migrations/from-langgraph.mdx
@@ -17,7 +17,7 @@ description: Migrate an existing LangGraph agent to AgentBreeder.
 - [ ] Your agent code is in a directory with `agent.py` and `requirements.txt` (or `pyproject.toml`)
 - [ ] Python 3.11+ is installed
 - [ ] Docker is installed and running (for local deploys)
-- [ ] You have installed AgentBreeder: `pip install agentbreeder`
+- [ ] You have installed AgentBreeder: `pipx install agentbreeder` (or `python3 -m pip install agentbreeder`)
 
 ---
 

--- a/website/content/docs/migrations/from-openai-agents.mdx
+++ b/website/content/docs/migrations/from-openai-agents.mdx
@@ -17,7 +17,7 @@ description: Migrate an existing OpenAI Agents project to AgentBreeder.
 - [ ] Your agent code is in `agent.py` or `main.py` with `requirements.txt`
 - [ ] Python 3.11+ is installed
 - [ ] Docker is installed and running
-- [ ] You have installed AgentBreeder: `pip install agentbreeder`
+- [ ] You have installed AgentBreeder: `pipx install agentbreeder` (or `python3 -m pip install agentbreeder`)
 
 ---
 

--- a/website/content/docs/migrations/overview.mdx
+++ b/website/content/docs/migrations/overview.mdx
@@ -74,7 +74,7 @@ deploy:
 ### Step 3: Deploy
 
 ```bash
-pip install agentbreeder
+pipx install agentbreeder    # or: python3 -m pip install agentbreeder
 agentbreeder deploy agent.yaml
 ```
 

--- a/website/content/docs/quickstart.mdx
+++ b/website/content/docs/quickstart.mdx
@@ -10,9 +10,19 @@ import { Callout } from 'fumadocs-ui/components/callout';
 Two commands. Three minutes. Done.
 
 ```bash
-pip3 install agentbreeder
+pipx install agentbreeder
 agentbreeder quickstart
 ```
+
+<Callout type="info" title="No pipx? Use the standard installer instead">
+  ```bash
+  python3 -m pip install agentbreeder
+  ```
+
+  `python3 -m pip` works on every Python install regardless of whether `pip`, `pip3`, or neither is on your `PATH`. If you see `agentbreeder: command not found` after, see [Troubleshooting](#when-something-goes-wrong).
+
+  We recommend `pipx` because it installs `agentbreeder` into an isolated environment and puts the executable on `PATH` automatically — no shell-rc edits, no clashes with other tools.
+</Callout>
 
 <Callout type="info" title="Before you start">
   AgentBreeder needs three things on the machine:
@@ -114,7 +124,7 @@ The 8-step deploy pipeline (parse → RBAC → resolve deps → build container 
 
 | Problem | Fix |
 |---|---|
-| `agentbreeder: command not found` | pip's script directory isn't on `PATH`. Run `python3 -c "import sysconfig; print(sysconfig.get_path('scripts'))"` and add it to your shell rc. |
+| `agentbreeder: command not found` | pip's script directory isn't on `PATH`. Either re-install with `pipx install agentbreeder` (recommended), or find the dir with `python3 -c "import sysconfig; print(sysconfig.get_path('scripts'))"` and prepend it to `PATH` in your shell rc. Running `agentbreeder welcome` once it works prints the same hint. |
 | Port conflict (`:5432 already in use` etc.) | Quickstart will offer to kill the conflicting process. Accept with `y`, or stop it manually. |
 | Container daemon not running | Quickstart will tell you what to start (Docker Desktop, OrbStack, Colima, Podman, systemd, etc.) and re-detect after you confirm. |
 | Stack already up, ports stuck | `agentbreeder down --clean` then retry. |


### PR DESCRIPTION
## Summary

The #1 entry in `quickstart.mdx`'s troubleshooting table has been **`agentbreeder: command not found` after `pip install`** for as long as the docs have existed — pip's script directory often isn't on `PATH`. This PR closes that gap two ways:

1. **Docs lead with `pipx install agentbreeder`** everywhere (pipx installs into an isolated env and puts the binary on a directory that's already on `PATH` on every system). Fallback is `python3 -m pip install agentbreeder`, which works regardless of whether `pip`/`pip3` is on `PATH`. **All `pip3` vs `pip` ambiguity is removed from user-facing install docs.**
2. **`agentbreeder welcome` (and the first-run banner) now show the scripts dir and the exact shell-rc line** to append (zsh / bash / fish / PowerShell). The hint is suppressed when the scripts dir is already on `PATH`, so pipx and venv users see no extra noise.

Closes #463 — the P2 ("drop-off prevention") item on tracker #461. Acceptance criteria from the issue:

- [x] `quickstart.mdx` recommends `pipx install agentbreeder` as the primary path, with `python3 -m pip install agentbreeder` as the alternative.
- [x] No `pip3` vs `pip` ambiguity anywhere in docs.
- [x] First-run `agentbreeder welcome` shows the PATH location and how to add it.

## What changed

**CLI (`cli/main.py`):**
- New helpers `_scripts_dir()`, `_path_entries()`, `_scripts_dir_on_path()`, `_shell_rc_hint()`, `_print_install_path_hint()`.
- The `Install path` panel renders only when `_scripts_dir_on_path()` is false. It prints the scripts dir, the active shell label, the exact `export PATH=…` (or `fish_add_path`, or `$env:PATH = …`) line, and a nudge toward `pipx install agentbreeder` for next time.
- Both `_welcome_cmd()` (the explicit `agentbreeder welcome`) and `_maybe_show_welcome()` (the first-run banner) call the hint before printing the Getting Started panel.

**Docs:**
- `quickstart.mdx` — two-command snippet now reads `pipx install agentbreeder`; new callout points at `python3 -m pip install agentbreeder` for users without pipx; "command not found" troubleshooting row updated.
- `how-to.mdx` — Install section leads with `pipx`, then `python3 -m pip`. `pip3 install` lines removed.
- `faq.mdx` — "command not found" entry now recommends `pipx install` first, then shows the manual `PATH` edit; section header updated to `python3 -m pip install agentbreeder`.
- `full-code.mdx`, `low-code.mdx`, `migrations/overview.mdx`, and all five `migrations/from-*.mdx` checklists — install commands standardized.

**Out of scope (deliberate):**
- Blog posts (time-stamped artifacts) — left as-is.
- The GitHub Actions CI snippet in `evaluations.mdx` — `pip install` is idiomatic in `ubuntu-latest` runners.
- `ROADMAP.md`, `CLAUDE.md`, `ARCHITECTURE.md` — internal docs, not user-facing install paths.

## Test plan

- [x] `python3 -m pytest tests/unit/test_cli_install_path.py tests/unit/test_cli.py -q` — 47 / 47 pass (12 new + 35 existing).
- [x] `python3 -m cli.main welcome` — happy path (scripts dir on PATH) prints just the Getting Started panel; no install-path noise.
- [x] Forced not-on-PATH branch via `mock.patch('cli.main._scripts_dir_on_path', return_value=False)` renders the yellow `Install path` panel with the correct shell-rc line for zsh on my machine.
- [x] `ruff check cli/main.py tests/unit/test_cli_install_path.py` — clean.
- [x] `ruff format --check` — clean.
- [x] `mypy cli/main.py` — clean.
- [x] `grep -rn "pip3 install agentbreeder\|pip install agentbreeder" website/content/docs/` — only `evaluations.mdx` CI snippet remains, which is intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
