### PR TITLE
feat(cli): realistic quickstart expectations + --yes for scripted runs (#468)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+### v2.5 — Realistic quickstart expectations + `--yes` for scripted runs (#468)
+
+> **P3 trust gap closed.** "Two commands. That's it." was technically true and practically misleading — `quickstart` is an interactive wizard with up to six prompts (container runtime, model source, port conflicts, Ollama install, model pull, cloud keys), plus a ~3 GB download if you pick Ollama. The new headline sets realistic expectations, the new callout names what the wizard will ask, and a `--yes` flag gives CI users a true zero-prompt path.
+
+- **Added** a `--yes` / `-y` flag to `agentbreeder quickstart`. Sets a module-level sentinel consulted by 13 `console.input` call sites so every yes/no prompt picks the safe default: model-source falls back to the legacy "Both" path (or Cloud when `--no-ollama` is set), port-conflict killer auto-accepts, Ollama install / rebind / model-pull / Studio rebuild auto-accept, missing env keys are silently skipped. Blocking prompts that require human input (e.g. "press Enter once the daemon is up") **exit fast with a clear error** instead of waiting on stdin. `--yes` deliberately does **not** auto-install Docker (heavy side effect, sudo) and does **not** invent provider keys (export `OPENAI_API_KEY` etc. before running). The recommended scripted recipe is `agentbreeder quickstart --yes --no-ollama --no-browser`.
+- **Marketing copy** — `quickstart.mdx` headline changes from "Two commands. That's it." to "Two commands. Three minutes. Done." A new "What to expect" callout names the interactive prompts and the ~3 GB download, plus shows the scripted recipe.
+- **Docs sync** — `cli-reference.mdx` `quickstart` table gains a `--yes` row that names every prompt the flag short-circuits and explicitly calls out the two things it does not do (auto-install Docker, invent provider keys). `quickstart.mdx` "Useful flags" table gets a matching `--yes` / `-y` row. The fully-scripted example is added to both the `Examples:` block in the docstring and the docs Examples list.
+- **Tests** new `tests/unit/test_quickstart_assume_yes.py` — 9 cases covering the flag toggle, `_ask_model_source` short-circuit (with/without `--no-ollama`, TTY override), `_collect_provider_keys` non-interactive paths (Ollama reachable / unreachable / no keys collected), and a signature-introspection check confirming `quickstart()` exposes both `--yes` and `-y` decls. Existing 9 model-source tests still pass.
+
 ### v2.5 — Cloud-only quickstart branch (#466)
 
 > **P3 UX gap closed.** A power user with an existing OpenAI / Anthropic / Google API key used to sit through `quickstart`'s Ollama install + ~3 GB model pull whether they wanted local inference or not. `--no-ollama` existed but was buried in the troubleshooting table. Quickstart now asks up front, and the flag is documented as a first-class cloud-only shortcut.

--- a/cli/commands/quickstart.py
+++ b/cli/commands/quickstart.py
@@ -41,6 +41,21 @@ from rich.table import Table
 
 console = Console()
 
+# Set by quickstart() when --yes is passed. Consulted by prompt helpers so we
+# don't have to thread the flag through every single console.input call site.
+_ASSUME_YES = False
+
+
+def _is_assume_yes() -> bool:
+    """Return True if quickstart was invoked with --yes."""
+    return _ASSUME_YES
+
+
+def _set_assume_yes(value: bool) -> None:
+    global _ASSUME_YES
+    _ASSUME_YES = value
+
+
 # ── Paths ──────────────────────────────────────────────────────────────────
 REPO_ROOT = Path(__file__).parent.parent.parent
 DEPLOY_DIR = REPO_ROOT / "deploy"
@@ -709,7 +724,7 @@ def _check_cloud_prerequisites(target: str) -> bool:
     return True
 
 
-def _guide_cloud_deploy(target: str) -> None:
+def _guide_cloud_deploy(target: str, assume_yes: bool = False) -> None:
     """Interactive guide for deploying to AWS / GCP / Azure."""
     docs_url = CLOUD_DEPLOY_DOCS.get(target, "https://docs.agentbreeder.io")
 
@@ -753,11 +768,15 @@ def _guide_cloud_deploy(target: str) -> None:
     missing_keys = [k for k in info["env_keys"] if not os.environ.get(k)]
     if missing_keys:
         console.print("  [yellow]Missing environment variables:[/yellow]")
-        for k in missing_keys:
-            val = console.input(f"    [bold]{k}[/bold] (or Enter to skip): ").strip()
-            if val:
-                os.environ[k] = val
-                _write_env_key(k, val)
+        if _is_assume_yes():
+            for k in missing_keys:
+                console.print(f"    [dim]{k}[/dim] [dim](--yes: skipped)[/dim]")
+        else:
+            for k in missing_keys:
+                val = console.input(f"    [bold]{k}[/bold] (or Enter to skip): ").strip()
+                if val:
+                    os.environ[k] = val
+                    _write_env_key(k, val)
         console.print()
 
     console.print("  [bold]Deploy command:[/bold]")
@@ -766,7 +785,14 @@ def _guide_cloud_deploy(target: str) -> None:
     console.print(f"  [dim]Docs: {docs_url}[/dim]")
     console.print()
 
-    proceed = console.input("  [bold]Deploy now? (y/N): [/bold]").strip().lower()
+    if assume_yes:
+        console.print(
+            "  [dim]--yes: skipping interactive cloud deploy. Run "
+            f"[cyan]{info['cmd']} <agent.yaml>[/cyan] when you're ready.[/dim]"
+        )
+        proceed = "n"
+    else:
+        proceed = console.input("  [bold]Deploy now? (y/N): [/bold]").strip().lower()
     if proceed == "y":
         yaml_files = sorted(EXAMPLES_QS.glob("*.yaml"))
         if yaml_files:
@@ -988,14 +1014,14 @@ def _start_ollama() -> bool:
     return _ollama_running()
 
 
-def _ask_model_source(no_ollama_flag: bool) -> tuple[bool, bool]:
+def _ask_model_source(no_ollama_flag: bool, assume_yes: bool = False) -> tuple[bool, bool]:
     """Ask up front whether to set up local models, cloud providers, or both.
 
     Returns ``(skip_ollama, skip_cloud_keys)``.
 
     Short-circuits when the user has already declared their intent:
       - ``--no-ollama`` on the CLI → ``(True, False)``  (cloud path)
-      - stdin is not a TTY        → ``(no_ollama_flag, False)``  (legacy default)
+      - ``--yes`` / non-TTY         → ``(no_ollama_flag, False)``  (legacy default)
 
     Choices:
       1. Local   — install Ollama, pull a model. Skip cloud key prompts.
@@ -1006,7 +1032,7 @@ def _ask_model_source(no_ollama_flag: bool) -> tuple[bool, bool]:
         return (True, False)
     import sys as _sys
 
-    if not _sys.stdin.isatty():
+    if assume_yes or not _sys.stdin.isatty():
         return (False, False)
 
     console.print()
@@ -1063,6 +1089,9 @@ def _ensure_ollama(skip: bool, default_model: str) -> bool:
                 "  [dim]Auto-install isn't supported on this OS.[/dim]\n"
                 "  [dim]Download manually: [cyan]https://ollama.com/download[/cyan][/dim]"
             )
+            if _is_assume_yes():
+                _info("--yes: skipping Ollama (manual install required on this OS)")
+                return False
             ans = (
                 console.input(
                     "  [bold]Press Enter once installed, or type [cyan]skip[/cyan]: [/bold]"
@@ -1075,14 +1104,18 @@ def _ensure_ollama(skip: bool, default_model: str) -> bool:
                 return False
         else:
             cmd_parts, human = install
-            ans = (
-                console.input(
-                    f"  [bold]Install Ollama now?[/bold] "
-                    f"[dim](runs: [cyan]{human}[/cyan])[/dim] [Y/n]: "
+            if _is_assume_yes():
+                console.print(f"  [dim]--yes: installing Ollama ([cyan]{human}[/cyan])[/dim]")
+                ans = "y"
+            else:
+                ans = (
+                    console.input(
+                        f"  [bold]Install Ollama now?[/bold] "
+                        f"[dim](runs: [cyan]{human}[/cyan])[/dim] [Y/n]: "
+                    )
+                    .strip()
+                    .lower()
                 )
-                .strip()
-                .lower()
-            )
             if ans in ("n", "no", "skip"):
                 _info("Skipping Ollama install")
                 return False
@@ -1116,16 +1149,20 @@ def _ensure_ollama(skip: bool, default_model: str) -> bool:
             "Ollama is listening on [cyan]127.0.0.1[/cyan] only — Docker "
             "containers cannot reach it via [cyan]host.docker.internal[/cyan]."
         )
-        ans = (
-            console.input(
-                "  [bold]Rebind Ollama to 0.0.0.0:11434 so containers can "
-                "reach it?[/bold] [dim](runs: [cyan]launchctl setenv "
-                "OLLAMA_HOST 0.0.0.0:11434[/cyan] + restarts Ollama)[/dim] "
-                "[Y/n]: "
+        if _is_assume_yes():
+            console.print("  [dim]--yes: rebinding Ollama to 0.0.0.0:11434[/dim]")
+            ans = "y"
+        else:
+            ans = (
+                console.input(
+                    "  [bold]Rebind Ollama to 0.0.0.0:11434 so containers can "
+                    "reach it?[/bold] [dim](runs: [cyan]launchctl setenv "
+                    "OLLAMA_HOST 0.0.0.0:11434[/cyan] + restarts Ollama)[/dim] "
+                    "[Y/n]: "
+                )
+                .strip()
+                .lower()
             )
-            .strip()
-            .lower()
-        )
         if ans not in ("n", "no", "skip"):
             console.print("  [dim]Rebinding Ollama daemon...[/dim]")
             if _rebind_ollama_all_interfaces():
@@ -1159,9 +1196,13 @@ def _ensure_ollama(skip: bool, default_model: str) -> bool:
         "  [dim]Other good picks: [cyan]llama3.2[/cyan] · [cyan]phi4-mini[/cyan] · "
         "[cyan]qwen2.5[/cyan] · [cyan]mistral[/cyan][/dim]"
     )
-    ans = console.input(
-        "  [bold]Pull a model now?[/bold] [Y/n / type a model name to override]: "
-    ).strip()
+    if _is_assume_yes():
+        console.print(f"  [dim]--yes: pulling [cyan]{default_model}[/cyan][/dim]")
+        ans = ""
+    else:
+        ans = console.input(
+            "  [bold]Pull a model now?[/bold] [Y/n / type a model name to override]: "
+        ).strip()
     if ans.lower() in ("n", "no", "skip"):
         _warn("No model pulled — agents will need a model before they can run")
         return False
@@ -1176,8 +1217,12 @@ def _ensure_ollama(skip: bool, default_model: str) -> bool:
     return False
 
 
-def _collect_provider_keys(existing_env: dict) -> tuple[dict, bool]:
-    """Interactively prompt for cloud API keys. Returns (new_keys_dict, has_ollama)."""
+def _collect_provider_keys(existing_env: dict, assume_yes: bool = False) -> tuple[dict, bool]:
+    """Interactively prompt for cloud API keys. Returns (new_keys_dict, has_ollama).
+
+    Under ``--yes`` the prompts are skipped — the caller is expected to have
+    already exported provider keys via the environment.
+    """
     has_ollama = False
     try:
         resp = httpx.get("http://localhost:11434/", timeout=3.0)
@@ -1203,6 +1248,14 @@ def _collect_provider_keys(existing_env: dict) -> tuple[dict, bool]:
             console.print(f"  [green]●[/green] {name}  [dim]({masked} — already set)[/dim]")
         else:
             console.print(f"  [dim]○[/dim] {name}  [dim]({models})[/dim]")
+
+    if assume_yes:
+        console.print()
+        console.print(
+            "  [dim]--yes: skipping key prompts. Set provider keys via env vars "
+            "(e.g. [cyan]OPENAI_API_KEY[/cyan]) before re-running if any are missing.[/dim]"
+        )
+        return {}, has_ollama
 
     console.print()
     console.print("  [bold]Add or update API keys[/bold]  [dim](press Enter to skip any)[/dim]")
@@ -1555,6 +1608,17 @@ def quickstart(
         "--ollama-model",
         help=f"Default local model to pull when none are installed (default: {DEFAULT_LOCAL_MODEL})",
     ),
+    assume_yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help=(
+            "Non-interactive mode for CI / scripted runs. Skip every yes/no prompt "
+            "and use the safe default for each. Pair with --no-ollama and "
+            "--no-browser for a fully scripted bootstrap. Provider keys must be "
+            "supplied via env vars (OPENAI_API_KEY etc.) — --yes does not invent them."
+        ),
+    ),
 ) -> None:
     """Full local platform bootstrap — one command to go from zero to running agents.
 
@@ -1565,12 +1629,20 @@ def quickstart(
     All agents are usable via CLI and Studio.
 
     Examples:
-        agentbreeder quickstart                     # local only (interactive)
-        agentbreeder quickstart --no-ollama         # cloud-only (skip ~3 GB download)
-        agentbreeder quickstart --cloud aws         # local + deploy to AWS
-        agentbreeder quickstart --cloud gcp         # local + deploy to GCP
-        agentbreeder quickstart --skip-seed         # restart without re-seeding
+        agentbreeder quickstart                                  # local only (interactive)
+        agentbreeder quickstart --no-ollama                      # cloud-only (skip ~3 GB download)
+        agentbreeder quickstart --yes --no-ollama --no-browser   # fully scripted (CI)
+        agentbreeder quickstart --cloud aws                      # local + deploy to AWS
+        agentbreeder quickstart --cloud gcp                      # local + deploy to GCP
+        agentbreeder quickstart --skip-seed                      # restart without re-seeding
     """
+    _set_assume_yes(assume_yes)
+    if assume_yes:
+        console.print(
+            "  [dim]--yes: non-interactive mode. Yes/no prompts will use safe defaults; "
+            "blocking prompts (e.g. 'press Enter once daemon is up') will exit instead "
+            "of waiting.[/dim]"
+        )
     total_steps = 9 if cloud else 8
 
     if reset:
@@ -1635,10 +1707,12 @@ def quickstart(
             )
         )
         # Offer to run an auto-install for the user when we know how.
+        # --yes intentionally does *not* trigger Docker install — it's a heavy
+        # side effect (sudo, downloads, daemon spawn) we don't want in CI.
         install = _runtime_install_command()
         import sys as _sys
 
-        if install and _sys.stdin.isatty():
+        if install and _sys.stdin.isatty() and not assume_yes:
             cmd_parts, human = install
             console.print()
             ans = (
@@ -1697,6 +1771,12 @@ def quickstart(
         else:
             console.print(f"  [dim]Start the {binary} daemon and re-run.[/dim]")
         console.print()
+        if assume_yes:
+            console.print(
+                "  [red]--yes: cannot wait for a daemon to start. "
+                "Start the runtime and re-run.[/red]"
+            )
+            raise typer.Exit(code=1)
         console.input(
             "  [bold]Press Enter once any container runtime is running "
             "(or Ctrl+C to cancel): [/bold]"
@@ -1720,7 +1800,9 @@ def quickstart(
 
     # Ask the user how they want to run models so we can short-circuit either
     # the Ollama install or the cloud-key prompts.
-    skip_ollama, skip_cloud_keys = _ask_model_source(no_ollama_flag=no_ollama)
+    skip_ollama, skip_cloud_keys = _ask_model_source(
+        no_ollama_flag=no_ollama, assume_yes=assume_yes
+    )
 
     # First: offer to install/start Ollama and pull a default local model so the
     # platform has a free, no-API-key inference backend out of the box.
@@ -1739,7 +1821,7 @@ def quickstart(
         new_provider_keys: dict[str, str] = {}
         has_ollama = _ollama_running()
     else:
-        new_provider_keys, has_ollama = _collect_provider_keys(_cwd_env)
+        new_provider_keys, has_ollama = _collect_provider_keys(_cwd_env, assume_yes=assume_yes)
 
     # Merge new keys into process env so the compose step picks them up
     os.environ.update(new_provider_keys)
@@ -1780,9 +1862,18 @@ def quickstart(
                 padding=(1, 2),
             )
         )
-        proceed = (
-            console.input("  [bold]Continue without a provider? (y/N): [/bold]").strip().lower()
-        )
+        if assume_yes:
+            console.print(
+                "  [dim]--yes: continuing without a provider — "
+                "set OPENAI_API_KEY (or equivalent) in the environment before re-running.[/dim]"
+            )
+            proceed = "y"
+        else:
+            proceed = (
+                console.input("  [bold]Continue without a provider? (y/N): [/bold]")
+                .strip()
+                .lower()
+            )
         if proceed != "y":
             console.print(
                 "  [dim]Re-run agentbreeder quickstart and enter an API key above.[/dim]"
@@ -1892,7 +1983,11 @@ def quickstart(
                     "  [dim]N = exit so you can stop them yourself "
                     "(safer if any of these are services you care about)[/dim]"
                 )
-                ans = console.input("  > ").strip().lower()
+                if assume_yes:
+                    console.print("  [dim]--yes: auto-killing conflicting processes[/dim]")
+                    ans = "y"
+                else:
+                    ans = console.input("  > ").strip().lower()
                 if ans == "y":
                     still = _kill_port_owners(all_pids)
                     time.sleep(1.0)
@@ -2237,15 +2332,19 @@ def quickstart(
             # offer to rebuild the Studio image locally.
             dashboard_src = REPO_ROOT / "dashboard" / "package.json"
             if dashboard_src.exists():
-                ans = (
-                    console.input(
-                        "  [bold]Rebuild Studio from source now?[/bold] "
-                        "[dim](runs: compose up -d --build dashboard)[/dim] "
-                        "[Y/n]: "
+                if _is_assume_yes():
+                    console.print("  [dim]--yes: rebuilding Studio from source[/dim]")
+                    ans = "y"
+                else:
+                    ans = (
+                        console.input(
+                            "  [bold]Rebuild Studio from source now?[/bold] "
+                            "[dim](runs: compose up -d --build dashboard)[/dim] "
+                            "[Y/n]: "
+                        )
+                        .strip()
+                        .lower()
                     )
-                    .strip()
-                    .lower()
-                )
                 if ans not in ("n", "no", "skip"):
                     console.print("  [dim]Rebuilding Studio image (~30s)...[/dim]")
                     rebuild = _compose_run(
@@ -2362,7 +2461,7 @@ def quickstart(
                 )
             )
         else:
-            _guide_cloud_deploy(cloud)
+            _guide_cloud_deploy(cloud, assume_yes=assume_yes)
 
     # ── Final summary ─────────────────────────────────────────────────────────
     _print_final_summary(services_ok, [p.stem for p in sorted(EXAMPLES_QS.glob("*.yaml"))])

--- a/tests/unit/test_quickstart_assume_yes.py
+++ b/tests/unit/test_quickstart_assume_yes.py
@@ -1,0 +1,101 @@
+"""Tests for the quickstart --yes (assume_yes) non-interactive plumbing (issue #468)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from cli.commands import quickstart
+from cli.commands.quickstart import (
+    _ask_model_source,
+    _collect_provider_keys,
+    _is_assume_yes,
+    _set_assume_yes,
+)
+
+
+class TestAssumeYesFlagToggle:
+    def setup_method(self) -> None:
+        _set_assume_yes(False)
+
+    def teardown_method(self) -> None:
+        _set_assume_yes(False)
+
+    def test_default_state_is_false(self) -> None:
+        assert _is_assume_yes() is False
+
+    def test_set_assume_yes_flips_flag(self) -> None:
+        _set_assume_yes(True)
+        assert _is_assume_yes() is True
+        _set_assume_yes(False)
+        assert _is_assume_yes() is False
+
+
+class TestAskModelSourceWithAssumeYes:
+    def test_assume_yes_without_no_ollama_returns_legacy_default(self) -> None:
+        """--yes alone falls into the non-TTY path = (False, False) = Both."""
+        with patch("cli.commands.quickstart.console.input") as mock_input:
+            result = _ask_model_source(no_ollama_flag=False, assume_yes=True)
+        assert result == (False, False)
+        mock_input.assert_not_called()
+
+    def test_assume_yes_with_no_ollama_short_circuits_to_cloud(self) -> None:
+        with patch("cli.commands.quickstart.console.input") as mock_input:
+            result = _ask_model_source(no_ollama_flag=True, assume_yes=True)
+        assert result == (True, False)
+        mock_input.assert_not_called()
+
+    def test_assume_yes_overrides_tty_check(self) -> None:
+        """Even on a TTY, --yes must skip the interactive prompt."""
+        with patch("sys.stdin.isatty", return_value=True):
+            with patch("cli.commands.quickstart.console.input") as mock_input:
+                result = _ask_model_source(no_ollama_flag=False, assume_yes=True)
+        assert result == (False, False)
+        mock_input.assert_not_called()
+
+
+class TestCollectProviderKeysWithAssumeYes:
+    def test_assume_yes_skips_all_prompts(self) -> None:
+        with patch("httpx.get") as mock_get:
+            mock_get.return_value.status_code = 200
+            with patch("cli.commands.quickstart.console.input") as mock_input:
+                collected, has_ollama = _collect_provider_keys({}, assume_yes=True)
+        assert collected == {}
+        assert has_ollama is True
+        mock_input.assert_not_called()
+
+    def test_assume_yes_still_reports_ollama_status(self) -> None:
+        """The ollama detection should still run — only the per-key prompts skip."""
+        with patch("httpx.get") as mock_get:
+            mock_get.return_value.status_code = 200
+            collected, has_ollama = _collect_provider_keys({}, assume_yes=True)
+        assert has_ollama is True
+        assert collected == {}
+
+    def test_assume_yes_handles_ollama_unreachable(self) -> None:
+        import httpx
+
+        with patch("httpx.get", side_effect=httpx.ConnectError("nope")):
+            collected, has_ollama = _collect_provider_keys({}, assume_yes=True)
+        assert collected == {}
+        assert has_ollama is False
+
+
+class TestQuickstartFunctionWiresAssumeYes:
+    """Smoke test: the typer command exposes --yes / -y and threads it through."""
+
+    def test_help_mentions_yes_flag(self) -> None:
+        # Inspect the typer command's params instead of running the full command.
+        # Each typer.Option becomes a default value with a `.param_decls` tuple.
+        func = quickstart.quickstart
+        # Defaults are typer.OptionInfo objects. We look for the --yes flag.
+        import inspect
+
+        sig = inspect.signature(func)
+        assume_yes_param = sig.parameters.get("assume_yes")
+        assert assume_yes_param is not None, "quickstart() must accept assume_yes"
+        opt = assume_yes_param.default
+        # typer.OptionInfo stores declarations under `param_decls`
+        decls = getattr(opt, "param_decls", ()) or ()
+        flags = {d for d in decls if isinstance(d, str)}
+        assert "--yes" in flags
+        assert "-y" in flags

--- a/website/content/docs/cli-reference.mdx
+++ b/website/content/docs/cli-reference.mdx
@@ -96,7 +96,8 @@ agentbreeder context clear            # Fall back to your primary team
 Full local platform bootstrap — Docker, services, sample data, 5 sample agents, and Studio in one command.
 
 ```
-agentbreeder quickstart [--cloud TARGET] [--no-browser] [--skip-seed] [--dev] [--reset] [--no-ollama] [--ollama-model NAME]
+agentbreeder quickstart [--cloud TARGET] [--no-browser] [--skip-seed] [--dev] [--reset]
+                        [--no-ollama] [--ollama-model NAME] [--yes]
 ```
 
 | Option | Default | Description |
@@ -108,6 +109,7 @@ agentbreeder quickstart [--cloud TARGET] [--no-browser] [--skip-seed] [--dev] [-
 | `--reset` | Off | Tear down all docker volumes (postgres, redis, chromadb, neo4j) and start fresh |
 | `--no-ollama` | Off | **Cloud-only setup.** Skip the Ollama install, daemon start, and model pull (saves ~1–2 min and a ~3 GB download). Equivalent to choosing **Cloud** at the interactive model-source prompt. |
 | `--ollama-model` | `gemma3` | Pull a different default model for Ollama (e.g. `llama3.2`, `phi4-mini`) |
+| `--yes`, `-y` | Off | **Non-interactive mode for CI / scripted runs.** Skip every yes/no prompt and use safe defaults: model-source falls back to the legacy "Both" path (or Cloud when `--no-ollama` is set), port conflicts get auto-killed, Ollama install/rebind/model-pull and Studio rebuild are auto-accepted. Blocking prompts that require human input (e.g. "press Enter once the daemon is up") exit fast instead of waiting. Does **not** auto-install Docker — runtime must already be present. Does **not** invent provider keys — export `OPENAI_API_KEY` (or equivalent) before running. |
 
 What it does:
 1. Detects Docker / Podman; shows OS-specific install instructions if neither is found
@@ -121,13 +123,14 @@ What it does:
 
 **Examples:**
 ```bash
-agentbreeder quickstart                       # Local only, interactive
-agentbreeder quickstart --no-ollama           # Cloud-only (skip ~3 GB download)
-agentbreeder quickstart --cloud gcp           # Local + deploy to GCP Cloud Run (shipped greenfield)
-agentbreeder quickstart --cloud aws           # Local + deploy to AWS ECS Fargate (requires existing VPC + IAM)
-agentbreeder quickstart --cloud azure         # Local + deploy to Azure Container Apps (requires existing resource group)
-agentbreeder quickstart --skip-seed           # Restart stack without re-seeding data
-agentbreeder quickstart --dev                 # Build from source
+agentbreeder quickstart                                  # Local only, interactive
+agentbreeder quickstart --no-ollama                      # Cloud-only (skip ~3 GB download)
+agentbreeder quickstart --yes --no-ollama --no-browser   # Fully scripted (CI)
+agentbreeder quickstart --cloud gcp                      # Local + deploy to GCP Cloud Run (shipped greenfield)
+agentbreeder quickstart --cloud aws                      # Local + deploy to AWS ECS Fargate (requires existing VPC + IAM)
+agentbreeder quickstart --cloud azure                    # Local + deploy to Azure Container Apps (requires existing resource group)
+agentbreeder quickstart --skip-seed                      # Restart stack without re-seeding data
+agentbreeder quickstart --dev                            # Build from source
 ```
 
 ---

--- a/website/content/docs/quickstart.mdx
+++ b/website/content/docs/quickstart.mdx
@@ -7,12 +7,24 @@ import { Callout } from 'fumadocs-ui/components/callout';
 
 # Quickstart
 
-Two commands. That's it.
+Two commands. Three minutes. Done.
 
 ```bash
 pip3 install agentbreeder
 agentbreeder quickstart
 ```
+
+<Callout type="info" title="What to expect">
+  `agentbreeder quickstart` is an **interactive wizard**. It asks a handful of questions (container runtime, model source, API keys, port conflicts) and pulls ~3 GB if you choose local models. Expect ~3 minutes on a cold first run.
+
+  Want zero prompts for CI? Use the scripted path:
+
+  ```bash
+  agentbreeder quickstart --yes --no-ollama --no-browser
+  ```
+
+  `--yes` skips every yes/no prompt and uses safe defaults. `--no-ollama` keeps you on the cloud path (set `OPENAI_API_KEY` etc. before running). `--no-browser` skips opening Studio.
+</Callout>
 
 `agentbreeder quickstart` is interactive and walks you through everything:
 
@@ -77,6 +89,7 @@ The 8-step deploy pipeline (parse → RBAC → resolve deps → build container 
 
 | Flag | What it does |
 |---|---|
+| `--yes` / `-y` | Non-interactive mode for CI. Skip every yes/no prompt and use safe defaults. Pair with `--no-ollama` and `--no-browser` for a fully scripted bootstrap. |
 | `--no-ollama` | Skip the Ollama install/start/pull bootstrap |
 | `--ollama-model NAME` | Pull a different default model (e.g. `llama3.2`, `phi4-mini`) |
 | `--no-browser` | Don't open Studio at the end |


### PR DESCRIPTION
## Summary

Closes #468.

The marketing claim "Two commands. That's it." was technically true and practically misleading — `quickstart` is a 6-prompt interactive wizard that pulls ~3 GB on the local-models path. This PR aligns the copy with reality and adds a true scripted path for CI.

## Changes

**Marketing copy**
- `quickstart.mdx` headline: `"Two commands. That's it."` → `"Two commands. Three minutes. Done."`
- New `<Callout>` immediately below the two-command snippet that names every prompt the wizard will ask and the ~3 GB download, plus shows the scripted recipe.

**`--yes` / `-y` flag for scripted runs**
- New flag on `agentbreeder quickstart`. Sets a module-level sentinel (`_ASSUME_YES`) consulted by all 13 `console.input` call sites so every yes/no prompt picks the safe default:
  - Model-source falls back to "Both" (or "Cloud" with `--no-ollama`)
  - Port-conflict killer auto-accepts
  - Ollama install / rebind / model-pull auto-accept
  - Studio rebuild auto-accepts
  - Missing env keys are silently skipped
- Blocking prompts that require human input (e.g. "press Enter once the daemon is up") **exit fast with a clear error** instead of waiting on stdin.
- Explicitly does **not** auto-install Docker (heavy side effect, sudo) and does **not** invent provider keys.

**Docs sync**
- `cli-reference.mdx` `quickstart` table gets a `--yes` row that names every prompt the flag short-circuits and calls out the two non-actions.
- `quickstart.mdx` "Useful flags" table gets a matching row.
- Scripted example added to both the docstring `Examples:` block and the docs Examples list.

**Tests**
- New `tests/unit/test_quickstart_assume_yes.py` — 9 cases covering flag toggle, `_ask_model_source` short-circuit (with/without `--no-ollama`, TTY override), `_collect_provider_keys` non-interactive paths, and signature introspection.

## Acceptance checks

- [x] Hero / headline updated to set realistic expectations
- [x] Expectations callout under the two-command snippet
- [x] `--yes` flag exists and works (skip all prompts, use defaults)
- [x] Docs show both paths: interactive (recommended) + scripted

## Test plan

- [x] `pytest tests/unit/test_quickstart_assume_yes.py` — 9/9 pass
- [x] `pytest tests/unit/test_quickstart_model_source.py` — 9/9 still pass
- [x] `ruff check` + `ruff format --check` clean
- [x] `agentbreeder quickstart --help` shows `--yes` / `-y` with full help text
- [ ] Manual: `agentbreeder quickstart --yes --no-ollama --no-browser` end-to-end on a machine with Docker running and `OPENAI_API_KEY` exported

🤖 Generated with [Claude Code](https://claude.com/claude-code)
