### PR TITLE
chore(release): v2.5.0 — security CVE fixes + 5 v2.5 features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+## [2.5.0] — 2026-05-22
+
+### Security — HIGH-severity dependency CVE fixes
+
+> **All four findings were pulled in transitively and predate the v2.4 cycle.** Pinning floors here so every `pip install agentbreeder` picks up the patched releases. CI's `pip-audit` job is now clean against the v2.5.0 lockset.
+
+- **Bumped** `python-multipart>=0.0.27` (was `>=0.0.26`) — fixes [GHSA-pp6c-gr5w-3c5g](https://github.com/advisories/GHSA-pp6c-gr5w-3c5g): DoS via unbounded multipart part headers. Reaches us through FastAPI's form parsing.
+- **Pinned** transitive `Mako>=1.3.12` — fixes [GHSA-2h4p-vjrc-8xpq](https://github.com/advisories/GHSA-2h4p-vjrc-8xpq): path traversal via backslash URI in `TemplateLookup` (Windows-only, used by alembic).
+- **Pinned** transitive `urllib3>=2.7.0` — fixes [GHSA-mf9v-mfxr-j63j](https://github.com/advisories/GHSA-mf9v-mfxr-j63j) (decompression-bomb safeguards bypassed in streaming API) and [GHSA-qccp-gfcp-xxvc](https://github.com/advisories/GHSA-qccp-gfcp-xxvc) (sensitive headers forwarded across origins on proxied low-level redirects).
+- **Pinned** transitive `starlette>=1.0.1` and `idna>=3.15` — picks up [GHSA-86qp-5c8j-p5mr](https://github.com/advisories/GHSA-86qp-5c8j-p5mr) and [GHSA-65pc-fj4g-8rjx](https://github.com/advisories/GHSA-65pc-fj4g-8rjx) (IDNA encode bypass of CVE-2024-3651 fix) alongside the urllib3 bump.
+
 ### v2.5 — Realistic quickstart expectations + `--yes` for scripted runs (#468)
 
 > **P3 trust gap closed.** "Two commands. That's it." was technically true and practically misleading — `quickstart` is an interactive wizard with up to six prompts (container runtime, model source, port conflicts, Ollama install, model pull, cloud keys), plus a ~3 GB download if you pick Ollama. The new headline sets realistic expectations, the new callout names what the wizard will ask, and a `--yes` flag gives CI users a true zero-prompt path.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,18 @@ dependencies = [
     "redis>=5.0.0",
     "PyJWT[crypto]>=2.8.0",
     "bcrypt>=4.0.0",
-    "python-multipart>=0.0.26",
+    "python-multipart>=0.0.27",
     "keyring>=24.0.0",
     "chromadb>=0.5.0",
     "slowapi>=0.1.9",
     "sse-starlette>=2.0.0",
+    # Transitive pins for HIGH-severity CVE fixes (v2.5.0).
+    # These ship through alembic / httpx / starlette / boto3 — pin floors here
+    # so `pip install agentbreeder` always picks up the patched releases.
+    "Mako>=1.3.12",            # GHSA-2h4p-vjrc-8xpq (path traversal)
+    "urllib3>=2.7.0",          # GHSA-mf9v-mfxr-j63j + GHSA-qccp-gfcp-xxvc
+    "starlette>=1.0.1",        # GHSA-86qp-5c8j-p5mr
+    "idna>=3.15",              # GHSA-65pc-fj4g-8rjx
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Cuts the **v2.5.0** release tag, bundling the security pin bumps with the v2.5 feature work that has been accumulating in `[Unreleased]` since v2.1.0.

### Why now
- Latest tag is `v2.1.0` (2026-04-30). The v2.2/v2.3/v2.4 cycles never tagged — six weeks of shipped work sits behind the last tag.
- Two PyPI HIGH-severity advisories landed against `python-multipart` and `urllib3` between the last CI run and now; bundling the fixes in the same tag rather than a follow-up patch keeps the picture clean for downstream users.

### Security fixes (HIGH)
| Package | Old → New | CVE |
|---|---|---|
| python-multipart | 0.0.26 → 0.0.27 | GHSA-pp6c-gr5w-3c5g (multipart DoS) |
| Mako (transitive pin) | — → ≥ 1.3.12 | GHSA-2h4p-vjrc-8xpq (path traversal) |
| urllib3 (transitive pin) | — → ≥ 2.7.0 | GHSA-mf9v-mfxr-j63j + GHSA-qccp-gfcp-xxvc |
| starlette (transitive pin) | — → ≥ 1.0.1 | GHSA-86qp-5c8j-p5mr |
| idna (transitive pin) | — → ≥ 3.15 | GHSA-65pc-fj4g-8rjx |

After bumps, `pip-audit --skip-editable` (with CI's documented ignore list) reports **No known vulnerabilities found**.

### Features rolled in (already on main, just renaming "v2.5" → tagged release)
- `agentbreeder doctor` prerequisite preflight + quickstart wiring (#462 → #471)
- Cloud-only quickstart branch (`--no-ollama` promoted) (#466 → #473)
- Container-runtime diagnostics with cause + fix per failure (#467 → #474)
- Realistic quickstart expectations + `--yes` for scripted runs (#468 → #475)
- pipx-first install + welcome PATH hint (#463 → #472)
- Plus earlier v2.4-cycle work: studio rebrand (#460), first-run tour (#465/#470), team-scope CLI (#456–#459), deployment wizard (#447/#451), cloud-deploy Phase A (12 merged PRs)

## Local gate (run before opening this PR)

| Gate | Result |
|---|---|
| Unit tests | ✅ 4988 passed, 1 skipped (1 known-stale boto3 test deselected — fires only when `[aws]` extra installed locally; CI skips it via `_cloud_sdk_installed` guard) |
| Dashboard tests | ✅ 94/94 vitest, 0 lint errors, tsc clean |
| pip-audit | ✅ clean after bumps |
| npm audit | ⚠️ 2 moderate (dev deps only: brace-expansion, qs) |
| Python build + twine check | ✅ sdist + wheel PASSED |
| Dashboard build | ✅ |
| Docker builds | ✅ agentbreeder-api (859MB), agentbreeder-cli (259MB), agentbreeder-dashboard (65.6MB) |
| Wheel install smoke | ✅ fresh-venv install + `agentbreeder --version` |

## Post-merge

Once merged, I will fast-forward and tag `v2.5.0` from the merge commit. `release.yml` then publishes to PyPI + Docker Hub + Homebrew tap.

## Test plan
- [x] Local gate passes (above)
- [ ] CI green on this PR
- [ ] After merge: `git tag -a v2.5.0` on merge commit
- [ ] `release.yml` green
- [ ] `pip install agentbreeder==2.5.0` works in a clean venv

## Follow-up issue
- `tests/unit/test_provisioners.py::test_provision_destroy_raise_not_implemented_for_now` is stale since PR #413 implemented `provision()` — the test expects `NotImplementedError("#378")` but `provision()` now actually calls boto3. The test currently only passes on CI because boto3 is not in `.[dev]` extras; will file a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
