### PR TITLE
feat(api): team_from_jwt — current_tenant_slug claim as team resolver source

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -58,3 +58,25 @@ async def get_optional_user(
         return None
 
     return await get_user_by_id(db, uuid.UUID(payload["sub"]))
+
+
+def team_from_jwt(authorization_header: str | None) -> str | None:
+    """Extract `current_tenant_slug` from a Bearer JWT, if present.
+
+    Returns the slug string when the header is `Bearer <jwt>` and the JWT is
+    signed with our `jwt_secret_key` and contains a `current_tenant_slug`
+    claim. Returns None otherwise — for missing/non-Bearer headers, invalid
+    signatures, expired tokens, or JWTs that simply don't carry the claim.
+
+    Intended for external overlays (e.g. agentbreeder-cloud's SaaS control
+    plane) that need to inject tenant context as the OSS `team` scope. Self-
+    hosted deployments that don't issue JWTs with this claim are unaffected
+    — every caller still falls back to existing team-resolution paths.
+    """
+    if not authorization_header or not authorization_header.startswith("Bearer "):
+        return None
+    payload = decode_access_token(authorization_header[len("Bearer ") :])
+    if payload is None:
+        return None
+    slug = payload.get("current_tenant_slug")
+    return slug if isinstance(slug, str) else None

--- a/tests/unit/test_team_jwt_claim.py
+++ b/tests/unit/test_team_jwt_claim.py
@@ -1,0 +1,79 @@
+"""Tests for `team_from_jwt` — JWT `current_tenant_slug` claim extraction."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import jwt as pyjwt
+
+from api.auth import team_from_jwt
+from api.config import settings
+
+
+def _sign(payload: dict, secret: str | None = None) -> str:
+    return pyjwt.encode(
+        payload, secret or settings.jwt_secret_key, algorithm=settings.jwt_algorithm
+    )
+
+
+def test_extracts_slug_from_valid_jwt():
+    token = _sign(
+        {
+            "sub": "11111111-1111-1111-1111-111111111111",
+            "current_tenant_slug": "acme-corp",
+            "exp": datetime.now(UTC) + timedelta(hours=1),
+        }
+    )
+    assert team_from_jwt(f"Bearer {token}") == "acme-corp"
+
+
+def test_missing_header_returns_none():
+    assert team_from_jwt(None) is None
+
+
+def test_non_bearer_header_returns_none():
+    assert team_from_jwt("Basic abc") is None
+
+
+def test_jwt_without_claim_returns_none():
+    token = _sign(
+        {
+            "sub": "11111111-1111-1111-1111-111111111111",
+            "exp": datetime.now(UTC) + timedelta(hours=1),
+        }
+    )
+    assert team_from_jwt(f"Bearer {token}") is None
+
+
+def test_invalid_signature_returns_none():
+    token = _sign(
+        {
+            "sub": "11111111-1111-1111-1111-111111111111",
+            "current_tenant_slug": "x",
+            "exp": datetime.now(UTC) + timedelta(hours=1),
+        },
+        secret="a-completely-different-secret-key",
+    )
+    assert team_from_jwt(f"Bearer {token}") is None
+
+
+def test_expired_token_returns_none():
+    token = _sign(
+        {
+            "sub": "11111111-1111-1111-1111-111111111111",
+            "current_tenant_slug": "x",
+            "exp": datetime.now(UTC) - timedelta(hours=1),
+        }
+    )
+    assert team_from_jwt(f"Bearer {token}") is None
+
+
+def test_non_string_claim_returns_none():
+    token = _sign(
+        {
+            "sub": "11111111-1111-1111-1111-111111111111",
+            "current_tenant_slug": 123,
+            "exp": datetime.now(UTC) + timedelta(hours=1),
+        }
+    )
+    assert team_from_jwt(f"Bearer {token}") is None


### PR DESCRIPTION
## Summary

Adds `api.auth.team_from_jwt(authorization_header)` — a pure helper that extracts a `current_tenant_slug` claim from a Bearer JWT signed with our `jwt_secret_key`. Returns `None` on any failure mode (missing/non-Bearer header, invalid signature, expired token, missing or non-string claim).

This is a **foundation PR**: it adds the helper but does **not** call it from any existing route. Every current `team` resolution path — query parameter, `agent.team` lookup, `user.team` default — is unchanged. Self-hosted deployments behave identically.

## Why

The companion SaaS overlay at [agentbreeder-cloud](https://github.com/agentbreeder/agentbreeder-cloud) issues JWTs that already authenticate the user. We want the overlay to inject **team scope** through the same JWT — not a parallel header or query parameter — so OSS stays ignorant of the overlay's tenant model while still being able to scope per request to one team.

Architecture sketch:
```
console.agentbreeder.com  →  Cloud API issues JWT with current_tenant_slug
                              ↓
                         Cloud middleware → set X-AB-Team or pass through
                              ↓
                         OSS API team_from_jwt(authorization) → "acme-corp"
```

Closes #497.

## Test plan
- [x] 7 new unit tests in `tests/unit/test_team_jwt_claim.py` cover: valid claim, missing header, non-Bearer scheme, missing claim, bad signature, expired token, non-string claim
- [x] All 31 existing `tests/unit/test_auth.py` tests still pass
- [x] `ruff check` and `ruff format --check` clean

## Out of scope (future PRs)

- Wiring `team_from_jwt` into specific routes — each route owner can opt in when they need the override behavior (e.g. agents list, deploy create, audit query)
- Cloud-side middleware that signs the JWT with the claim — that lives in `agentbreeder-cloud` and is rolled out alongside the Tenancy v1 sub-project