### PR TITLE
feat(website): production readiness — a11y, /cloud, display font (#495)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,6 +25,7 @@
 | **v1.8** | Connectors & Scheduling | SMTP email connector, HackerNews/ArXiv/RSS news connectors, `agentbreeder schedule` cron command, Ollama + OpenRouter wired into `scan` and `init` | M37 | Done |
 | **v1.9** | Polyglot Runtime | Node.js/TypeScript first-class runtime — 8 TS framework templates, NodeRuntimeFamily, @agentbreeder/aps-client, mcp-server.schema.json, `agentbreeder init --language node` | #129 | Done |
 | **v2.0** | Quality & Testing | Exhaustive live Docker Playwright suite: providers, prompts, tools, RAG, MCP, agents (no-code + low-code), execution, tracing, evals, costs, RBAC — 104 tests, 15 spec files | M38 | Done |
+| **v2.6** | Website Production Readiness | Marketing site at agentbreeder.io: WCAG 2.1 AA compliance, branded 404, `/about` `/privacy` `/terms` `/cloud` pages, `robots.txt` + `sitemap.xml`, design-system token centralization, `console.agentbreeder.io` launch prep | [#495](https://github.com/agentbreeder/agentbreeder/issues/495) | In Progress |
 
 ---
 

--- a/website/app/about/page.tsx
+++ b/website/app/about/page.tsx
@@ -146,6 +146,32 @@ export default function AboutPage() {
           </ul>
         </section>
 
+        {/* Accessibility */}
+        <section className="mb-14">
+          <h2
+            className="mb-4 text-[24px] sm:text-[28px] font-extrabold text-white"
+            style={{ letterSpacing: '-0.5px' }}
+          >
+            Accessibility
+          </h2>
+          <p className="mb-3 text-[15px] leading-[1.7]" style={{ color: 'var(--text-muted)' }}>
+            The site is dark-only by design — the whole color system is tuned for dark
+            surfaces and a separate light mode would mean re-tuning every component. If
+            that&rsquo;s a blocker for you, let us know at{' '}
+            <a href={`mailto:${CONTACT_EMAIL}`} className="underline" style={{ color: 'var(--accent)' }}>
+              {CONTACT_EMAIL}
+            </a>.
+          </p>
+          <p className="text-[15px] leading-[1.7]" style={{ color: 'var(--text-muted)' }}>
+            The site respects <code className="rounded px-1.5 py-0.5 text-[13px]" style={{ background: 'var(--bg-elevated)', color: 'var(--accent)' }}>prefers-reduced-motion</code> and
+            targets WCAG 2.1 AA contrast for all body and meta text. Found an
+            accessibility issue? Open one on{' '}
+            <Link href={`${GITHUB_URL}/issues`} className="underline" style={{ color: 'var(--accent)' }}>
+              GitHub
+            </Link>.
+          </p>
+        </section>
+
         {/* Contact */}
         <section className="mb-4">
           <h2

--- a/website/app/about/page.tsx
+++ b/website/app/about/page.tsx
@@ -27,7 +27,7 @@ export default function AboutPage() {
           About AgentBreeder
         </p>
         <h1
-          className="mb-6 text-[36px] sm:text-[48px] font-extrabold text-white"
+          className="mb-6 font-display text-[36px] sm:text-[48px] font-extrabold text-white"
           style={{ letterSpacing: '-1.5px', lineHeight: 1.1 }}
         >
           One agent.yaml. Any framework. Any cloud.

--- a/website/app/about/page.tsx
+++ b/website/app/about/page.tsx
@@ -1,0 +1,173 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { Nav } from '@/components/nav';
+import { Footer } from '@/components/footer';
+
+export const metadata: Metadata = {
+  title: 'About',
+  description:
+    'AgentBreeder is an open-source platform for building, deploying, and governing enterprise AI agents. Built by Rajit Saha alongside his role as Director of Data Platform at Udemy + Coursera.',
+  alternates: { canonical: '/about' },
+};
+
+const CONTACT_EMAIL = 'hello@agentbreeder.io';
+const GITHUB_URL = 'https://github.com/agentbreeder/agentbreeder';
+const LINKEDIN_URL = 'https://www.linkedin.com/in/rajsaha/';
+
+export default function AboutPage() {
+  return (
+    <>
+      <Nav />
+      <main className="mx-auto max-w-[860px] px-4 sm:px-8 py-16 sm:py-24">
+        <p
+          className="mb-3 text-[11px] font-semibold uppercase tracking-[2px]"
+          style={{ color: 'var(--accent)' }}
+        >
+          About AgentBreeder
+        </p>
+        <h1
+          className="mb-6 text-[36px] sm:text-[48px] font-extrabold text-white"
+          style={{ letterSpacing: '-1.5px', lineHeight: 1.1 }}
+        >
+          One agent.yaml. Any framework. Any cloud.
+        </h1>
+        <p
+          className="mb-12 text-[18px] sm:text-[20px] leading-[1.6]"
+          style={{ color: 'var(--text-muted)' }}
+        >
+          AgentBreeder is an open-source platform for building, deploying, and governing
+          enterprise AI agents. It exists so a developer can write one config file, run one
+          command, and ship an agent to AWS, GCP, Azure, or Kubernetes — with RBAC, cost
+          tracking, audit trail, and observability automatic.
+        </p>
+
+        {/* Mission */}
+        <section className="mb-14">
+          <h2
+            className="mb-4 text-[24px] sm:text-[28px] font-extrabold text-white"
+            style={{ letterSpacing: '-0.5px' }}
+          >
+            Why this exists
+          </h2>
+          <p className="mb-4 text-[16px] leading-[1.75]" style={{ color: 'var(--text-muted)' }}>
+            Every team building production AI agents reinvents the same plumbing: a deploy
+            pipeline, a registry, RBAC, cost attribution, an audit log, observability.
+            And every framework (LangGraph, CrewAI, OpenAI Agents, Claude SDK, Google ADK)
+            asks you to learn a new container shape, a new entrypoint, a new way to wire
+            secrets.
+          </p>
+          <p className="text-[16px] leading-[1.75]" style={{ color: 'var(--text-muted)' }}>
+            AgentBreeder collapses that down. Pick your framework. Pick your cloud. Write
+            <code className="mx-1 rounded px-1.5 py-0.5 text-[14px]" style={{ background: 'var(--bg-elevated)', color: 'var(--accent)' }}>agent.yaml</code>.
+            Run <code className="rounded px-1.5 py-0.5 text-[14px]" style={{ background: 'var(--bg-elevated)', color: 'var(--accent)' }}>agentbreeder deploy</code>.
+            Governance happens as a side effect, not as extra configuration.
+          </p>
+        </section>
+
+        {/* The inventor */}
+        <section className="mb-14">
+          <h2
+            className="mb-6 text-[24px] sm:text-[28px] font-extrabold text-white"
+            style={{ letterSpacing: '-0.5px' }}
+          >
+            The inventor
+          </h2>
+          <div
+            className="rounded-[18px] border p-6 sm:p-8"
+            style={{ background: 'var(--bg-surface)', borderColor: 'var(--border)' }}
+          >
+            <div className="flex flex-col sm:flex-row gap-6 sm:gap-8 items-start">
+              <div className="flex-shrink-0">
+                <div className="relative overflow-hidden rounded-2xl" style={{ width: 96, height: 96 }}>
+                  <Image
+                    src="/rajit-saha.jpg"
+                    alt="Rajit Saha"
+                    fill
+                    className="object-cover"
+                    sizes="96px"
+                  />
+                </div>
+              </div>
+              <div className="flex-1 min-w-0">
+                <h3 className="mb-1 text-[20px] font-bold text-white">Rajit Saha</h3>
+                <p className="mb-4 text-[13px]" style={{ color: 'var(--accent)' }}>
+                  Founder, AgentBreeder · Director of Data Platform, Udemy + Coursera
+                </p>
+                <p className="mb-3 text-[14px] leading-[1.75]" style={{ color: 'var(--text-muted)' }}>
+                  Rajit has spent 23+ years building distributed systems and data
+                  infrastructure across Oracle, IBM, Yahoo, Teradata, VMware, LendingClub,
+                  Experian, and Udemy. At the merged Udemy + Coursera company he leads the
+                  Data Platform team, where shipping AI agents into production surfaced the
+                  exact gap AgentBreeder fills.
+                </p>
+                <p className="mb-4 text-[14px] leading-[1.75]" style={{ color: 'var(--text-muted)' }}>
+                  AgentBreeder is currently built alongside that role. The open-source
+                  project is released under Apache 2.0, with a managed cloud offering
+                  (<Link href="https://console.agentbreeder.io" className="underline" style={{ color: 'var(--accent)' }}>console.agentbreeder.io</Link>) coming next.
+                </p>
+                <Link
+                  href={LINKEDIN_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-[12px] font-medium no-underline transition-all hover:border-[var(--accent)] hover:text-[var(--accent)]"
+                  style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
+                >
+                  LinkedIn
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Status & roadmap */}
+        <section className="mb-14">
+          <h2
+            className="mb-4 text-[24px] sm:text-[28px] font-extrabold text-white"
+            style={{ letterSpacing: '-0.5px' }}
+          >
+            Where we are today
+          </h2>
+          <ul className="space-y-3 text-[15px] leading-[1.7]" style={{ color: 'var(--text-muted)' }}>
+            <li>
+              <strong className="text-white">Open-source CLI + engine</strong> — Apache 2.0,
+              installable via pip, Homebrew, or Docker. Multi-cloud, multi-framework, governance built in.
+            </li>
+            <li>
+              <strong className="text-white">Managed cloud (coming soon)</strong> — a hosted
+              control plane at <Link href="https://console.agentbreeder.io" className="underline" style={{ color: 'var(--accent)' }}>console.agentbreeder.io</Link> for
+              teams that want the registry, RBAC, and observability without running the API server themselves.
+            </li>
+            <li>
+              <strong className="text-white">Status</strong> — bootstrapped, no external funding,
+              built in public on <Link href={GITHUB_URL} className="underline" style={{ color: 'var(--accent)' }}>GitHub</Link>.
+              Contributions and design feedback welcome.
+            </li>
+          </ul>
+        </section>
+
+        {/* Contact */}
+        <section className="mb-4">
+          <h2
+            className="mb-4 text-[24px] sm:text-[28px] font-extrabold text-white"
+            style={{ letterSpacing: '-0.5px' }}
+          >
+            Contact
+          </h2>
+          <p className="text-[15px] leading-[1.7]" style={{ color: 'var(--text-muted)' }}>
+            Email{' '}
+            <a href={`mailto:${CONTACT_EMAIL}`} className="underline" style={{ color: 'var(--accent)' }}>
+              {CONTACT_EMAIL}
+            </a>{' '}
+            for partnerships, pilots, press, or just to say hi. For bug reports and feature
+            requests, please open an issue on{' '}
+            <Link href={`${GITHUB_URL}/issues`} className="underline" style={{ color: 'var(--accent)' }}>
+              GitHub
+            </Link>.
+          </p>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/website/app/cloud/page.tsx
+++ b/website/app/cloud/page.tsx
@@ -1,0 +1,268 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { Nav } from '@/components/nav';
+import { Footer } from '@/components/footer';
+
+export const metadata: Metadata = {
+  title: 'Cloud — Managed AgentBreeder',
+  description:
+    'Managed AgentBreeder at console.agentbreeder.io — hosted registry, RBAC, observability, and billing. Your agents stay in your cloud.',
+  alternates: { canonical: '/cloud' },
+};
+
+const WAITLIST_HREF =
+  'mailto:hello@agentbreeder.io?subject=AgentBreeder%20Cloud%20Waitlist&body=Please%20add%20me%20to%20the%20console.agentbreeder.io%20waitlist.%20Team%20size%3A%20___%20%7C%20Cloud%3A%20AWS%20%2F%20GCP%20%2F%20Azure%20%7C%20Use%20case%3A%20___';
+const CONSOLE_URL = 'https://console.agentbreeder.io';
+const GITHUB_URL = 'https://github.com/agentbreeder/agentbreeder';
+
+const HOSTED = [
+  'Cross-team registry of agents, prompts, tools, RAG indexes',
+  'OAuth + SSO + RBAC + audit log',
+  'Cost tracking per team / agent / model / call',
+  'Tracing + evals + replay across runs',
+  'Org-wide policy enforcement (guardrails, budgets, approvals)',
+  'Multi-cloud deploy orchestration',
+];
+
+const YOURS = [
+  'The agent containers run in YOUR cloud account',
+  'Your VPC, your network rules, your secrets manager',
+  'Your model inference endpoints (or BYO LLM gateway)',
+  'Your data — nothing leaves your perimeter without a configured egress',
+  'Your existing IAM, your existing observability sinks',
+];
+
+const COMPARISON = [
+  { feature: 'CLI + engine + connectors', oss: 'Yes (Apache 2.0)', cloud: 'Yes' },
+  { feature: 'Per-team isolated registry', oss: 'Self-host', cloud: 'Hosted, multi-tenant' },
+  { feature: 'RBAC + SSO + audit', oss: 'You wire it up', cloud: 'Out of the box' },
+  { feature: 'Cost + tracing + evals', oss: 'You provision Postgres, OTLP sinks', cloud: 'Out of the box' },
+  { feature: 'Upgrades + migrations', oss: 'You run alembic', cloud: 'Managed' },
+  { feature: 'Agent containers run in', oss: 'Your cloud', cloud: 'Your cloud (same)' },
+  { feature: 'Support', oss: 'GitHub issues, community', cloud: 'Email + SLA (paid tiers)' },
+];
+
+const FAQ = [
+  {
+    q: 'When does the Cloud launch?',
+    a: 'Private alpha is rolling out in 2026. Waitlist members get invited first. The exact GA date depends on alpha feedback — we are not putting an arbitrary date on the calendar.',
+  },
+  {
+    q: 'How does pricing work?',
+    a: 'Free tier for individuals and tiny teams. Paid tiers based on number of deployed agents, traces ingested, and team seats. Exact prices announced at launch — waitlist members get founder pricing.',
+  },
+  {
+    q: 'Can I use my own cloud accounts (AWS / GCP / Azure)?',
+    a: 'Yes. That is the point — agents always run in your cloud, never on our infrastructure. Cloud only hosts the control plane (registry, RBAC, observability, billing).',
+  },
+  {
+    q: 'Is the open-source project still maintained?',
+    a: 'Yes. The OSS engine, CLI, and SDK are the foundation Cloud is built on. Every feature ships to OSS first. Self-hosting will always be a supported path.',
+  },
+  {
+    q: 'What happens to my data if I leave?',
+    a: 'Export your full registry as YAML at any time. Agents in your cloud are unaffected. The data we hold (registry metadata, traces, costs) is exportable.',
+  },
+];
+
+export default function CloudPage() {
+  return (
+    <>
+      <Nav />
+      <main className="mx-auto max-w-[1100px] px-4 sm:px-8 py-16 sm:py-24">
+        {/* Hero */}
+        <section className="mb-24 max-w-[820px]">
+          <p
+            className="mb-3 text-[11px] font-semibold uppercase tracking-[2px]"
+            style={{ color: 'var(--accent)' }}
+          >
+            Coming soon · console.agentbreeder.io
+          </p>
+          <h1
+            className="mb-6 text-[40px] sm:text-[56px] font-extrabold text-white"
+            style={{ letterSpacing: '-1.5px', lineHeight: 1.05 }}
+          >
+            Managed AgentBreeder. <br className="hidden sm:inline" />
+            Zero DevOps.
+          </h1>
+          <p
+            className="mb-10 text-[18px] sm:text-[20px] leading-[1.6]"
+            style={{ color: 'var(--text-muted)' }}
+          >
+            All the registry, RBAC, observability, and billing of AgentBreeder &mdash;
+            hosted for you. Your agents still run in your cloud. Your data never
+            leaves your perimeter.
+          </p>
+          <div className="flex flex-wrap items-center gap-3">
+            <a
+              href={WAITLIST_HREF}
+              className="flex min-h-[44px] items-center rounded-lg px-5 text-[15px] font-bold no-underline transition-opacity hover:opacity-90"
+              style={{ background: 'var(--accent)', color: '#000' }}
+            >
+              Join the waitlist &rarr;
+            </a>
+            <Link
+              href={GITHUB_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex min-h-[44px] items-center rounded-lg border px-5 text-[14px] no-underline transition-colors hover:text-white"
+              style={{ borderColor: 'var(--border-hover)', color: 'var(--text-muted)' }}
+            >
+              Or self-host the OSS &rarr;
+            </Link>
+          </div>
+        </section>
+
+        {/* What's hosted vs what's yours */}
+        <section className="mb-24">
+          <p
+            className="mb-3 text-[11px] font-semibold uppercase tracking-[2px]"
+            style={{ color: 'var(--accent)' }}
+          >
+            Where things live
+          </p>
+          <h2
+            className="mb-10 text-[28px] sm:text-[36px] font-extrabold text-white"
+            style={{ letterSpacing: '-1px' }}
+          >
+            We host the control plane. You keep the agents.
+          </h2>
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+            <div
+              className="rounded-[18px] border p-6 sm:p-8"
+              style={{ background: 'var(--bg-surface)', borderColor: 'var(--border)' }}
+            >
+              <h3 className="mb-4 text-[16px] font-bold text-white">
+                Hosted at console.agentbreeder.io
+              </h3>
+              <ul className="space-y-2.5 list-none m-0 p-0">
+                {HOSTED.map((line) => (
+                  <li
+                    key={line}
+                    className="flex gap-2.5 text-[14px] leading-[1.55]"
+                    style={{ color: 'var(--text-muted)' }}
+                  >
+                    <span style={{ color: 'var(--accent)' }} aria-hidden>&bull;</span>
+                    <span>{line}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div
+              className="rounded-[18px] border p-6 sm:p-8"
+              style={{ background: 'var(--bg-surface)', borderColor: 'var(--border)' }}
+            >
+              <h3 className="mb-4 text-[16px] font-bold text-white">
+                Stays in your cloud
+              </h3>
+              <ul className="space-y-2.5 list-none m-0 p-0">
+                {YOURS.map((line) => (
+                  <li
+                    key={line}
+                    className="flex gap-2.5 text-[14px] leading-[1.55]"
+                    style={{ color: 'var(--text-muted)' }}
+                  >
+                    <span style={{ color: 'var(--purple)' }} aria-hidden>&bull;</span>
+                    <span>{line}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        {/* Comparison */}
+        <section className="mb-24">
+          <p
+            className="mb-3 text-[11px] font-semibold uppercase tracking-[2px]"
+            style={{ color: 'var(--accent)' }}
+          >
+            OSS vs Cloud
+          </p>
+          <h2
+            className="mb-8 text-[28px] sm:text-[36px] font-extrabold text-white"
+            style={{ letterSpacing: '-1px' }}
+          >
+            Same engine. Different operating model.
+          </h2>
+
+          <div
+            className="overflow-x-auto rounded-[14px] border"
+            style={{ borderColor: 'var(--border)' }}
+          >
+            <table className="w-full text-left text-[14px]" style={{ borderCollapse: 'collapse' }}>
+              <thead>
+                <tr style={{ background: 'var(--bg-surface)' }}>
+                  <th className="px-5 py-3.5 text-[11px] font-semibold uppercase tracking-[1.5px]" style={{ color: 'var(--text-dim)' }}>Feature</th>
+                  <th className="px-5 py-3.5 text-[11px] font-semibold uppercase tracking-[1.5px]" style={{ color: 'var(--text-dim)' }}>OSS (self-host)</th>
+                  <th className="px-5 py-3.5 text-[11px] font-semibold uppercase tracking-[1.5px]" style={{ color: 'var(--text-dim)' }}>Cloud</th>
+                </tr>
+              </thead>
+              <tbody>
+                {COMPARISON.map((row, i) => (
+                  <tr key={row.feature} style={{ borderTop: i === 0 ? 'none' : '1px solid var(--border)' }}>
+                    <td className="px-5 py-3.5 font-medium text-white">{row.feature}</td>
+                    <td className="px-5 py-3.5" style={{ color: 'var(--text-muted)' }}>{row.oss}</td>
+                    <td className="px-5 py-3.5" style={{ color: 'var(--text-muted)' }}>{row.cloud}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="mb-24">
+          <p
+            className="mb-3 text-[11px] font-semibold uppercase tracking-[2px]"
+            style={{ color: 'var(--accent)' }}
+          >
+            FAQ
+          </p>
+          <h2
+            className="mb-8 text-[28px] sm:text-[36px] font-extrabold text-white"
+            style={{ letterSpacing: '-1px' }}
+          >
+            The honest answers
+          </h2>
+
+          <div className="space-y-4">
+            {FAQ.map(({ q, a }) => (
+              <div
+                key={q}
+                className="rounded-[12px] border p-5 sm:p-6"
+                style={{ background: 'var(--bg-surface)', borderColor: 'var(--border)' }}
+              >
+                <h3 className="mb-2 text-[15px] font-bold text-white">{q}</h3>
+                <p className="text-[14px] leading-[1.7]" style={{ color: 'var(--text-muted)' }}>{a}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Final CTA */}
+        <section
+          className="rounded-[18px] border p-8 sm:p-12 text-center"
+          style={{ background: 'var(--bg-surface)', borderColor: 'var(--border)' }}
+        >
+          <h2 className="mb-3 text-[24px] sm:text-[32px] font-extrabold text-white" style={{ letterSpacing: '-0.8px' }}>
+            Ready when the alpha opens?
+          </h2>
+          <p className="mb-6 text-[15px] sm:text-[16px]" style={{ color: 'var(--text-muted)' }}>
+            Join the waitlist and we&rsquo;ll reach out as soon as <Link href={CONSOLE_URL} className="underline" style={{ color: 'var(--accent)' }}>console.agentbreeder.io</Link> opens up access.
+          </p>
+          <a
+            href={WAITLIST_HREF}
+            className="inline-flex min-h-[44px] items-center rounded-lg px-6 text-[15px] font-bold no-underline transition-opacity hover:opacity-90"
+            style={{ background: 'var(--accent)', color: '#000' }}
+          >
+            Join the waitlist &rarr;
+          </a>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/website/app/cloud/page.tsx
+++ b/website/app/cloud/page.tsx
@@ -79,7 +79,7 @@ export default function CloudPage() {
             Coming soon · console.agentbreeder.io
           </p>
           <h1
-            className="mb-6 text-[40px] sm:text-[56px] font-extrabold text-white"
+            className="mb-6 font-display text-[40px] sm:text-[56px] font-extrabold text-white"
             style={{ letterSpacing: '-1.5px', lineHeight: 1.05 }}
           >
             Managed AgentBreeder. <br className="hidden sm:inline" />

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -60,13 +60,41 @@ body {
   50%       { opacity: 0.15; }
 }
 
-/* Respect user motion preference — WCAG 2.3.3, Apple HIG, Material Motion. */
+/* Hero load-in: staggered fade + translate. See #494. */
+@keyframes hero-reveal {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.hero-stagger > * {
+  opacity: 0;
+  animation: hero-reveal 600ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+.hero-stagger > *:nth-child(1) { animation-delay: 0ms; }
+.hero-stagger > *:nth-child(2) { animation-delay: 80ms; }
+.hero-stagger > *:nth-child(3) { animation-delay: 160ms; }
+.hero-stagger > *:nth-child(4) { animation-delay: 240ms; }
+.hero-stagger > *:nth-child(5) { animation-delay: 320ms; }
+
+.hero-reveal-late {
+  opacity: 0;
+  animation: hero-reveal 600ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  animation-delay: 320ms;
+}
+
+/* Respect user motion preference — WCAG 2.3.3, Apple HIG, Material Motion.
+   Also resets the staggered reveal so content is immediately visible. */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
+  }
+  .hero-stagger > *,
+  .hero-reveal-late {
+    opacity: 1 !important;
+    transform: none !important;
   }
 }
 

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -60,6 +60,16 @@ body {
   50%       { opacity: 0.15; }
 }
 
+/* Respect user motion preference — WCAG 2.3.3, Apple HIG, Material Motion. */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* Blog article prose */
 .prose-blog {
   color: var(--text);

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -9,8 +9,8 @@
   --border: rgba(255, 255, 255, 0.07);
   --border-hover: rgba(255, 255, 255, 0.14);
   --text: #e4e4e7;
-  --text-muted: #71717a;
-  --text-dim: #3f3f46;
+  --text-muted: #a1a1aa;   /* zinc-400 — ~7.8:1 on --bg, AAA */
+  --text-dim:   #8b8b95;   /* ~5.9:1 on --bg, AA — was #3f3f46 which was ~1.9:1 and failed WCAG */
   --accent: #22c55e;
   --accent-dim: rgba(34, 197, 94, 0.10);
   --accent-border: rgba(34, 197, 94, 0.22);

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -32,6 +32,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       suppressHydrationWarning
     >
       <body>
+        {/*
+          Dark mode is intentional, not an oversight. The whole design system
+          (background, glows, syntax-highlighted YAML, accent palette) is built
+          around dark surfaces. Switching to light would require re-tuning every
+          token and component. Tracked in #489 if we revisit.
+
+          The site respects `prefers-reduced-motion` (see app/globals.css)
+          and uses WCAG-AA contrast for all body and meta text.
+        */}
         <RootProvider theme={{ forcedTheme: 'dark', disableTransitionOnChange: true }}>{children}</RootProvider>
       </body>
     </html>

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -1,8 +1,21 @@
 import type { Metadata } from 'next';
 import { GeistSans } from 'geist/font/sans';
 import { GeistMono } from 'geist/font/mono';
+import { Bricolage_Grotesque } from 'next/font/google';
 import { RootProvider } from 'fumadocs-ui/provider/next';
 import './globals.css';
+
+// Distinctive display font for marketing headlines — #493.
+// Applied selectively via the `font-display` Tailwind utility (see
+// tailwind.config.ts), only on hero h1 and a few high-impact h2s on
+// the marketing pages. Docs and blog continue using Geist Sans for
+// readability and consistency with the technical content.
+const bricolage = Bricolage_Grotesque({
+  subsets: ['latin'],
+  variable: '--font-display',
+  weight: ['600', '700', '800'],
+  display: 'swap',
+});
 
 export const metadata: Metadata = {
   title: {
@@ -28,7 +41,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html
       lang="en"
-      className={`${GeistSans.variable} ${GeistMono.variable} dark`}
+      className={`${GeistSans.variable} ${GeistMono.variable} ${bricolage.variable} dark`}
       suppressHydrationWarning
     >
       <body>

--- a/website/app/not-found.tsx
+++ b/website/app/not-found.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { Nav } from '@/components/nav';
+import { Footer } from '@/components/footer';
+
+export const metadata: Metadata = {
+  title: 'Page not found',
+  description: "The page you're looking for doesn't exist.",
+  robots: { index: false, follow: false },
+};
+
+const RECOVERY_LINKS = [
+  { href: '/', label: 'Home', description: 'Back to the front page' },
+  { href: '/docs', label: 'Docs', description: 'Read the documentation' },
+  { href: '/docs/quickstart', label: 'Quickstart', description: 'Deploy your first agent in 5 minutes' },
+  { href: '/blog', label: 'Blog', description: 'Posts on agents, deploy, and AgentBreeder' },
+  { href: '/about', label: 'About', description: 'About AgentBreeder and the project' },
+];
+
+export default function NotFound() {
+  return (
+    <>
+      <Nav />
+      <main className="mx-auto max-w-[820px] px-4 sm:px-8 py-20 sm:py-28">
+        <p
+          className="mb-3 text-[11px] font-semibold uppercase tracking-[2px]"
+          style={{ color: 'var(--accent)' }}
+        >
+          404
+        </p>
+        <h1
+          className="mb-6 text-[40px] sm:text-[56px] font-extrabold text-white"
+          style={{ letterSpacing: '-1.5px', lineHeight: 1.05 }}
+        >
+          This page didn&rsquo;t deploy.
+        </h1>
+        <p
+          className="mb-12 max-w-[560px] text-[17px] sm:text-[18px] leading-[1.6]"
+          style={{ color: 'var(--text-muted)' }}
+        >
+          The URL you followed isn&rsquo;t in our registry. It may have moved, been renamed,
+          or never existed. Here&rsquo;s where to go next:
+        </p>
+
+        <nav aria-label="Suggested pages">
+          <ul className="grid grid-cols-1 sm:grid-cols-2 gap-3 list-none p-0 m-0">
+            {RECOVERY_LINKS.map(({ href, label, description }) => (
+              <li key={href}>
+                <Link
+                  href={href}
+                  className="flex min-h-[44px] flex-col justify-center rounded-[12px] border px-5 py-3 no-underline transition-colors hover:border-[var(--accent)]"
+                  style={{ background: 'var(--bg-surface)', borderColor: 'var(--border)' }}
+                >
+                  <span className="text-[15px] font-semibold text-white">{label} &rarr;</span>
+                  <span className="text-[13px]" style={{ color: 'var(--text-muted)' }}>
+                    {description}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
+
+        <p className="mt-10 text-[13px]" style={{ color: 'var(--text-dim)' }}>
+          Still stuck? Email{' '}
+          <a href="mailto:hello@agentbreeder.io" className="underline" style={{ color: 'var(--accent)' }}>
+            hello@agentbreeder.io
+          </a>{' '}
+          or open an issue on{' '}
+          <Link
+            href="https://github.com/agentbreeder/agentbreeder/issues"
+            className="underline"
+            style={{ color: 'var(--accent)' }}
+          >
+            GitHub
+          </Link>
+          .
+        </p>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/website/app/not-found.tsx
+++ b/website/app/not-found.tsx
@@ -29,7 +29,7 @@ export default function NotFound() {
           404
         </p>
         <h1
-          className="mb-6 text-[40px] sm:text-[56px] font-extrabold text-white"
+          className="mb-6 font-display text-[40px] sm:text-[56px] font-extrabold text-white"
           style={{ letterSpacing: '-1.5px', lineHeight: 1.05 }}
         >
           This page didn&rsquo;t deploy.

--- a/website/app/privacy/page.tsx
+++ b/website/app/privacy/page.tsx
@@ -1,0 +1,160 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { Nav } from '@/components/nav';
+import { Footer } from '@/components/footer';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy',
+  description: 'How AgentBreeder collects, uses, and protects information.',
+  alternates: { canonical: '/privacy' },
+};
+
+const CONTACT_EMAIL = 'hello@agentbreeder.io';
+const LAST_UPDATED = 'May 23, 2026';
+
+export default function PrivacyPage() {
+  return (
+    <>
+      <Nav />
+      <main className="mx-auto max-w-[820px] px-4 sm:px-8 py-16 sm:py-24">
+        <p
+          className="mb-3 text-[11px] font-semibold uppercase tracking-[2px]"
+          style={{ color: 'var(--accent)' }}
+        >
+          Legal
+        </p>
+        <h1
+          className="mb-4 text-[36px] sm:text-[44px] font-extrabold text-white"
+          style={{ letterSpacing: '-1px' }}
+        >
+          Privacy Policy
+        </h1>
+        <p className="mb-10 text-[13px]" style={{ color: 'var(--text-dim)' }}>
+          Last updated: {LAST_UPDATED}
+        </p>
+
+        <Section title="Who this covers">
+          <p>
+            This policy describes how the AgentBreeder open-source project (&ldquo;AgentBreeder,&rdquo;
+            &ldquo;we,&rdquo; or &ldquo;us&rdquo;) handles information collected through the website
+            at <code>agentbreeder.io</code> and the related documentation. The project is
+            currently maintained by Rajit Saha.
+          </p>
+          <p>
+            The managed cloud offering at <code>console.agentbreeder.io</code> is not yet
+            launched. A separate, more detailed privacy policy will apply when it goes live.
+          </p>
+        </Section>
+
+        <Section title="What we collect">
+          <p>The website collects only what is necessary to serve and operate it:</p>
+          <ul>
+            <li>
+              <strong>Standard server logs</strong> — IP address, user agent, referrer,
+              requested path, and timestamp. These are produced by our hosting provider
+              (Vercel) for every request and are used for security, abuse prevention, and
+              basic operational diagnostics.
+            </li>
+            <li>
+              <strong>Emails you send us</strong> — if you email{' '}
+              <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>, we retain the
+              message and your email address to reply and to keep a record of the
+              conversation.
+            </li>
+          </ul>
+          <p>The marketing site does <strong>not</strong> use third-party analytics, advertising trackers, or marketing cookies.</p>
+        </Section>
+
+        <Section title="What the open-source CLI and SDK collect">
+          <p>
+            The <code>agentbreeder</code> CLI and{' '}
+            <code>agentbreeder-sdk</code> package do not send telemetry to AgentBreeder.
+            All data the CLI handles (your <code>agent.yaml</code>, your secrets, your
+            deploy artifacts) stays within your own environment and the cloud accounts
+            you configure.
+          </p>
+        </Section>
+
+        <Section title="How we use information">
+          <ul>
+            <li>To operate and secure the website.</li>
+            <li>To respond to email you send us.</li>
+            <li>To investigate abuse, fraud, or violations of our terms.</li>
+          </ul>
+          <p>We do not sell or rent personal information to anyone.</p>
+        </Section>
+
+        <Section title="Third parties">
+          <p>The website relies on the following service providers:</p>
+          <ul>
+            <li>
+              <strong>Vercel</strong> — hosting and CDN. See{' '}
+              <Link href="https://vercel.com/legal/privacy-policy" target="_blank" rel="noopener noreferrer">
+                Vercel&rsquo;s privacy policy
+              </Link>.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="Your choices">
+          <ul>
+            <li>
+              You can browse the site without providing any personal information beyond
+              what is in standard server logs.
+            </li>
+            <li>
+              You can email us at <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a> to
+              ask what information we hold about you, to request deletion, or to raise
+              any other privacy concern. We will respond in a reasonable timeframe.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="Children">
+          <p>
+            AgentBreeder is a developer tool and is not directed to children under 13.
+            We do not knowingly collect personal information from children.
+          </p>
+        </Section>
+
+        <Section title="Governing law">
+          <p>
+            This policy is governed by the laws of the United States. Any disputes will
+            be handled under U.S. law.
+          </p>
+        </Section>
+
+        <Section title="Changes to this policy">
+          <p>
+            We may update this policy as the project evolves — most notably when the
+            managed cloud offering launches. The &ldquo;Last updated&rdquo; date at the
+            top reflects the most recent change.
+          </p>
+        </Section>
+
+        <Section title="Contact">
+          <p>
+            Questions about privacy? Email{' '}
+            <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>.
+          </p>
+        </Section>
+      </main>
+      <Footer />
+    </>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-10 [&_p]:mb-3 [&_p]:text-[15px] [&_p]:leading-[1.75] [&_ul]:my-3 [&_ul]:ml-5 [&_ul]:list-disc [&_ul]:space-y-2 [&_li]:text-[15px] [&_li]:leading-[1.75] [&_a]:underline [&_code]:rounded [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:text-[13px]"
+      style={{ color: 'var(--text-muted)' }}
+    >
+      <h2 className="mb-3 text-[20px] sm:text-[22px] font-bold text-white" style={{ letterSpacing: '-0.3px' }}>
+        {title}
+      </h2>
+      <div className="[&_strong]:text-white [&_a]:text-[color:var(--accent)] [&_code]:bg-[color:var(--bg-elevated)] [&_code]:text-[color:var(--accent)]">
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/website/app/robots.ts
+++ b/website/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from 'next';
+
+const BASE_URL = 'https://www.agentbreeder.io';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: '*', allow: '/' },
+    sitemap: `${BASE_URL}/sitemap.xml`,
+    host: BASE_URL,
+  };
+}

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -1,0 +1,33 @@
+import type { MetadataRoute } from 'next';
+import { source } from '@/lib/source';
+import { getBlogPosts, getSlug } from '@/lib/blog';
+
+const BASE_URL = 'https://www.agentbreeder.io';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    { url: `${BASE_URL}/`, lastModified: now, changeFrequency: 'weekly', priority: 1.0 },
+    { url: `${BASE_URL}/about`, lastModified: now, changeFrequency: 'monthly', priority: 0.7 },
+    { url: `${BASE_URL}/blog`, lastModified: now, changeFrequency: 'weekly', priority: 0.6 },
+    { url: `${BASE_URL}/privacy`, lastModified: now, changeFrequency: 'yearly', priority: 0.3 },
+    { url: `${BASE_URL}/terms`, lastModified: now, changeFrequency: 'yearly', priority: 0.3 },
+  ];
+
+  const docRoutes: MetadataRoute.Sitemap = source.getPages().map((page) => ({
+    url: `${BASE_URL}${page.url}`,
+    lastModified: now,
+    changeFrequency: 'weekly' as const,
+    priority: 0.7,
+  }));
+
+  const blogRoutes: MetadataRoute.Sitemap = getBlogPosts().map((post) => ({
+    url: `${BASE_URL}/blog/${getSlug(post)}`,
+    lastModified: post.date ? new Date(post.date) : now,
+    changeFrequency: 'monthly' as const,
+    priority: 0.5,
+  }));
+
+  return [...staticRoutes, ...docRoutes, ...blogRoutes];
+}

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -10,6 +10,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const staticRoutes: MetadataRoute.Sitemap = [
     { url: `${BASE_URL}/`, lastModified: now, changeFrequency: 'weekly', priority: 1.0 },
     { url: `${BASE_URL}/about`, lastModified: now, changeFrequency: 'monthly', priority: 0.7 },
+    { url: `${BASE_URL}/cloud`, lastModified: now, changeFrequency: 'weekly', priority: 0.9 },
     { url: `${BASE_URL}/blog`, lastModified: now, changeFrequency: 'weekly', priority: 0.6 },
     { url: `${BASE_URL}/privacy`, lastModified: now, changeFrequency: 'yearly', priority: 0.3 },
     { url: `${BASE_URL}/terms`, lastModified: now, changeFrequency: 'yearly', priority: 0.3 },

--- a/website/app/terms/page.tsx
+++ b/website/app/terms/page.tsx
@@ -1,0 +1,156 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { Nav } from '@/components/nav';
+import { Footer } from '@/components/footer';
+
+export const metadata: Metadata = {
+  title: 'Terms of Use',
+  description: 'Terms governing your use of the AgentBreeder website and documentation.',
+  alternates: { canonical: '/terms' },
+};
+
+const CONTACT_EMAIL = 'hello@agentbreeder.io';
+const LAST_UPDATED = 'May 23, 2026';
+const LICENSE_URL = 'https://github.com/agentbreeder/agentbreeder/blob/main/LICENSE';
+
+export default function TermsPage() {
+  return (
+    <>
+      <Nav />
+      <main className="mx-auto max-w-[820px] px-4 sm:px-8 py-16 sm:py-24">
+        <p
+          className="mb-3 text-[11px] font-semibold uppercase tracking-[2px]"
+          style={{ color: 'var(--accent)' }}
+        >
+          Legal
+        </p>
+        <h1
+          className="mb-4 text-[36px] sm:text-[44px] font-extrabold text-white"
+          style={{ letterSpacing: '-1px' }}
+        >
+          Terms of Use
+        </h1>
+        <p className="mb-10 text-[13px]" style={{ color: 'var(--text-dim)' }}>
+          Last updated: {LAST_UPDATED}
+        </p>
+
+        <Section title="Scope">
+          <p>
+            These terms govern your use of the AgentBreeder website at{' '}
+            <code>agentbreeder.io</code> and the documentation hosted there. They do
+            <strong> not</strong> govern your use of the AgentBreeder software itself —
+            see the <strong>Software license</strong> section below.
+          </p>
+          <p>
+            The managed cloud offering at <code>console.agentbreeder.io</code> is not yet
+            launched. Separate terms will apply when it goes live.
+          </p>
+        </Section>
+
+        <Section title="Software license">
+          <p>
+            The <code>agentbreeder</code> CLI, <code>agentbreeder-sdk</code>, and all
+            related open-source components are licensed under the{' '}
+            <Link href={LICENSE_URL} target="_blank" rel="noopener noreferrer">
+              Apache License 2.0
+            </Link>. Your use, modification, and distribution of the software is governed
+            by that license — not by these terms.
+          </p>
+          <p>
+            Under Apache 2.0, the software is provided <strong>&ldquo;as is&rdquo;,
+            without warranties of any kind</strong>.
+          </p>
+        </Section>
+
+        <Section title="Acceptable use of the website">
+          <p>You agree not to:</p>
+          <ul>
+            <li>Use the website to violate any applicable law or regulation.</li>
+            <li>Attempt to interfere with, disrupt, or compromise the website&rsquo;s integrity or performance.</li>
+            <li>Scrape or copy the site at a volume that imposes an unreasonable load on our infrastructure.</li>
+            <li>Use AgentBreeder branding, logos, or trademarks in a way that suggests endorsement, partnership, or affiliation without our written permission.</li>
+          </ul>
+          <p>
+            Normal crawling by search engines, normal documentation reading, code copying
+            from documentation, and forking the open-source repository are all fine.
+          </p>
+        </Section>
+
+        <Section title="Intellectual property">
+          <p>
+            The AgentBreeder name and logo are trademarks of Rajit Saha (registration
+            pending). The source code is licensed under Apache 2.0 as described above.
+            Website copy, design, and documentation are © Rajit Saha and may be quoted
+            with attribution.
+          </p>
+        </Section>
+
+        <Section title="Third-party links">
+          <p>
+            The website links to third-party services (GitHub, PyPI, Docker Hub,
+            Homebrew, LinkedIn, and others). We do not control those services and are
+            not responsible for their content or practices.
+          </p>
+        </Section>
+
+        <Section title="Disclaimer">
+          <p>
+            The website and documentation are provided <strong>&ldquo;as is&rdquo;</strong>{' '}
+            without warranties of any kind, express or implied, including but not limited
+            to warranties of merchantability, fitness for a particular purpose, and
+            non-infringement. We do not guarantee that the information on the site is
+            accurate, complete, or current.
+          </p>
+        </Section>
+
+        <Section title="Limitation of liability">
+          <p>
+            To the maximum extent permitted by law, AgentBreeder and Rajit Saha will not
+            be liable for any indirect, incidental, special, consequential, or punitive
+            damages arising out of or related to your use of the website, the
+            documentation, or the open-source software.
+          </p>
+        </Section>
+
+        <Section title="Governing law">
+          <p>
+            These terms are governed by the laws of the United States. Any disputes
+            arising out of or related to these terms will be handled under U.S. law.
+          </p>
+        </Section>
+
+        <Section title="Changes">
+          <p>
+            We may revise these terms from time to time as the project evolves. The
+            &ldquo;Last updated&rdquo; date at the top reflects the most recent change.
+            Continued use of the site after a change constitutes acceptance of the
+            revised terms.
+          </p>
+        </Section>
+
+        <Section title="Contact">
+          <p>
+            Questions about these terms? Email{' '}
+            <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>.
+          </p>
+        </Section>
+      </main>
+      <Footer />
+    </>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-10 [&_p]:mb-3 [&_p]:text-[15px] [&_p]:leading-[1.75] [&_ul]:my-3 [&_ul]:ml-5 [&_ul]:list-disc [&_ul]:space-y-2 [&_li]:text-[15px] [&_li]:leading-[1.75] [&_a]:underline [&_code]:rounded [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:text-[13px]"
+      style={{ color: 'var(--text-muted)' }}
+    >
+      <h2 className="mb-3 text-[20px] sm:text-[22px] font-bold text-white" style={{ letterSpacing: '-0.3px' }}>
+        {title}
+      </h2>
+      <div className="[&_strong]:text-white [&_a]:text-[color:var(--accent)] [&_code]:bg-[color:var(--bg-elevated)] [&_code]:text-[color:var(--accent)]">
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/website/components/built-by.tsx
+++ b/website/components/built-by.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 
 const CAREER_HIGHLIGHTS = [
   { label: '23+ years', desc: 'industry experience with distributed systems & data infrastructure' },
-  { label: '8 companies', desc: 'Oracle · IBM · Yahoo · Teradata · VMware · LendingClub · Experian · Udemy' },
+  { label: '8 companies', desc: 'Oracle · IBM · Yahoo · Teradata · VMware · LendingClub · Experian · Udemy + Coursera' },
 ];
 
 export function BuiltBy() {
@@ -69,11 +69,11 @@ export function BuiltBy() {
                 </span>
               </div>
               <p className="mb-4 text-[13px]" style={{ color: 'var(--accent)' }}>
-                Director of Data Intelligence Platform · Udemy
+                Director of Data Platform · Udemy + Coursera
               </p>
               <p className="mb-4 text-[14px] leading-[1.75]" style={{ color: 'var(--text-muted)' }}>
                 Spent 20 years making data platforms bigger and faster. Then decided smarter was more interesting.
-                At Udemy, shipped AI agents that actually do things in production.
+                At Udemy + Coursera, shipped AI agents that actually do things in production.
                 AgentBreeder is the tool I kept wishing existed while building them.
               </p>
               <p className="text-[14px] leading-[1.75]" style={{ color: 'var(--text-muted)' }}>

--- a/website/components/footer.tsx
+++ b/website/components/footer.tsx
@@ -21,9 +21,9 @@ const LINKS = {
     { label: 'All Posts', href: '/blog' },
   ],
   Community: [
-    { label: 'Twitter ↗', href: 'https://twitter.com' },
     { label: 'LinkedIn ↗', href: 'https://www.linkedin.com/in/rajsaha/' },
     { label: 'Issues ↗', href: 'https://github.com/agentbreeder/agentbreeder/issues' },
+    { label: 'Discussions ↗', href: 'https://github.com/agentbreeder/agentbreeder/discussions' },
   ],
   Company: [
     { label: 'About', href: '/about' },

--- a/website/components/footer.tsx
+++ b/website/components/footer.tsx
@@ -25,6 +25,12 @@ const LINKS = {
     { label: 'LinkedIn ↗', href: 'https://www.linkedin.com/in/rajsaha/' },
     { label: 'Issues ↗', href: 'https://github.com/agentbreeder/agentbreeder/issues' },
   ],
+  Company: [
+    { label: 'About', href: '/about' },
+    { label: 'Contact', href: 'mailto:hello@agentbreeder.io' },
+    { label: 'Privacy', href: '/privacy' },
+    { label: 'Terms', href: '/terms' },
+  ],
 };
 
 export function Footer() {
@@ -80,7 +86,7 @@ export function Footer() {
               color: 'var(--accent)',
             }}
           >
-            v2.0.0
+            v2.5.1
           </span>
         </div>
       </div>

--- a/website/components/footer.tsx
+++ b/website/components/footer.tsx
@@ -59,7 +59,7 @@ export function Footer() {
                   <Link
                     key={label}
                     href={href}
-                    className="mb-2 block text-[13px] no-underline transition-colors"
+                    className="-mx-2 flex min-h-[44px] items-center rounded-md px-2 text-[13px] no-underline transition-colors hover:text-white"
                     style={{ color: 'var(--text-muted)' }}
                     target={href.startsWith('http') ? '_blank' : undefined}
                     rel={href.startsWith('http') ? 'noopener noreferrer' : undefined}

--- a/website/components/hero.tsx
+++ b/website/components/hero.tsx
@@ -147,7 +147,7 @@ export function Hero() {
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 lg:gap-16 items-center">
 
           {/* Left column */}
-          <div>
+          <div className="hero-stagger">
             <h1
               className="mb-5 font-display font-black leading-[1.06] text-white text-[38px] sm:text-[48px] lg:text-[56px] xl:text-[64px]"
               style={{ letterSpacing: '-2.5px' }}
@@ -208,7 +208,7 @@ export function Hero() {
           </div>
 
           {/* Right column */}
-          <div className="w-full min-w-0">
+          <div className="w-full min-w-0 hero-reveal-late">
             {/* YAML card */}
             <div
               className="overflow-hidden rounded-[14px] border"

--- a/website/components/hero.tsx
+++ b/website/components/hero.tsx
@@ -149,7 +149,7 @@ export function Hero() {
           {/* Left column */}
           <div>
             <h1
-              className="mb-5 font-black leading-[1.06] text-white text-[38px] sm:text-[48px] lg:text-[56px] xl:text-[64px]"
+              className="mb-5 font-display font-black leading-[1.06] text-white text-[38px] sm:text-[48px] lg:text-[56px] xl:text-[64px]"
               style={{ letterSpacing: '-2.5px' }}
             >
               Build agents.<br />

--- a/website/components/nav.tsx
+++ b/website/components/nav.tsx
@@ -36,6 +36,20 @@ function NavIcon({ name }: { name: 'zap' }) {
   return null;
 }
 
+function GitHubIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+    >
+      <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.78-.25.78-.55v-2.03c-3.2.7-3.88-1.37-3.88-1.37-.53-1.34-1.29-1.69-1.29-1.69-1.05-.72.08-.71.08-.71 1.16.08 1.77 1.19 1.77 1.19 1.04 1.78 2.72 1.27 3.38.97.11-.75.41-1.27.74-1.56-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.19a11.05 11.05 0 0 1 5.78 0c2.21-1.5 3.18-1.19 3.18-1.19.63 1.59.23 2.77.11 3.06.74.81 1.19 1.84 1.19 3.1 0 4.42-2.69 5.39-5.25 5.68.42.36.8 1.07.8 2.16v3.2c0 .31.21.66.79.55 4.57-1.52 7.86-5.83 7.86-10.91C23.5 5.65 18.35.5 12 .5z" />
+    </svg>
+  );
+}
+
 const GITHUB_URL = 'https://github.com/agentbreeder/agentbreeder';
 
 export function Nav({ docsSearch = false }: { docsSearch?: boolean }) {
@@ -106,10 +120,12 @@ export function Nav({ docsSearch = false }: { docsSearch?: boolean }) {
             href={GITHUB_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex min-h-[44px] items-center gap-1.5 rounded-lg border px-3 text-xs no-underline transition-colors hover:text-white"
-            style={{ borderColor: 'var(--border-hover)', color: 'var(--text-muted)' }}
+            aria-label="AgentBreeder on GitHub"
+            className="flex min-h-[44px] items-center gap-1.5 rounded-md px-2 text-sm no-underline transition-colors hover:text-white"
+            style={{ color: 'var(--text-muted)' }}
           >
-            ★ &nbsp;GitHub
+            <GitHubIcon />
+            <span className="hidden lg:inline">GitHub</span>
           </a>
           {!docsSearch && (
             <Link
@@ -185,10 +201,11 @@ export function Nav({ docsSearch = false }: { docsSearch?: boolean }) {
               href={GITHUB_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex min-h-[44px] items-center justify-center gap-1.5 rounded-lg border px-3 text-sm no-underline transition-colors hover:text-white"
-              style={{ borderColor: 'var(--border-hover)', color: 'var(--text-muted)' }}
+              className="flex min-h-[44px] items-center justify-center gap-2 rounded-md text-sm no-underline transition-colors hover:text-white"
+              style={{ color: 'var(--text-muted)' }}
             >
-              ★ &nbsp;GitHub
+              <GitHubIcon />
+              GitHub
             </a>
             <Link
               href="/docs"

--- a/website/components/nav.tsx
+++ b/website/components/nav.tsx
@@ -106,7 +106,7 @@ export function Nav({ docsSearch = false }: { docsSearch?: boolean }) {
             href={GITHUB_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs no-underline transition-colors hover:text-white"
+            className="flex min-h-[44px] items-center gap-1.5 rounded-lg border px-3 text-xs no-underline transition-colors hover:text-white"
             style={{ borderColor: 'var(--border-hover)', color: 'var(--text-muted)' }}
           >
             ★ &nbsp;GitHub
@@ -114,7 +114,7 @@ export function Nav({ docsSearch = false }: { docsSearch?: boolean }) {
           {!docsSearch && (
             <Link
               href="/docs"
-              className="rounded-lg px-4 py-1.5 text-sm font-bold no-underline transition-opacity hover:opacity-90"
+              className="flex min-h-[44px] items-center rounded-lg px-4 text-sm font-bold no-underline transition-opacity hover:opacity-90"
               style={{ background: 'var(--accent)', color: '#000' }}
             >
               Get Started →
@@ -185,7 +185,7 @@ export function Nav({ docsSearch = false }: { docsSearch?: boolean }) {
               href={GITHUB_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center justify-center gap-1.5 rounded-lg border px-3 py-2 text-sm no-underline transition-colors hover:text-white"
+              className="flex min-h-[44px] items-center justify-center gap-1.5 rounded-lg border px-3 text-sm no-underline transition-colors hover:text-white"
               style={{ borderColor: 'var(--border-hover)', color: 'var(--text-muted)' }}
             >
               ★ &nbsp;GitHub
@@ -193,7 +193,7 @@ export function Nav({ docsSearch = false }: { docsSearch?: boolean }) {
             <Link
               href="/docs"
               onClick={() => setOpen(false)}
-              className="rounded-lg px-4 py-2 text-sm font-bold no-underline text-center transition-opacity hover:opacity-90"
+              className="flex min-h-[44px] items-center justify-center rounded-lg px-4 text-sm font-bold no-underline transition-opacity hover:opacity-90"
               style={{ background: 'var(--accent)', color: '#000' }}
             >
               Get Started →

--- a/website/components/nav.tsx
+++ b/website/components/nav.tsx
@@ -4,12 +4,37 @@ import Link from 'next/link';
 import { useState } from 'react';
 import { Logo } from './logo';
 
-const NAV_LINKS = [
+type NavLink = {
+  href: string;
+  label: string;
+  highlight?: boolean;
+  icon?: 'zap';
+};
+
+const NAV_LINKS: NavLink[] = [
   { href: '/docs', label: 'Docs' },
   { href: '/docs/quickstart', label: 'Examples' },
-  { href: '#cloud', label: 'Cloud ⚡', highlight: true },
+  { href: '#cloud', label: 'Cloud', highlight: true, icon: 'zap' },
   { href: '/blog', label: 'Blog' },
 ];
+
+function NavIcon({ name }: { name: 'zap' }) {
+  if (name === 'zap') {
+    return (
+      <svg
+        aria-hidden="true"
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        className="inline-block -mt-0.5 ml-1"
+      >
+        <path d="M13 2 3 14h9l-1 8 10-12h-9l1-8Z" />
+      </svg>
+    );
+  }
+  return null;
+}
 
 const GITHUB_URL = 'https://github.com/agentbreeder/agentbreeder';
 
@@ -35,7 +60,7 @@ export function Nav({ docsSearch = false }: { docsSearch?: boolean }) {
         <div className="hidden md:flex items-center justify-center">
           {!docsSearch && (
             <ul className="flex list-none gap-1 m-0 p-0">
-              {NAV_LINKS.map(({ href, label, highlight }) => (
+              {NAV_LINKS.map(({ href, label, highlight, icon }) => (
                 <li key={href}>
                   <Link
                     href={href}
@@ -46,6 +71,7 @@ export function Nav({ docsSearch = false }: { docsSearch?: boolean }) {
                     }
                   >
                     {label}
+                    {icon && <NavIcon name={icon} />}
                   </Link>
                 </li>
               ))}
@@ -137,7 +163,7 @@ export function Nav({ docsSearch = false }: { docsSearch?: boolean }) {
           }}
         >
           <ul className="flex flex-col gap-1 list-none m-0 p-0 mb-3">
-            {NAV_LINKS.map(({ href, label, highlight }) => (
+            {NAV_LINKS.map(({ href, label, highlight, icon }) => (
               <li key={href}>
                 <Link
                   href={href}
@@ -149,6 +175,7 @@ export function Nav({ docsSearch = false }: { docsSearch?: boolean }) {
                   }
                 >
                   {label}
+                  {icon && <NavIcon name={icon} />}
                 </Link>
               </li>
             ))}

--- a/website/components/nav.tsx
+++ b/website/components/nav.tsx
@@ -14,7 +14,7 @@ type NavLink = {
 const NAV_LINKS: NavLink[] = [
   { href: '/docs', label: 'Docs' },
   { href: '/docs/quickstart', label: 'Examples' },
-  { href: '#cloud', label: 'Cloud', highlight: true, icon: 'zap' },
+  { href: '/cloud', label: 'Cloud', highlight: true, icon: 'zap' },
   { href: '/blog', label: 'Blog' },
 ];
 

--- a/website/components/platform-lock.tsx
+++ b/website/components/platform-lock.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 const PLATFORMS = [
   {
     name: 'Google Gemini Agent Platform',
@@ -192,9 +194,9 @@ export function PlatformLock() {
         <p className="mt-6 text-[13px]" style={{ color: 'var(--text-dim)' }}>
           * Google Gemini Enterprise Agent Platform announced April 22, 2026.
           Claude Managed Agents GA April 2026. Azure AI Foundry GA May 2025.
-          <a href="/blog/the-big-four-agent-platforms-2026" className="ml-1 underline" style={{ color: 'var(--accent)' }}>
+          <Link href="/blog/the-big-four-agent-platforms-2026" className="ml-1 underline" style={{ color: 'var(--accent)' }}>
             Read the full analysis →
-          </a>
+          </Link>
         </p>
       </div>
     </section>

--- a/website/tailwind.config.ts
+++ b/website/tailwind.config.ts
@@ -58,6 +58,8 @@ const config: Config = {
       fontFamily: {
         sans: ['var(--font-geist-sans)', 'Inter', 'sans-serif'],
         mono: ['var(--font-geist-mono)', 'JetBrains Mono', 'monospace'],
+        // Display font for marketing hero headlines only. See #493.
+        display: ['var(--font-display)', 'var(--font-geist-sans)', 'Inter', 'sans-serif'],
       },
     },
   },

--- a/website/tailwind.config.ts
+++ b/website/tailwind.config.ts
@@ -1,6 +1,11 @@
 // website/tailwind.config.ts
 // Note: fumadocs-ui v16 uses CSS-based theming (see app/globals.css).
-// This config provides font and colour extensions for Tailwind v4.
+// Tailwind v4 — the JS config still exposes utilities; the source-of-truth
+// for color values is the CSS custom properties in app/globals.css.
+//
+// All semantic colors below map to CSS vars so changing a value in
+// globals.css propagates to every utility class automatically. Use these
+// utilities in new code instead of `style={{ color: 'var(--text-muted)' }}`.
 import type { Config } from 'tailwindcss';
 
 const config: Config = {
@@ -13,8 +18,43 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        accent: '#22c55e',
+        // Surfaces
+        bg: 'var(--bg)',
+        surface: 'var(--bg-surface)',
+        elevated: 'var(--bg-elevated)',
+
+        // Borders
+        'border-default': 'var(--border)',
+        'border-hover': 'var(--border-hover)',
+
+        // Text — text, text-muted, text-dim already meet WCAG 4.5:1 (see #482)
+        text: 'var(--text)',
+        muted: 'var(--text-muted)',
+        dim: 'var(--text-dim)',
+
+        // Brand
+        accent: 'var(--accent)',
+        'accent-dim': 'var(--accent-dim)',
+        'accent-border': 'var(--accent-border)',
+        purple: 'var(--purple)',
       },
+
+      // Marketing type scale. Apply with `text-display`, `text-h1`, etc.
+      // Body sizes inherit Tailwind defaults (text-sm, text-base, text-lg).
+      fontSize: {
+        'display-xl': ['3.5rem', { lineHeight: '1.05', letterSpacing: '-0.035em' }],
+        'display':    ['3rem',   { lineHeight: '1.1',  letterSpacing: '-0.03em'  }],
+        'h1':         ['2.25rem',{ lineHeight: '1.15', letterSpacing: '-0.025em' }],
+        'h2':         ['1.75rem',{ lineHeight: '1.2',  letterSpacing: '-0.02em'  }],
+        'h3':         ['1.375rem',{ lineHeight: '1.3', letterSpacing: '-0.015em' }],
+        'eyebrow':    ['0.6875rem', { lineHeight: '1', letterSpacing: '0.125em' }],
+      },
+
+      letterSpacing: {
+        display: '-0.035em',
+        headline: '-0.02em',
+      },
+
       fontFamily: {
         sans: ['var(--font-geist-sans)', 'Inter', 'sans-serif'],
         mono: ['var(--font-geist-mono)', 'JetBrains Mono', 'monospace'],


### PR DESCRIPTION
## Summary

Production-readiness work on the marketing site at agentbreeder.io, driven by the Google for Startups Cloud Program verification rejection on 2026-05-20 and reviewed against the `frontend-design` + `ui-ux-pro-max` skill frameworks.

Lands the scaffolding plus 12 of the 14 sub-issues filed under [#495](https://github.com/agentbreeder/agentbreeder/issues/495).

## Scaffolding (in 50b08b0)

- `/about`, `/privacy`, `/terms` — company info, honest minimal legal pages
- `app/robots.ts` + `app/sitemap.ts` — fixes the bare 404s the Google verifier hit
- Footer — added Company column (About, Contact, Privacy, Terms); version v2.0.0 → v2.5.1
- ROADMAP v2.6 row pointing at the epic

## Closes (12 issues)

| # | Title | Commit |
|---|---|---|
| #481 | Replace ⚡ emoji nav icon with inline Zap SVG | `28347a1` |
| #482 | Bump `--text-dim` + `--text-muted` to meet WCAG 4.5:1 | `e02413a` |
| #483 | Add `prefers-reduced-motion` global guard | `941cb05` |
| #484 | Bump footer + nav touch targets to ≥44pt | `dbfa19e`, `2fe574d` |
| #485 | Branded `/not-found` page | `cc1b510` |
| #486 | Remove broken Twitter footer placeholder | `d0cbdde` |
| #487 | Sync founder bio in `built-by.tsx` (Udemy + Coursera) | `79ce3dd` |
| #488 | Single primary nav CTA; GitHub demoted to icon link | `b51e916` |
| #489 | Document forced-dark choice (Option B); a11y section on /about | `05e5d24`, `1a19de3` |
| #491 | `/cloud` landing page + waitlist + sitemap entry | `7a402b7`, `50429d6` |
| #493 | Bricolage Grotesque display font for hero headlines | `5a7cc90` |
| #494 | Staggered hero load animation | `9e8d63c` |

## Progress, not closed

- **#490** — token foundation landed in `bbea956`. Component-by-component refactor is the bigger remaining half; deserves its own PR with visual regression checks.
- **#492** — blocked-on the console.agentbreeder.io private-alpha launch; commented and left open.

## Bonus

- `08bc97b` — fixed a pre-existing lint error in `platform-lock.tsx` (used `<a>` for an internal route) so CI passes.

## Why merge-commit, not squash

Per [[feedback_preserve_wave_history]] / the project's pattern on multi-issue PRs (#402 audit waves): each commit here is independently scoped to a single issue, independently green, and bisectable. Squashing would destroy the per-issue traceability that the commit subjects + issue numbers give. Use a merge commit.

## Test plan

- [x] `npx next build` — clean, 64 routes
- [x] `npm run lint` — no errors
- [x] `npx tsc --noEmit` — no type errors
- [ ] Spot-check on production after deploy: `curl https://www.agentbreeder.io/robots.txt` returns the robots file (not the 404 HTML), `/sitemap.xml` returns the sitemap, `/about` `/privacy` `/terms` `/cloud` `/not-found` all render with Nav + Footer
- [ ] Visual spot-check the homepage hero with a hard refresh — should see staggered fade-in
- [ ] Enable macOS "Reduce motion" — hero should be visible immediately, no animation

## Epic

Tracks [#495](https://github.com/agentbreeder/agentbreeder/issues/495). After merge: #490 and #492 stay open as documented; everything else closes via the commit "Closes #NNN" trailers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
