### PR TITLE
fix(release): roll release.yml namespace to rajits/ so publish chain runs (HR-7 followup)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,8 +154,8 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/api:${{ steps.version.outputs.version }}
             ghcr.io/${{ github.repository }}/api:latest
-            agentbreeder/agentbreeder-api:${{ steps.version.outputs.version }}
-            agentbreeder/agentbreeder-api:latest
+            rajits/agentbreeder-api:${{ steps.version.outputs.version }}
+            rajits/agentbreeder-api:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -168,12 +168,13 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/dashboard:${{ steps.version.outputs.version }}
             ghcr.io/${{ github.repository }}/dashboard:latest
-            agentbreeder/agentbreeder-dashboard:${{ steps.version.outputs.version }}
-            agentbreeder/agentbreeder-dashboard:latest
+            rajits/agentbreeder-dashboard:${{ steps.version.outputs.version }}
+            rajits/agentbreeder-dashboard:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Track J: Go sidecar — multi-arch publish (agentbreeder/agentbreeder-sidecar).
+      # Track J: Go sidecar — multi-arch publish (rajits/agentbreeder-sidecar; canonical
+      # `agentbreeder/agentbreeder-sidecar` namespace is the long-term target — see HR-7).
       - name: Build and push Sidecar image
         uses: docker/build-push-action@v6
         with:
@@ -186,8 +187,8 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/sidecar:${{ steps.version.outputs.version }}
             ghcr.io/${{ github.repository }}/sidecar:latest
-            agentbreeder/agentbreeder-sidecar:${{ steps.version.outputs.version }}
-            agentbreeder/agentbreeder-sidecar:latest
+            rajits/agentbreeder-sidecar:${{ steps.version.outputs.version }}
+            rajits/agentbreeder-sidecar:latest
           cache-from: type=gha,scope=sidecar
           cache-to: type=gha,scope=sidecar,mode=max
 
@@ -204,8 +205,8 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/go-agent-example:${{ steps.version.outputs.version }}
             ghcr.io/${{ github.repository }}/go-agent-example:latest
-            agentbreeder/agentbreeder-go-agent-example:${{ steps.version.outputs.version }}
-            agentbreeder/agentbreeder-go-agent-example:latest
+            rajits/agentbreeder-go-agent-example:${{ steps.version.outputs.version }}
+            rajits/agentbreeder-go-agent-example:latest
           cache-from: type=gha,scope=go-example
           cache-to: type=gha,scope=go-example,mode=max
 
@@ -413,8 +414,8 @@ jobs:
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
           tags: |
-            agentbreeder/agentbreeder-cli:${{ steps.version.outputs.version }}
-            agentbreeder/agentbreeder-cli:latest
+            rajits/agentbreeder-cli:${{ steps.version.outputs.version }}
+            rajits/agentbreeder-cli:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 ### Fixed
 - **Release pipeline** — rolled `release.yml` Docker image refs back from `agentbreeder/agentbreeder-*` to `rajits/agentbreeder-*`. The canonical `agentbreeder/` org doesn't have repos provisioned on Docker Hub yet (HR-7), so v2.5.0 failed at the `Build & Push Images` step with `insufficient_scope`, cascade-blocking PyPI publish + GitHub Release + Homebrew. v2.5.0 stays as a phantom tag; this patch is the first build to actually land on PyPI + Docker Hub since v2.1.0.
 
-## [2.5.0] — 2026-05-22
+## [2.5.0] — 2026-05-22 — **YANKED (phantom tag, never published)**
+
+> **Do not `pip install agentbreeder==2.5.0` — it does not exist on PyPI.** The git tag `v2.5.0` was cut but `release.yml` failed at the Docker Hub push step (`agentbreeder/agentbreeder-api` → `insufficient_scope`; the canonical `agentbreeder/` org has no repos provisioned yet, see [#479](https://github.com/agentbreeder/agentbreeder/issues/479)). The cascade-failure left publish-pypi, github-release, and homebrew-tap all skipped. **v2.5.1** carries the same payload (security fixes + 5 v2.5 features) and is the first build to actually land on PyPI + Docker Hub since v2.1.0.
 
 ### Security — HIGH-severity dependency CVE fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+## [2.5.1] — 2026-05-22
+
+### Fixed
+- **Release pipeline** — rolled `release.yml` Docker image refs back from `agentbreeder/agentbreeder-*` to `rajits/agentbreeder-*`. The canonical `agentbreeder/` org doesn't have repos provisioned on Docker Hub yet (HR-7), so v2.5.0 failed at the `Build & Push Images` step with `insufficient_scope`, cascade-blocking PyPI publish + GitHub Release + Homebrew. v2.5.0 stays as a phantom tag; this patch is the first build to actually land on PyPI + Docker Hub since v2.1.0.
+
 ## [2.5.0] — 2026-05-22
 
 ### Security — HIGH-severity dependency CVE fixes


### PR DESCRIPTION
## Summary

v2.5.0's `release.yml` failed at **Build & Push Images** with `insufficient_scope: authorization failed` because the workflow targets `agentbreeder/agentbreeder-*` on Docker Hub but the **`agentbreeder/` org has 0 repos provisioned** — all images currently live under `rajits/*` (where v2.1.0 published, 22 days ago).

The Docker push failure cascade-blocked **publish-pypi**, **github-release**, and **homebrew-tap** via `release.yml`'s job dependencies (`publish-pypi: needs: [github-release, …]` and `github-release: needs: […, build-images]`). Net effect: v2.5.0 is a phantom tag with **nothing on PyPI or Docker Hub**.

## What this PR does

Reverts the 5 image refs in `.github/workflows/release.yml` to `rajits/agentbreeder-*`:
- `rajits/agentbreeder-api`
- `rajits/agentbreeder-dashboard`
- `rajits/agentbreeder-sidecar`
- `rajits/agentbreeder-go-agent-example`
- `rajits/agentbreeder-cli`

`ghcr.io` push refs are unchanged (those work fine).

Comment on the Sidecar block flags the `agentbreeder/` namespace as the long-term target (see HR-7 follow-up).

## What this PR does NOT do

- Does **not** rename CLAUDE.md, README, or website docs (still reference the canonical `agentbreeder/agentbreeder-*` aspirational name). Separate cleanup needed once HR-7 lands the namespace migration.
- Does **not** touch v2.5.0 — the tag stays as a phantom marker. v2.5.1 cuts from this commit and is the first build to actually publish since v2.1.0.

## Test plan
- [x] Local diff verified — only the 5 image refs changed in release.yml
- [ ] CI green on this PR
- [ ] After merge: tag `v2.5.1` and re-run release.yml end-to-end
- [ ] `pip install agentbreeder==2.5.1` works in clean venv
- [ ] `docker pull rajits/agentbreeder-api:2.5.1` works

## Follow-up
HR-7 (Docker Hub namespace migration): provision the `agentbreeder/` Docker Hub org + create the 4 repos + restore the canonical refs in this workflow + update docs in lockstep. Issue to be filed alongside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
