### PR TITLE
feat(cli): cloud-only quickstart branch + --no-ollama promotion (#466)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+### v2.5 — Cloud-only quickstart branch (#466)
+
+> **P3 UX gap closed.** A power user with an existing OpenAI / Anthropic / Google API key used to sit through `quickstart`'s Ollama install + ~3 GB model pull whether they wanted local inference or not. `--no-ollama` existed but was buried in the troubleshooting table. Quickstart now asks up front, and the flag is documented as a first-class cloud-only shortcut.
+
+- **Added** `_ask_model_source()` to `cli/commands/quickstart.py` — early in Step 2 (LLM Providers) the interactive wizard asks: **Local** (Ollama + model pull), **Cloud** (skip Ollama, prompt for cloud keys), or **Both** (default, current behavior). Pressing Enter picks "Both" so muscle-memory keeps working; passing `--no-ollama` short-circuits to "Cloud" without prompting; non-TTY runs keep the legacy "Both" behavior so existing CI scripts don't break.
+- **Wired** the new helper into the Step 2 flow: `skip_ollama` is now forwarded to `_ensure_ollama()`, and `skip_cloud_keys` shortcuts past `_collect_provider_keys()` for the Local-only path (Ollama status is still checked via the existing `_ollama_running()` helper so the summary line stays accurate).
+- **Improved** the `--no-ollama` help text on `agentbreeder quickstart --help` from a terse one-liner to a description that names the use case, the time/disk it saves, and that it's equivalent to the interactive Cloud choice.
+- **Added** an `--no-ollama` example to the quickstart docstring's `Examples:` block so it shows up in `--help`.
+- **Docs** — `quickstart.mdx` step-2 description rewritten to name the three model-source options; new "Already have a cloud API key?" callout pointing at `--no-ollama`. `cli-reference.mdx` `quickstart` table updates the `--no-ollama` row, adds the model-source prompt to the "What it does" list, and adds the `--no-ollama` example.
+- **Tests** new `tests/unit/test_quickstart_model_source.py` — 9 cases covering the `--no-ollama` short-circuit, the non-TTY short-circuit (with and without the flag), each interactive branch (1 → Local, 2 → Cloud, 3 → Both), the default-on-Enter case, the invalid-input-then-retry case, and whitespace trimming.
+
 ### v2.5 — First-run guided tour + empty-state hero (#465)
 
 > **P1 UX gap closed.** After first sign-in the user used to land in Studio with a fully populated registry (5 sample agents seeded by quickstart) and zero guidance on what to click. The 4-step welcome tour fixes that, and the no-agents page now ships a hero CTA instead of a one-line text dead-end.

--- a/cli/commands/quickstart.py
+++ b/cli/commands/quickstart.py
@@ -988,6 +988,56 @@ def _start_ollama() -> bool:
     return _ollama_running()
 
 
+def _ask_model_source(no_ollama_flag: bool) -> tuple[bool, bool]:
+    """Ask up front whether to set up local models, cloud providers, or both.
+
+    Returns ``(skip_ollama, skip_cloud_keys)``.
+
+    Short-circuits when the user has already declared their intent:
+      - ``--no-ollama`` on the CLI → ``(True, False)``  (cloud path)
+      - stdin is not a TTY        → ``(no_ollama_flag, False)``  (legacy default)
+
+    Choices:
+      1. Local   — install Ollama, pull a model. Skip cloud key prompts.
+      2. Cloud   — skip Ollama entirely. Prompt for cloud provider keys.
+      3. Both    — default; the original behavior.
+    """
+    if no_ollama_flag:
+        return (True, False)
+    import sys as _sys
+
+    if not _sys.stdin.isatty():
+        return (False, False)
+
+    console.print()
+    console.print(
+        Panel(
+            "[bold cyan]How do you want to run models?[/bold cyan]\n\n"
+            "  [bold]1.[/bold] Local — install Ollama and pull a model "
+            "[dim](~3 GB; offline / privacy)[/dim]\n"
+            "  [bold]2.[/bold] Cloud — OpenAI · Anthropic · Google · OpenRouter "
+            "[dim](BYO API key, no download)[/dim]\n"
+            "  [bold]3.[/bold] Both — local Ollama plus cloud keys "
+            "[dim](default)[/dim]",
+            border_style="cyan",
+            padding=(1, 3),
+        )
+    )
+
+    while True:
+        answer = console.input("  Choice [1/2/3, default=3]: ").strip()
+        if answer in ("", "3"):
+            return (False, False)
+        if answer == "1":
+            return (False, True)
+        if answer == "2":
+            console.print(
+                "  [dim]Skipping Ollama install. Equivalent flag: [bold]--no-ollama[/bold].[/dim]"
+            )
+            return (True, False)
+        console.print("  [red]Enter 1, 2, or 3.[/red]")
+
+
 def _ensure_ollama(skip: bool, default_model: str) -> bool:
     """Interactive bootstrap: install Ollama → start daemon → pull a model.
 
@@ -1493,7 +1543,12 @@ def quickstart(
     no_ollama: bool = typer.Option(
         False,
         "--no-ollama",
-        help="Skip the Ollama install / start / model-pull bootstrap",
+        help=(
+            "Cloud-only setup: skip the Ollama install, daemon start, and model pull "
+            "(saves ~1–2 min and a ~3 GB download). Use this when you already have "
+            "an OpenAI / Anthropic / Google / OpenRouter API key. Equivalent to "
+            "choosing 'Cloud' at the interactive model-source prompt."
+        ),
     ),
     ollama_model: str = typer.Option(
         DEFAULT_LOCAL_MODEL,
@@ -1510,7 +1565,8 @@ def quickstart(
     All agents are usable via CLI and Studio.
 
     Examples:
-        agentbreeder quickstart                     # local only
+        agentbreeder quickstart                     # local only (interactive)
+        agentbreeder quickstart --no-ollama         # cloud-only (skip ~3 GB download)
         agentbreeder quickstart --cloud aws         # local + deploy to AWS
         agentbreeder quickstart --cloud gcp         # local + deploy to GCP
         agentbreeder quickstart --skip-seed         # restart without re-seeding
@@ -1662,9 +1718,13 @@ def quickstart(
     # ── Step 2: LLM providers ────────────────────────────────────────────────
     _step("LLM Providers", 2, total_steps)
 
+    # Ask the user how they want to run models so we can short-circuit either
+    # the Ollama install or the cloud-key prompts.
+    skip_ollama, skip_cloud_keys = _ask_model_source(no_ollama_flag=no_ollama)
+
     # First: offer to install/start Ollama and pull a default local model so the
     # platform has a free, no-API-key inference backend out of the box.
-    _ensure_ollama(skip=no_ollama, default_model=ollama_model)
+    _ensure_ollama(skip=skip_ollama, default_model=ollama_model)
 
     # Read any existing .env from CWD first so we can show masked existing keys.
     _cwd_env: dict[str, str] = {}
@@ -1675,7 +1735,11 @@ def quickstart(
                 _k, _v = _line.split("=", 1)
                 _cwd_env[_k.strip()] = _v.strip()
 
-    new_provider_keys, has_ollama = _collect_provider_keys(_cwd_env)
+    if skip_cloud_keys:
+        new_provider_keys: dict[str, str] = {}
+        has_ollama = _ollama_running()
+    else:
+        new_provider_keys, has_ollama = _collect_provider_keys(_cwd_env)
 
     # Merge new keys into process env so the compose step picks them up
     os.environ.update(new_provider_keys)

--- a/tests/unit/test_quickstart_model_source.py
+++ b/tests/unit/test_quickstart_model_source.py
@@ -1,0 +1,71 @@
+"""Tests for the quickstart model-source prompt (issue #466)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from cli.commands.quickstart import _ask_model_source
+
+
+class TestNoOllamaFlagShortCircuit:
+    def test_no_ollama_flag_skips_prompt_and_returns_cloud_path(self) -> None:
+        with patch("cli.commands.quickstart.console.input") as mock_input:
+            result = _ask_model_source(no_ollama_flag=True)
+        assert result == (True, False)
+        mock_input.assert_not_called()
+
+
+class TestNonTtyShortCircuit:
+    def test_non_tty_keeps_legacy_default(self) -> None:
+        with patch("sys.stdin.isatty", return_value=False):
+            with patch("cli.commands.quickstart.console.input") as mock_input:
+                result = _ask_model_source(no_ollama_flag=False)
+        assert result == (False, False)
+        mock_input.assert_not_called()
+
+    def test_non_tty_respects_no_ollama_flag(self) -> None:
+        with patch("sys.stdin.isatty", return_value=False):
+            result = _ask_model_source(no_ollama_flag=True)
+        assert result == (True, False)
+
+
+class TestInteractivePrompt:
+    def _mock_tty_and_inputs(self, *answers: str):
+        return (
+            patch("sys.stdin.isatty", return_value=True),
+            patch(
+                "cli.commands.quickstart.console.input",
+                side_effect=list(answers),
+            ),
+        )
+
+    def test_choice_1_local_skips_cloud_keys(self) -> None:
+        tty, inputs = self._mock_tty_and_inputs("1")
+        with tty, inputs:
+            assert _ask_model_source(no_ollama_flag=False) == (False, True)
+
+    def test_choice_2_cloud_skips_ollama(self) -> None:
+        tty, inputs = self._mock_tty_and_inputs("2")
+        with tty, inputs:
+            assert _ask_model_source(no_ollama_flag=False) == (True, False)
+
+    def test_choice_3_both_is_default(self) -> None:
+        tty, inputs = self._mock_tty_and_inputs("3")
+        with tty, inputs:
+            assert _ask_model_source(no_ollama_flag=False) == (False, False)
+
+    def test_empty_answer_falls_back_to_default(self) -> None:
+        """Pressing Enter at the prompt picks option 3 (Both)."""
+        tty, inputs = self._mock_tty_and_inputs("")
+        with tty, inputs:
+            assert _ask_model_source(no_ollama_flag=False) == (False, False)
+
+    def test_invalid_answer_retries_then_accepts(self) -> None:
+        tty, inputs = self._mock_tty_and_inputs("hello", "42", "2")
+        with tty, inputs:
+            assert _ask_model_source(no_ollama_flag=False) == (True, False)
+
+    def test_whitespace_is_trimmed_before_matching(self) -> None:
+        tty, inputs = self._mock_tty_and_inputs("  1  ")
+        with tty, inputs:
+            assert _ask_model_source(no_ollama_flag=False) == (False, True)

--- a/website/content/docs/cli-reference.mdx
+++ b/website/content/docs/cli-reference.mdx
@@ -106,12 +106,12 @@ agentbreeder quickstart [--cloud TARGET] [--no-browser] [--skip-seed] [--dev] [-
 | `--skip-seed` | Off | Skip ChromaDB + Neo4j seeding (fast restart) |
 | `--dev` | Off | Build API and Studio from local source instead of pulling images |
 | `--reset` | Off | Tear down all docker volumes (postgres, redis, chromadb, neo4j) and start fresh |
-| `--no-ollama` | Off | Skip the Ollama install/start/pull bootstrap step |
+| `--no-ollama` | Off | **Cloud-only setup.** Skip the Ollama install, daemon start, and model pull (saves ~1–2 min and a ~3 GB download). Equivalent to choosing **Cloud** at the interactive model-source prompt. |
 | `--ollama-model` | `gemma3` | Pull a different default model for Ollama (e.g. `llama3.2`, `phi4-mini`) |
 
 What it does:
 1. Detects Docker / Podman; shows OS-specific install instructions if neither is found
-2. Checks for Ollama and cloud API keys; suggests `agentbreeder setup` if neither is found
+2. Asks how you want to run models: **Local** (Ollama, ~3 GB), **Cloud** (BYO API key), or **Both** (default). Press Enter at the prompt to take the default; pass `--no-ollama` to short-circuit to Cloud. Non-interactive runs keep the legacy "Both" behavior.
 3. Creates `.env` with secure random secrets if not present
 4. Starts the full stack via `docker-compose.quickstart.yml`: API · Studio · PostgreSQL · Redis · ChromaDB · Neo4j · MCP servers · LiteLLM
 5. Waits for all services with a live progress bar
@@ -121,7 +121,8 @@ What it does:
 
 **Examples:**
 ```bash
-agentbreeder quickstart                       # Local only
+agentbreeder quickstart                       # Local only, interactive
+agentbreeder quickstart --no-ollama           # Cloud-only (skip ~3 GB download)
 agentbreeder quickstart --cloud gcp           # Local + deploy to GCP Cloud Run (shipped greenfield)
 agentbreeder quickstart --cloud aws           # Local + deploy to AWS ECS Fargate (requires existing VPC + IAM)
 agentbreeder quickstart --cloud azure         # Local + deploy to Azure Container Apps (requires existing resource group)

--- a/website/content/docs/quickstart.mdx
+++ b/website/content/docs/quickstart.mdx
@@ -17,13 +17,23 @@ agentbreeder quickstart
 `agentbreeder quickstart` is interactive and walks you through everything:
 
 1. Detects (or installs) Docker, Podman, or nerdctl
-2. Detects (or installs) Ollama and pulls a local model — `gemma3` by default
-3. Optionally collects cloud API keys (OpenAI, Anthropic, Google, OpenRouter)
+2. Asks how you want to run models: **Local** (Ollama, ~3 GB download), **Cloud** (OpenAI / Anthropic / Google / OpenRouter API keys), or **Both** (default)
+3. Sets up the path you chose — installs Ollama and pulls `gemma3`, collects cloud API keys, or both
 4. Frees any conflicting ports for you on confirmation
 5. Starts the full stack — API · Studio · Postgres · Redis · ChromaDB · Neo4j · MCP servers · LiteLLM
 6. Seeds RAG docs, the knowledge graph, MCP servers, and prompts
 7. Deploys 5 sample agents (`assistant`, `rag-agent`, `graph-agent`, `search-agent`, `a2a-orchestrator`)
 8. Opens Studio at [http://localhost:3001](http://localhost:3001)
+
+<Callout type="info" title="Already have a cloud API key?">
+  Skip the ~3 GB Ollama download with the `--no-ollama` flag:
+
+  ```bash
+  agentbreeder quickstart --no-ollama
+  ```
+
+  Equivalent to choosing **Cloud** at the model-source prompt. You'll still be asked for OpenAI / Anthropic / Google / OpenRouter keys at the cloud-key step.
+</Callout>
 
 <Callout type="info" title="Default login">
   **Email:** `admin@agentbreeder.local` · **Password:** `plant`


### PR DESCRIPTION
## Summary

A power user with an existing OpenAI / Anthropic / Google API key used to sit through `quickstart`'s Ollama install + **~3 GB model pull** whether they wanted local inference or not. The `--no-ollama` escape hatch existed but was buried in the troubleshooting table.

This PR surfaces the choice up front and makes `--no-ollama` a first-class cloud-only shortcut.

```
How do you want to run models?
  1. Local  — install Ollama and pull a model (~3 GB; offline / privacy)
  2. Cloud  — OpenAI · Anthropic · Google · OpenRouter (BYO API key)
  3. Both   — local Ollama plus cloud keys (default)
```

- Choice **2** (or `--no-ollama` on the CLI) → skips `_ensure_ollama()` entirely; user still gets the cloud-key prompts.
- Choice **1** → skips `_collect_provider_keys()`; Ollama status for the summary line still comes from the existing `_ollama_running()` helper, so the printed summary stays accurate.
- Choice **3** / Enter / non-TTY → keeps the existing behavior, so CI scripts and muscle-memory both keep working.

Closes #466. Acceptance criteria from the issue:

- [x] Interactive `quickstart` asks model-source preference up front.
- [x] Cloud-only path skips Ollama install + model pull (saves 1–2 min on first run and a ~3 GB download).
- [x] `quickstart --help` lists `--no-ollama` prominently — help string rewritten from a terse one-liner to a description that names the use case, the savings, and that it's equivalent to the interactive Cloud choice. New `--no-ollama` example line added to the docstring's `Examples:` block (which `--help` renders verbatim).
- [x] Docs updated: `quickstart.mdx` step-2 description rewritten + new "Already have a cloud API key?" callout; `cli-reference.mdx` table + examples updated.

## Design notes

- The prompt short-circuits when the user has already declared intent. `--no-ollama` → `(skip_ollama=True, skip_cloud_keys=False)` without ever printing the prompt. Non-TTY → legacy `(no_ollama, False)` behavior so existing CI scripts don't suddenly hang on `stdin.read()`.
- The `_collect_provider_keys()` call already returns `(dict, has_ollama)` — to keep the Local-only path's summary line accurate without duplicating its inline httpx call, the new `skip_cloud_keys` branch reuses the existing `_ollama_running()` helper. (The duplication between `_ollama_running()` and `_collect_provider_keys()`'s inline check is pre-existing; not in scope for this PR.)
- Default-to-3 means the experience is unchanged for anyone who learned to just hit Enter. The prompt is additive.

## Test plan

- [x] `python3 -m pytest tests/unit/test_quickstart_model_source.py tests/unit/test_cli.py -q` — 44 / 44 pass (9 new + 35 existing).
- [x] `python3 -m cli.main quickstart --help` — `--no-ollama` row shows the new description; the new `--no-ollama` example appears in the docstring block.
- [x] `ruff check` + `ruff format --check` — clean (one auto-format pass).
- [x] Manual non-interactive smoke: piping `printf '\n' | agentbreeder quickstart` (would-be-TTY simulation) short-circuits past the new prompt via `sys.stdin.isatty()` — confirmed by the `test_non_tty_*` cases.

## Out of scope

- The "deprioritize the cloud-key prompts" suggestion from the issue: I implemented it as "skip them entirely" for Choice 1, because users who pick Local explicitly don't want to be asked. If you'd prefer "still ask but with `Enter to skip` more prominent," happy to change.
- Refactoring the inline httpx Ollama check inside `_collect_provider_keys()` to reuse `_ollama_running()` — noted in the design notes; will track separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
