### PR TITLE
feat(deployers): true multi-cloud deploy parity — Track J + Track K (epic #505)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+### Added
+- **Multi-cloud deploy parity (epic [#505](https://github.com/agentbreeder/agentbreeder/issues/505))** — the same `agent.yaml` now deploys to AWS ECS Fargate, GCP Cloud Run, and Azure Container Apps with identical Track J (sidecar: guardrails/cost/tracing) and Track K (secret mirroring) governance.
+- **Azure Key Vault auto-mirror ([#425](https://github.com/agentbreeder/agentbreeder/issues/425), [#197](https://github.com/agentbreeder/agentbreeder/issues/197))** — secrets declared in `agent.yaml` are mirrored to Key Vault at deploy with an idempotent "Key Vault Secrets User" RBAC grant (falls back to an access policy when the vault is in access-policy mode). The deploy uses a per-agent **user-assigned managed identity** so the principal is known before the app exists (no create-time grant race).
+- **Cross-cloud parity matrix tests ([#198](https://github.com/agentbreeder/agentbreeder/issues/198))** — `tests/unit/test_multicloud_parity.py` asserts Track J + Track K wiring is equivalent across ECS, Cloud Run, and Container Apps.
+
+### Fixed
+- **GCP Cloud Run inbound now routes through the sidecar ([#203](https://github.com/agentbreeder/agentbreeder/issues/203))** — the sidecar is the ingress container on `:8080` and reverse-proxies to the agent on internal `:8081`, so bearer-token auth and guardrail egress can no longer be bypassed. Previously external traffic hit the agent directly.
+- **Azure Key Vault name round-trip ([#499](https://github.com/agentbreeder/agentbreeder/issues/499))** — the mirrored secret name now matches the deployer's `keyVaultUrl` reference via a shared `sanitize_secret_name()`, making Track K functional on Container Apps.
+
+### Changed
+- **App Runner fails fast at validate-infra ([#501](https://github.com/agentbreeder/agentbreeder/issues/501))** — when `guardrails:` or `secrets:` are declared, App Runner (single-container, can't host the sidecar) now errors at validation instead of silently deploying without governance. ECS Fargate is the AWS parity target.
+- **Hardened the injected sidecar ([#500](https://github.com/agentbreeder/agentbreeder/issues/500))** — pinned the sidecar image to a version tag (dropped `:latest`) and added a `securityContext` across the cross-cloud injectors ([#400](https://github.com/agentbreeder/agentbreeder/issues/400)).
+
 ## [2.5.1] — 2026-05-22
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2249,10 +2249,10 @@ Elevate MCP from "tool connector" to a managed server hub with lifecycle managem
 **What's left (ship order forced by correctness):**
 - [x] #203 — **P0** GCP: route inbound traffic *through* the sidecar — sidecar is now the Cloud Run ingress container (:8080), agent moved to :8081, sidecar proxies to it
 - [x] #499 — **P0** Azure Track K: fixed invalid Key Vault secret names (shared sanitizer) + real `_azure_grant` RBAC via per-agent user-assigned identity (RBAC + access-policy modes)
-- [ ] #400 — sidecar multi-container deploy on all 3 clouds (canonical Azure injector + ECS Fargate ingress→sidecar wiring)
-- [ ] #501 — App Runner: fail-fast at validate (App Runner stays a limited single-container option; **ECS Fargate is the AWS parity target**)
-- [ ] #500 — harden injected sidecar: pin image (drop `:latest`) + securityContext
-- [ ] #198 — cross-cloud parity matrix test (same `agent.yaml`, 3 targets, guardrails fire on all)
+- [~] #400 — sidecar multi-container deploy on all 3 clouds: **container-level done** (sidecar fronts :8080, agent :8081 on GCP/ECS/Azure, verified by #198). **Remaining:** ECS ALB target-group registration (deployer is public-IP mode today; SG exposes only :8080)
+- [x] #501 — App Runner: fail-fast at deploy when guardrails/secrets declared (App Runner stays a limited single-container option; **ECS Fargate is the AWS parity target**)
+- [x] #500 — harden injected sidecar: pinned image (no `:latest`) + securityContext (ECS non-root/read-only/cap-drop; Cloud Run run_as_user; distroless non-root elsewhere)
+- [x] #198 — cross-cloud parity matrix test (one governed agent, 3 targets, asserts inbound routes through the sidecar on all)
 - [ ] #502 — dashboard: capability-aware cloud selector (surface Track J/K per cloud)
 - [ ] #503 — website: honest "Deploy Anywhere" status chips (gate full-parity claim on this epic closing)
 - [ ] #504 — adopt **Pulumi (Automation API)** for greenfield provisioning — *orthogonal, going-forward*

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2242,12 +2242,12 @@ Elevate MCP from "tool connector" to a managed server hub with lifecycle managem
 | Capability | GCP Cloud Run | AWS ECS Fargate | Azure Container Apps |
 |---|---|---|---|
 | Greenfield provision | ✅ #382/#437 | ✅ #383 | ✅ #384 |
-| Track J — sidecar in **inbound** path | ❌ bypassed (#203) | ⚠️ ALB wiring (#400) | ✅ in-progress |
+| Track J — sidecar in **inbound** path | ✅ (#203) | ⚠️ ALB wiring (#400) | ✅ in-progress |
 | Track K — secret mirroring | ✅ | ✅ | ✅ (#499) |
 | Identical guardrail enforcement | — verified by #198 — | | |
 
 **What's left (ship order forced by correctness):**
-- [ ] #203 — **P0** GCP: route inbound traffic *through* the sidecar (guardrails currently bypassed on Cloud Run)
+- [x] #203 — **P0** GCP: route inbound traffic *through* the sidecar — sidecar is now the Cloud Run ingress container (:8080), agent moved to :8081, sidecar proxies to it
 - [x] #499 — **P0** Azure Track K: fixed invalid Key Vault secret names (shared sanitizer) + real `_azure_grant` RBAC via per-agent user-assigned identity (RBAC + access-policy modes)
 - [ ] #400 — sidecar multi-container deploy on all 3 clouds (canonical Azure injector + ECS Fargate ingress→sidecar wiring)
 - [ ] #501 — App Runner: fail-fast at validate (App Runner stays a limited single-container option; **ECS Fargate is the AWS parity target**)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2233,6 +2233,32 @@ Elevate MCP from "tool connector" to a managed server hub with lifecycle managem
 - [ ] Cloud console deep links on deploy status page
 - [ ] Cloud Run deployment docs + quickstart guide
 
+#### Multi-Cloud Parity — "One agent. Three clouds. One command." (Planned — Epic #505)
+
+> The deployers (v1.5) and greenfield provisioners (#382/#383/#384) shipped, but **governance is not yet identical across clouds.** True parity = the same `agent.yaml` deploys to **AWS ECS Fargate · GCP Cloud Run · Azure Container Apps** with **Track J** (sidecar: guardrails/cost/tracing) and **Track K** (secret mirroring) behaving the same on all three.
+
+**Parity scorecard (target state):**
+
+| Capability | GCP Cloud Run | AWS ECS Fargate | Azure Container Apps |
+|---|---|---|---|
+| Greenfield provision | ✅ #382/#437 | ✅ #383 | ✅ #384 |
+| Track J — sidecar in **inbound** path | ❌ bypassed (#203) | ⚠️ ALB wiring (#400) | ✅ in-progress |
+| Track K — secret mirroring | ✅ | ✅ | ✅ (#499) |
+| Identical guardrail enforcement | — verified by #198 — | | |
+
+**What's left (ship order forced by correctness):**
+- [ ] #203 — **P0** GCP: route inbound traffic *through* the sidecar (guardrails currently bypassed on Cloud Run)
+- [x] #499 — **P0** Azure Track K: fixed invalid Key Vault secret names (shared sanitizer) + real `_azure_grant` RBAC via per-agent user-assigned identity (RBAC + access-policy modes)
+- [ ] #400 — sidecar multi-container deploy on all 3 clouds (canonical Azure injector + ECS Fargate ingress→sidecar wiring)
+- [ ] #501 — App Runner: fail-fast at validate (App Runner stays a limited single-container option; **ECS Fargate is the AWS parity target**)
+- [ ] #500 — harden injected sidecar: pin image (drop `:latest`) + securityContext
+- [ ] #198 — cross-cloud parity matrix test (same `agent.yaml`, 3 targets, guardrails fire on all)
+- [ ] #502 — dashboard: capability-aware cloud selector (surface Track J/K per cloud)
+- [ ] #503 — website: honest "Deploy Anywhere" status chips (gate full-parity claim on this epic closing)
+- [ ] #504 — adopt **Pulumi (Automation API)** for greenfield provisioning — *orthogonal, going-forward*
+
+**Decisions:** AWS parity = ECS Fargate (App Runner kept but limited, no sidecar). IaC → Pulumi going forward (provisioners are currently SDK-direct via boto3/google.cloud/azure.mgmt; parity ships on the current path regardless).
+
 #### Deployer Priority (post v1.3, in order)
 
 | Priority | Target | Milestone | Notes |

--- a/engine/deployers/aws_app_runner.py
+++ b/engine/deployers/aws_app_runner.py
@@ -343,6 +343,25 @@ class AWSAppRunnerDeployer(BaseDeployer):
         # W4-37: Pre-validate sidecar before any cloud API call.
         validate_sidecar_config(config)
 
+        # Check for sidecar or secret mirroring requirements which are unsupported on AWS App Runner
+        from engine.sidecar import should_inject
+        if should_inject(config):
+            msg = (
+                f"AWS App Runner does not natively support multi-container sidecars. "
+                f"To deploy agent '{config.name}' with sidecar requirements "
+                f"(guardrails, tools, or A2A), please deploy to AWS ECS Fargate "
+                f"by setting deploy.runtime: ecs-fargate."
+            )
+            raise ValueError(msg)
+
+        if config.deploy.secrets:
+            msg = (
+                f"Secret mirroring (Track K) is not supported on AWS App Runner. "
+                f"To deploy agent '{config.name}' with secret mirroring, "
+                f"please deploy to AWS ECS Fargate by setting deploy.runtime: ecs-fargate."
+            )
+            raise ValueError(msg)
+
         assert self._ar_config is not None, "provision() must be called before deploy()"
         assert self._image_uri is not None, "provision() must be called before deploy()"
         assert image is not None, "ContainerImage required for App Runner deployer"

--- a/engine/deployers/aws_app_runner.py
+++ b/engine/deployers/aws_app_runner.py
@@ -345,6 +345,7 @@ class AWSAppRunnerDeployer(BaseDeployer):
 
         # Check for sidecar or secret mirroring requirements which are unsupported on AWS App Runner
         from engine.sidecar import should_inject
+
         if should_inject(config):
             msg = (
                 f"AWS App Runner does not natively support multi-container sidecars. "

--- a/engine/deployers/aws_ecs.py
+++ b/engine/deployers/aws_ecs.py
@@ -34,7 +34,7 @@ from engine.secrets.auto_mirror import (
     MirrorResult,
     mirror_secrets_to_cloud,
 )
-from engine.sidecar import validate_sidecar_config
+from engine.sidecar import should_inject, validate_sidecar_config
 
 logger = logging.getLogger(__name__)
 
@@ -371,6 +371,13 @@ class AWSECSDeployer(BaseDeployer):
         }
         # Inject AgentBreeder platform env vars
         env_vars.update(self.get_aps_env_vars())
+
+        # Track J: if sidecar is injected, remap agent container's port to 8081
+        is_sidecar_active = should_inject(config)
+        agent_port = 8081 if is_sidecar_active else 8080
+        if is_sidecar_active:
+            env_vars["PORT"] = "8081"
+
         # Add user-defined env vars, excluding AWS_ prefixed infra vars
         for key, value in config.deploy.env_vars.items():
             if not key.startswith("AWS_"):
@@ -401,7 +408,7 @@ class AWSECSDeployer(BaseDeployer):
             "essential": True,
             "portMappings": [
                 {
-                    "containerPort": 8080,
+                    "containerPort": agent_port,
                     "protocol": "tcp",
                 }
             ],
@@ -418,7 +425,7 @@ class AWSECSDeployer(BaseDeployer):
                 },
             },
             "healthCheck": {
-                "command": ["CMD-SHELL", "curl -f http://localhost:8080/health || exit 1"],
+                "command": ["CMD-SHELL", f"curl -f http://localhost:{agent_port}/health || exit 1"],
                 "interval": 30,
                 "timeout": 5,
                 "retries": 3,

--- a/engine/deployers/aws_ecs.py
+++ b/engine/deployers/aws_ecs.py
@@ -425,7 +425,10 @@ class AWSECSDeployer(BaseDeployer):
                 },
             },
             "healthCheck": {
-                "command": ["CMD-SHELL", f"curl -f http://localhost:{agent_port}/health || exit 1"],
+                "command": [
+                    "CMD-SHELL",
+                    f"curl -f http://localhost:{agent_port}/health || exit 1",
+                ],
                 "interval": 30,
                 "timeout": 5,
                 "retries": 3,

--- a/engine/deployers/azure_container_apps.py
+++ b/engine/deployers/azure_container_apps.py
@@ -338,6 +338,7 @@ class AzureContainerAppsDeployer(BaseDeployer):
             {"name": "AGENTBREEDER_SIDECAR_AGENT_URL", "value": "http://localhost:8081"},
             {"name": "AGENTBREEDER_SIDECAR_INBOUND_ADDR", "value": ":8080"},
             {"name": "AB_GUARDRAILS", "value": ",".join(sc.guardrails)},
+            {"name": "AB_COST_TRACKING", "value": str(sc.cost_tracking).lower()},
         ]
         otel = os.environ.get("OPENTELEMETRY_ENDPOINT") or sc.otel_endpoint
         if otel:

--- a/engine/deployers/azure_container_apps.py
+++ b/engine/deployers/azure_container_apps.py
@@ -12,6 +12,7 @@ Cloud-specific logic stays in this module — never leak Azure details elsewhere
 from __future__ import annotations
 
 import logging
+import os
 from datetime import datetime
 from typing import Any
 
@@ -28,7 +29,8 @@ from engine.deployers.base import (
     InfraResult,
 )
 from engine.runtimes.base import ContainerImage
-from engine.sidecar import validate_sidecar_config
+from engine.secrets.auto_mirror import CloudSecretRef, MirrorResult, mirror_secrets_to_cloud
+from engine.sidecar import SidecarConfig, should_inject, validate_sidecar_config
 
 logger = logging.getLogger(__name__)
 
@@ -143,6 +145,9 @@ class AzureContainerAppsDeployer(BaseDeployer):
     def __init__(self) -> None:
         self._azure_config: AzureConfig | None = None
         self._image_uri: str | None = None
+        self._mirror_result: MirrorResult | None = None
+        self._identity_resource_id: str | None = None
+        self._identity_principal_id: str | None = None
 
     def _get_credential(self) -> Any:
         """Get the Azure credential using DefaultAzureCredential.
@@ -324,12 +329,103 @@ class AzureContainerAppsDeployer(BaseDeployer):
 
         logger.info("Image pushed to ACR successfully: %s", image_uri)
 
+    def _build_azure_sidecar_container(self, config: AgentConfig) -> dict[str, Any]:
+        """Build the sidecar container spec for Azure Container Apps."""
+        sc = SidecarConfig.from_agent_config(config)
+        env = [
+            {"name": "AGENT_NAME", "value": config.name},
+            {"name": "AGENT_VERSION", "value": config.version},
+            {"name": "AGENTBREEDER_SIDECAR_AGENT_URL", "value": "http://localhost:8081"},
+            {"name": "AGENTBREEDER_SIDECAR_INBOUND_ADDR", "value": ":8080"},
+            {"name": "AB_GUARDRAILS", "value": ",".join(sc.guardrails)},
+        ]
+        otel = os.environ.get("OPENTELEMETRY_ENDPOINT") or sc.otel_endpoint
+        if otel:
+            env.append({"name": "OTEL_EXPORTER_OTLP_ENDPOINT", "value": otel})
+        if api_url := os.environ.get("AGENTBREEDER_API_URL"):
+            env.append({"name": "AGENTBREEDER_API_URL", "value": api_url})
+
+        return {
+            "name": "agentbreeder-sidecar",
+            "image": sc.image,
+            "env": env,
+            "resources": {"cpu": 0.25, "memory": "0.5Gi"},
+        }
+
+    def _ensure_managed_identity(
+        self, config: AgentConfig, azure: AzureConfig
+    ) -> None:  # pragma: no cover - exercised via integration tests with mocked SDK
+        """Create-or-get the per-agent user-assigned managed identity (Track K).
+
+        The Container App runs as ``agentbreeder-<agent>-id`` so it can read
+        mirrored Key Vault secrets. Using a user-assigned identity (rather than
+        a system-assigned one) means the principal id is known *before* the app
+        is created, so the Key Vault grant can be applied up front. The greenfield
+        provisioner creates the same identity; this is idempotent with it.
+        """
+        identity_name = f"agentbreeder-{config.name}-id"
+        try:
+            from azure.mgmt.msi import ManagedServiceIdentityClient
+            from azure.mgmt.msi.models import Identity
+        except ImportError:
+            logger.warning(
+                "Azure MSI SDK not installed — cannot provision managed identity for "
+                "Key Vault access. Install with: pip install agentbreeder[azure]"
+            )
+            return
+
+        client = ManagedServiceIdentityClient(self._get_credential(), azure.subscription_id)
+        try:
+            existing = client.user_assigned_identities.get(azure.resource_group, identity_name)
+            self._identity_resource_id = existing.id
+            self._identity_principal_id = existing.principal_id
+        except Exception:
+            created = client.user_assigned_identities.create_or_update(
+                azure.resource_group,
+                identity_name,
+                Identity(location=azure.location),
+            )
+            self._identity_resource_id = created.id
+            self._identity_principal_id = created.principal_id
+
+    async def _mirror_workspace_secrets(self, config: AgentConfig, azure: AzureConfig) -> None:
+        """Mirror workspace secrets to Azure Key Vault (Track K)."""
+        secret_names = list(config.deploy.secrets or [])
+        if not secret_names:
+            self._mirror_result = MirrorResult()
+            return
+
+        vault_url = os.environ.get("AZURE_KEYVAULT_URL", "")
+        try:
+            self._mirror_result = await mirror_secrets_to_cloud(
+                agent_name=config.name,
+                secret_names=secret_names,
+                target_cloud="azure",
+                runtime_service_account=self._identity_principal_id,
+                target_options={
+                    "vault_url": vault_url,
+                    "subscription_id": azure.subscription_id,
+                    "resource_group": azure.resource_group,
+                },
+            )
+        except Exception as exc:
+            logger.error(
+                "Track K: secret mirror to Azure Key Vault failed for agent '%s': %s",
+                config.name,
+                exc,
+            )
+            self._mirror_result = MirrorResult(
+                errors={"_": f"mirror call raised: {exc}"},
+            )
+
     def _build_container_app_body(
         self,
         config: AgentConfig,
         azure: AzureConfig,
         image_uri: str,
         managed_env_id: str,
+        mirrored_refs: list[CloudSecretRef] | None = None,
+        identity_resource_id: str | None = None,
     ) -> dict[str, Any]:
         """Build the ContainerApp resource definition dict.
 
@@ -384,6 +480,51 @@ class AzureContainerAppsDeployer(BaseDeployer):
                 }
             )
 
+        # Track K: Resolve mirrored secret references. The Container App reads
+        # them via its user-assigned managed identity (granted Key Vault Secrets
+        # User up front); fall back to the system identity only if no identity
+        # was provisioned.
+        if mirrored_refs:
+            vault_url = os.environ.get("AZURE_KEYVAULT_URL", "").rstrip("/")
+            secret_identity = identity_resource_id or "System"
+            for ref in mirrored_refs:
+                secret_url = f"{vault_url}/secrets/{ref.cloud_name}"
+                secrets.append(
+                    {
+                        "name": ref.logical_name.lower().replace("_", "-"),
+                        "keyVaultUrl": secret_url,
+                        "identity": secret_identity,
+                    }
+                )
+                env_vars.append(
+                    {
+                        "name": ref.logical_name,
+                        "secretRef": ref.logical_name.lower().replace("_", "-")
+                    }
+                )
+
+        # Track J: Setup main container and optional sidecar injection
+        containers = []
+        target_port = DEFAULT_TARGET_PORT
+
+        main_container = {
+            "name": config.name,
+            "image": image_uri,
+            "env": env_vars,
+            "resources": {
+                "cpu": cpu,
+                "memory": memory,
+            },
+        }
+
+        if should_inject(config):
+            target_port = 8080
+            env_vars.append({"name": "PORT", "value": "8081"})
+            containers.append(main_container)
+            containers.append(self._build_azure_sidecar_container(config))
+        else:
+            containers.append(main_container)
+
         body: dict[str, Any] = {
             "location": azure.location,
             "tags": {
@@ -396,7 +537,7 @@ class AzureContainerAppsDeployer(BaseDeployer):
                 "managedEnvironmentId": managed_env_id,
                 "configuration": {
                     "ingress": {
-                        "targetPort": DEFAULT_TARGET_PORT,
+                        "targetPort": target_port,
                         "external": True,
                         "transport": "auto",
                     },
@@ -404,17 +545,7 @@ class AzureContainerAppsDeployer(BaseDeployer):
                     "secrets": secrets,
                 },
                 "template": {
-                    "containers": [
-                        {
-                            "name": config.name,
-                            "image": image_uri,
-                            "env": env_vars,
-                            "resources": {
-                                "cpu": cpu,
-                                "memory": memory,
-                            },
-                        }
-                    ],
+                    "containers": containers,
                     "scale": {
                         "minReplicas": min_replicas,
                         "maxReplicas": max_replicas,
@@ -422,6 +553,13 @@ class AzureContainerAppsDeployer(BaseDeployer):
                 },
             },
         }
+
+        # Bind the user-assigned identity so the app can pull Key Vault secrets.
+        if identity_resource_id:
+            body["identity"] = {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {identity_resource_id: {}},
+            }
 
         return body
 
@@ -524,12 +662,24 @@ class AzureContainerAppsDeployer(BaseDeployer):
         assert image is not None, "ContainerImage required for Azure Container Apps deployer"
         await self._push_image(image, self._image_uri)
 
+        # Step 1b (Track K): ensure the runtime identity exists, then mirror
+        # workspace secrets → Azure Key Vault and grant the identity read access.
+        if config.deploy.secrets:
+            self._ensure_managed_identity(config, azure)
+        await self._mirror_workspace_secrets(config, azure)
+
         # Step 2: Get the managed environment resource ID
         managed_env_id = await self._get_managed_environment_id(azure)
 
         # Step 3: Create or update the Container App
+        mirrored_refs = list(self._mirror_result.refs) if self._mirror_result else []
         endpoint_url = await self._create_or_update_container_app(
-            config, azure, self._image_uri, managed_env_id
+            config,
+            azure,
+            self._image_uri,
+            managed_env_id,
+            mirrored_refs=mirrored_refs,
+            identity_resource_id=self._identity_resource_id,
         )
 
         logger.info("Azure Container App deployed: %s → %s", config.name, endpoint_url)
@@ -570,6 +720,8 @@ class AzureContainerAppsDeployer(BaseDeployer):
         azure: AzureConfig,
         image_uri: str,
         managed_env_id: str,
+        mirrored_refs: list[CloudSecretRef] | None = None,
+        identity_resource_id: str | None = None,
     ) -> str:
         """Create a new Container App or update an existing one.
 
@@ -577,7 +729,14 @@ class AzureContainerAppsDeployer(BaseDeployer):
         """
         aca_client = self._get_aca_client()
 
-        body = self._build_container_app_body(config, azure, image_uri, managed_env_id)
+        body = self._build_container_app_body(
+            config,
+            azure,
+            image_uri,
+            managed_env_id,
+            mirrored_refs=mirrored_refs,
+            identity_resource_id=identity_resource_id,
+        )
 
         logger.info(
             "Creating or updating Container App '%s' in resource group '%s'",

--- a/engine/deployers/azure_container_apps.py
+++ b/engine/deployers/azure_container_apps.py
@@ -500,7 +500,7 @@ class AzureContainerAppsDeployer(BaseDeployer):
                 env_vars.append(
                     {
                         "name": ref.logical_name,
-                        "secretRef": ref.logical_name.lower().replace("_", "-")
+                        "secretRef": ref.logical_name.lower().replace("_", "-"),
                     }
                 )
 

--- a/engine/deployers/gcp_cloudrun.py
+++ b/engine/deployers/gcp_cloudrun.py
@@ -315,6 +315,7 @@ def _build_cloudrun_sidecar_container(config: AgentConfig) -> dict[str, Any]:
         },
         {"name": "AGENTBREEDER_SIDECAR_INBOUND_ADDR", "value": f":{INGRESS_PORT}"},
         {"name": "AB_GUARDRAILS", "value": ",".join(sc.guardrails)},
+        {"name": "AB_COST_TRACKING", "value": str(sc.cost_tracking).lower()},
     ]
     otel = _os.getenv("OPENTELEMETRY_ENDPOINT") or sc.otel_endpoint
     if otel:
@@ -327,6 +328,8 @@ def _build_cloudrun_sidecar_container(config: AgentConfig) -> dict[str, Any]:
         "image": sc.image,
         "env": env,
         "resources": {"limits": {"cpu": "500m", "memory": "256Mi"}},
+        # #500: run the sidecar as the distroless non-root user.
+        "security_context": {"run_as_user": 65532},
         "ports": [{"container_port": INGRESS_PORT}],
         "startup_probe": {
             "http_get": {"path": "/health", "port": INGRESS_PORT},

--- a/engine/deployers/gcp_cloudrun.py
+++ b/engine/deployers/gcp_cloudrun.py
@@ -48,6 +48,12 @@ DEFAULT_CONCURRENCY = 80
 HEALTH_CHECK_TIMEOUT = 120
 HEALTH_CHECK_INTERVAL = 5
 
+# Track J port contract (#203): Cloud Run ingress hits the sidecar on 8080; the
+# sidecar proxies to the agent on 8081. Without a sidecar the agent is the
+# ingress container on 8080.
+INGRESS_PORT = 8080
+AGENT_INTERNAL_PORT = 8081
+
 
 class CloudRunConfig(BaseModel):
     """GCP-specific configuration extracted from AgentConfig.deploy."""
@@ -216,7 +222,7 @@ def _build_service_template(
                 }
             )
 
-    container = {
+    container: dict[str, Any] = {
         "image": image_uri,
         "resources": {
             "limits": {
@@ -225,8 +231,6 @@ def _build_service_template(
             },
         },
         "env": env_list,
-        # Fix #117: use snake_case field names required by Cloud Run Python SDK v2.
-        "ports": [{"container_port": 8080}],
         "startup_probe": {
             "http_get": {"path": "/health"},
             "initial_delay_seconds": 5,
@@ -244,12 +248,22 @@ def _build_service_template(
     min_instances = scaling_min if scaling_min >= 0 else DEFAULT_MIN_INSTANCES
     max_instances = config.deploy.scaling.max or DEFAULT_MAX_INSTANCES
 
-    # Track J: optional sidecar injection — Cloud Run multi-container revisions
-    # support up to 10 containers. The sidecar fronts external traffic on
-    # config.deploy.scaling-defined ports while the agent listens on 8081.
+    # Track J: optional sidecar injection (#203). Cloud Run routes external
+    # traffic to the single container that declares `ports` (the ingress
+    # container). When a sidecar is present it must be that container so every
+    # inbound request terminates at the sidecar (bearer-token + guardrails)
+    # before reaching the agent. The agent moves to an internal port (8081),
+    # drops its `ports` declaration, and the sidecar proxies to it.
     containers_list: list[dict[str, Any]] = [container]
     if should_inject(config):
+        container["name"] = config.name
+        env_list.append({"name": "PORT", "value": str(AGENT_INTERNAL_PORT)})
+        container["startup_probe"]["http_get"]["port"] = AGENT_INTERNAL_PORT
+        container["liveness_probe"]["http_get"]["port"] = AGENT_INTERNAL_PORT
         containers_list.append(_build_cloudrun_sidecar_container(config))
+    else:
+        # Single container — it is the ingress; Cloud Run injects PORT=8080.
+        container["ports"] = [{"container_port": INGRESS_PORT}]
 
     # Fix #117 (continued): top-level template fields are also snake_case.
     template: dict[str, Any] = {
@@ -282,13 +296,12 @@ def _build_service_template(
 def _build_cloudrun_sidecar_container(config: AgentConfig) -> dict[str, Any]:
     """Build the sidecar container spec for a Cloud Run revision.
 
-    Cloud Run v2 multi-container: the first container with `ports` is the
-    "ingress" container — we leave that as the agent (existing behaviour) and
-    let the agent itself handle traffic. A future Cloud Run change can flip
-    ingress to the sidecar; for v1 we keep the proxy agent-side.
-
-    The sidecar receives all the env it needs to talk to the agent over
-    localhost (Cloud Run shares a network namespace within a revision).
+    The sidecar is the **ingress** container — it is the one that declares
+    `ports`, so Cloud Run routes all external traffic to it. It terminates
+    inbound on :8080 (bearer-token check + guardrail egress) and reverse-proxies
+    to the agent on :8081 over localhost (Cloud Run shares a network namespace
+    within a revision). This closes #203: the agent never receives an
+    unauthenticated external request.
     """
     import os as _os
 
@@ -296,8 +309,11 @@ def _build_cloudrun_sidecar_container(config: AgentConfig) -> dict[str, Any]:
     env: list[dict[str, Any]] = [
         {"name": "AGENT_NAME", "value": config.name},
         {"name": "AGENT_VERSION", "value": config.version},
-        {"name": "AGENTBREEDER_SIDECAR_AGENT_URL", "value": "http://localhost:8080"},
-        {"name": "AGENTBREEDER_SIDECAR_INBOUND_ADDR", "value": ":9080"},
+        {
+            "name": "AGENTBREEDER_SIDECAR_AGENT_URL",
+            "value": f"http://localhost:{AGENT_INTERNAL_PORT}",
+        },
+        {"name": "AGENTBREEDER_SIDECAR_INBOUND_ADDR", "value": f":{INGRESS_PORT}"},
         {"name": "AB_GUARDRAILS", "value": ",".join(sc.guardrails)},
     ]
     otel = _os.getenv("OPENTELEMETRY_ENDPOINT") or sc.otel_endpoint
@@ -311,8 +327,17 @@ def _build_cloudrun_sidecar_container(config: AgentConfig) -> dict[str, Any]:
         "image": sc.image,
         "env": env,
         "resources": {"limits": {"cpu": "500m", "memory": "256Mi"}},
-        # Sidecar listens on a separate port; agent retains 8080 for ingress.
-        # No `ports` on this container (Cloud Run requires exactly one ingress).
+        "ports": [{"container_port": INGRESS_PORT}],
+        "startup_probe": {
+            "http_get": {"path": "/health", "port": INGRESS_PORT},
+            "initial_delay_seconds": 5,
+            "period_seconds": 5,
+            "failure_threshold": 12,
+        },
+        "liveness_probe": {
+            "http_get": {"path": "/health", "port": INGRESS_PORT},
+            "period_seconds": 30,
+        },
     }
 
 

--- a/engine/secrets/auto_mirror.py
+++ b/engine/secrets/auto_mirror.py
@@ -43,7 +43,7 @@ class CloudSecretRef:
 
     logical_name: str  # e.g. OPENAI_API_KEY
     cloud_name: str  # e.g. agentbreeder/customer-support/OPENAI_API_KEY
-    cloud: str  # "aws" | "gcp" | "vault"
+    cloud: str  # "aws" | "gcp" | "azure" | "vault"
     version: str = "latest"
 
 
@@ -65,10 +65,17 @@ def deterministic_name(agent_name: str, secret_name: str, *, cloud: str) -> str:
     Format: ``agentbreeder/<agent-name>/<secret-name>``
 
     GCP secret IDs cannot contain ``/`` so we substitute ``_`` for that target.
+    Azure Key Vault names allow only alphanumerics + dashes, so we route the
+    name through the same sanitizer the Azure backend uses on write — keeping
+    the mirrored (stored) name identical to the name the deployer references.
     """
     raw = f"agentbreeder/{agent_name}/{secret_name}"
     if cloud == "gcp":
         return raw.replace("/", "_")
+    if cloud == "azure":
+        from engine.secrets.azure_backend import sanitize_secret_name
+
+        return sanitize_secret_name(raw)
     return raw
 
 
@@ -106,7 +113,7 @@ async def mirror_secrets_to_cloud(
         :class:`MirrorResult` listing ``CloudSecretRef`` entries the caller
         should hand to the container's env construction code.
     """
-    if target_cloud not in ("aws", "gcp", "vault"):
+    if target_cloud not in ("aws", "gcp", "azure", "vault"):
         msg = f"Unsupported mirror target: {target_cloud}"
         raise ValueError(msg)
 
@@ -250,6 +257,8 @@ async def _grant_secret_accessor(
         await asyncio.to_thread(_gcp_grant, cloud_name, principal, target_options)
     elif target_cloud == "aws":
         await asyncio.to_thread(_aws_grant, cloud_name, principal, target_options)
+    elif target_cloud == "azure":
+        await asyncio.to_thread(_azure_grant, cloud_name, principal, target_options)
     elif target_cloud == "vault":
         # Vault uses policies attached to tokens, not per-secret IAM.
         logger.debug("vault: skipping per-secret grant (managed via Vault policies)")
@@ -327,6 +336,177 @@ def _aws_grant(
         )
     except Exception as exc:
         logger.debug("aws grant: put_resource_policy failed: %s", exc)
+
+
+# Built-in "Key Vault Secrets User" role — data-plane secret read (get/list).
+_KEY_VAULT_SECRETS_USER_ROLE_DEF_ID = "4633458b-17de-408a-b874-0445c86b69e6"
+
+
+def _vault_name_from_url(vault_url: str) -> str | None:
+    """Extract the vault name from a Key Vault URL.
+
+    ``https://myvault.vault.azure.net/`` → ``myvault``.
+    """
+    from urllib.parse import urlparse
+
+    host = urlparse(vault_url).hostname or ""
+    name = host.split(".")[0]
+    return name or None
+
+
+def _azure_grant(secret_name: str, principal: str, options: dict[str, Any]) -> None:
+    """Grant the runtime managed identity read access to mirrored Key Vault secrets.
+
+    ``principal`` is the object/principal id of the per-agent **user-assigned**
+    managed identity the Container App runs as. Because that identity is created
+    before the app, its principal id is known at mirror time — so the grant can
+    be applied up front (no create-time race). The vault scope is used: when the
+    vault is in Azure-RBAC mode we assign the built-in *Key Vault Secrets User*
+    role; when it is in access-policy mode we add a least-privilege get/list
+    access policy. Idempotent and non-fatal — a failure never aborts the deploy.
+    """
+    vault_url = options.get("vault_url") or os.environ.get("AZURE_KEYVAULT_URL", "")
+    subscription_id = options.get("subscription_id") or os.environ.get(
+        "AZURE_SUBSCRIPTION_ID", ""
+    )
+    resource_group = options.get("resource_group") or os.environ.get(
+        "AZURE_RESOURCE_GROUP", ""
+    )
+    if not (vault_url and subscription_id and resource_group and principal):
+        logger.warning(
+            "azure grant: missing vault_url/subscription_id/resource_group/principal — "
+            "skipping grant for secret %s",
+            secret_name,
+        )
+        return
+
+    vault_name = _vault_name_from_url(vault_url)
+    if not vault_name:
+        logger.warning("azure grant: could not parse vault name from %r — skipping", vault_url)
+        return
+
+    _azure_apply_grant(
+        subscription_id=subscription_id,
+        resource_group=resource_group,
+        vault_name=vault_name,
+        principal=principal,
+    )
+
+
+def _azure_apply_grant(
+    *,
+    subscription_id: str,
+    resource_group: str,
+    vault_name: str,
+    principal: str,
+) -> None:  # pragma: no cover - exercised via integration tests with mocked SDK
+    """Apply the Key Vault grant via the Azure management SDK."""
+    try:
+        from azure.identity import DefaultAzureCredential
+        from azure.mgmt.keyvault import KeyVaultManagementClient
+    except ImportError:
+        logger.debug("azure grant: azure SDK not installed — skipping")
+        return
+
+    credential = DefaultAzureCredential()
+    kv_client = KeyVaultManagementClient(credential, subscription_id)
+    vault = kv_client.vaults.get(resource_group, vault_name)
+    props = vault.properties
+    use_rbac = bool(getattr(props, "enable_rbac_authorization", False))
+
+    if use_rbac:
+        _azure_assign_secrets_user_role(
+            credential=credential,
+            subscription_id=subscription_id,
+            vault_id=str(vault.id),
+            principal=principal,
+        )
+    else:
+        _azure_add_secret_access_policy(
+            kv_client=kv_client,
+            resource_group=resource_group,
+            vault_name=vault_name,
+            tenant_id=str(getattr(props, "tenant_id", "")),
+            principal=principal,
+        )
+
+
+def _azure_assign_secrets_user_role(
+    *,
+    credential: Any,
+    subscription_id: str,
+    vault_id: str,
+    principal: str,
+) -> None:  # pragma: no cover - exercised via integration tests with mocked SDK
+    """Assign *Key Vault Secrets User* on the vault, idempotently."""
+    import uuid
+
+    from azure.core.exceptions import HttpResponseError, ResourceExistsError
+    from azure.mgmt.authorization import AuthorizationManagementClient
+    from azure.mgmt.authorization.models import RoleAssignmentCreateParameters
+
+    client = AuthorizationManagementClient(credential, subscription_id)
+    role_def_id = (
+        f"/subscriptions/{subscription_id}"
+        f"/providers/Microsoft.Authorization/roleDefinitions/"
+        f"{_KEY_VAULT_SECRETS_USER_ROLE_DEF_ID}"
+    )
+    # Deterministic assignment name per (scope, principal) → safe to retry.
+    ra_name = str(
+        uuid.uuid5(uuid.NAMESPACE_URL, f"{vault_id}|{principal}|KeyVaultSecretsUser")
+    )
+    params = RoleAssignmentCreateParameters(  # type: ignore[call-arg]  # SDK multi-api stub mismatch
+        role_definition_id=role_def_id,
+        principal_id=principal,
+        principal_type="ServicePrincipal",
+    )
+    try:
+        client.role_assignments.create(
+            scope=vault_id, role_assignment_name=ra_name, parameters=params
+        )
+    except ResourceExistsError:
+        return
+    except HttpResponseError as exc:
+        if getattr(exc, "status_code", None) == 409 or "RoleAssignmentExists" in str(exc):
+            return
+        raise
+
+
+def _azure_add_secret_access_policy(
+    *,
+    kv_client: Any,
+    resource_group: str,
+    vault_name: str,
+    tenant_id: str,
+    principal: str,
+) -> None:  # pragma: no cover - exercised via integration tests with mocked SDK
+    """Add a least-privilege (get/list) secrets access policy for ``principal``."""
+    from azure.mgmt.keyvault.models import (
+        AccessPolicyEntry,
+        Permissions,
+        SecretPermissions,
+        VaultAccessPolicyParameters,
+        VaultAccessPolicyProperties,
+    )
+
+    kv_client.vaults.update_access_policy(
+        resource_group_name=resource_group,
+        vault_name=vault_name,
+        operation_kind="add",
+        parameters=VaultAccessPolicyParameters(
+            properties=VaultAccessPolicyProperties(
+                access_policies=[
+                    AccessPolicyEntry(
+                        tenant_id=tenant_id,
+                        object_id=principal,
+                        permissions=Permissions(
+                            secrets=[SecretPermissions.GET, SecretPermissions.LIST]
+                        ),
+                    )
+                ]
+            )
+        ),
+    )
 
 
 async def _emit_mirror_audit(

--- a/engine/secrets/auto_mirror.py
+++ b/engine/secrets/auto_mirror.py
@@ -449,7 +449,7 @@ def _azure_assign_secrets_user_role(
     )
     # Deterministic assignment name per (scope, principal) → safe to retry.
     ra_name = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{vault_id}|{principal}|KeyVaultSecretsUser"))
-    params = RoleAssignmentCreateParameters(  # type: ignore[call-arg]  # SDK multi-api stub mismatch
+    params = RoleAssignmentCreateParameters(
         role_definition_id=role_def_id,
         principal_id=principal,
         principal_type="ServicePrincipal",

--- a/engine/secrets/auto_mirror.py
+++ b/engine/secrets/auto_mirror.py
@@ -366,12 +366,8 @@ def _azure_grant(secret_name: str, principal: str, options: dict[str, Any]) -> N
     access policy. Idempotent and non-fatal — a failure never aborts the deploy.
     """
     vault_url = options.get("vault_url") or os.environ.get("AZURE_KEYVAULT_URL", "")
-    subscription_id = options.get("subscription_id") or os.environ.get(
-        "AZURE_SUBSCRIPTION_ID", ""
-    )
-    resource_group = options.get("resource_group") or os.environ.get(
-        "AZURE_RESOURCE_GROUP", ""
-    )
+    subscription_id = options.get("subscription_id") or os.environ.get("AZURE_SUBSCRIPTION_ID", "")
+    resource_group = options.get("resource_group") or os.environ.get("AZURE_RESOURCE_GROUP", "")
     if not (vault_url and subscription_id and resource_group and principal):
         logger.warning(
             "azure grant: missing vault_url/subscription_id/resource_group/principal — "
@@ -452,9 +448,7 @@ def _azure_assign_secrets_user_role(
         f"{_KEY_VAULT_SECRETS_USER_ROLE_DEF_ID}"
     )
     # Deterministic assignment name per (scope, principal) → safe to retry.
-    ra_name = str(
-        uuid.uuid5(uuid.NAMESPACE_URL, f"{vault_id}|{principal}|KeyVaultSecretsUser")
-    )
+    ra_name = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{vault_id}|{principal}|KeyVaultSecretsUser"))
     params = RoleAssignmentCreateParameters(  # type: ignore[call-arg]  # SDK multi-api stub mismatch
         role_definition_id=role_def_id,
         principal_id=principal,

--- a/engine/secrets/azure_backend.py
+++ b/engine/secrets/azure_backend.py
@@ -1,0 +1,137 @@
+"""Azure Key Vault secrets backend.
+
+Requires: pip install azure-keyvault-secrets azure-identity
+Optional env vars:
+    AZURE_KEYVAULT_URL — URL of the Azure Key Vault (e.g. https://myvault.vault.azure.net/)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC
+from typing import Any
+
+from engine.secrets.base import SecretEntry, SecretsBackend
+
+logger = logging.getLogger(__name__)
+
+_AZURE_IMPORT_ERROR = (
+    "Azure Key Vault backend requires azure-keyvault-secrets and azure-identity. "
+    "Install it with: pip install azure-keyvault-secrets azure-identity"
+)
+
+
+def sanitize_secret_name(name: str) -> str:
+    """Convert a logical name to an Azure Key Vault-legal secret name.
+
+    Key Vault secret names allow only alphanumerics and dashes (max 127 chars).
+    Underscores and slashes become dashes; any other character is dropped. The
+    transform is idempotent — applying it to an already-legal name is a no-op —
+    so the mirror's write name and the deployer's reference name always agree.
+    """
+    dashed = name.replace("_", "-").replace("/", "-")
+    chars = [c for c in dashed if c.isalnum() or c == "-"]
+    return "".join(chars)[:127]
+
+
+def _client(vault_url: str) -> Any:
+    """Create an Azure Key Vault SecretClient."""
+    try:
+        from azure.identity import DefaultAzureCredential
+        from azure.keyvault.secrets import SecretClient
+
+        return SecretClient(vault_url=vault_url, credential=DefaultAzureCredential())
+    except ImportError as exc:
+        raise ImportError(_AZURE_IMPORT_ERROR) from exc
+
+
+class AzureKeyVaultBackend(SecretsBackend):
+    """Secrets stored in Azure Key Vault.
+
+    Azure Key Vault secret names can only contain alphanumeric characters and hyphens.
+    Logical names with underscores or slashes (e.g., "agentbreeder/my-agent/MY_SECRET")
+    are converted to dashes.
+    """
+
+    def __init__(
+        self,
+        vault_url: str | None = None,
+        prefix: str = "agentbreeder-",
+    ) -> None:
+        self._vault_url = vault_url or os.environ.get("AZURE_KEYVAULT_URL", "")
+        if not self._vault_url:
+            raise ValueError(
+                "Azure Key Vault URL is required. Pass vault_url= or set AZURE_KEYVAULT_URL."
+            )
+        self._prefix = prefix
+
+    @property
+    def backend_name(self) -> str:
+        return "azure"
+
+    def _secret_id(self, name: str) -> str:
+        """Convert logical name to Azure-compatible secret name (alphanumeric and dashes)."""
+        return sanitize_secret_name(f"{self._prefix}{name}" if self._prefix else name)
+
+    async def get(self, name: str) -> str | None:
+        client = _client(self._vault_url)
+        try:
+            secret = client.get_secret(self._secret_id(name))
+            value: str | None = secret.value
+            return value
+        except Exception as exc:
+            # Handle ResourceNotFoundError
+            if "ResourceNotFoundError" in type(exc).__name__ or "not found" in str(exc).lower():
+                return None
+            logger.error("Failed to get secret '%s' from Azure Key Vault: %s", name, exc)
+            raise
+
+    async def set(self, name: str, value: str, *, tags: dict[str, str] | None = None) -> None:
+        client = _client(self._vault_url)
+        secret_id = self._secret_id(name)
+        azure_tags = {k.lower(): v.lower() for k, v in (tags or {}).items()}
+
+        try:
+            client.set_secret(secret_id, value, tags=azure_tags)
+            logger.info("Created or updated secret '%s' in Azure Key Vault", secret_id)
+        except Exception as exc:
+            logger.error("Failed to set secret '%s' in Azure Key Vault: %s", secret_id, exc)
+            raise
+
+    async def delete(self, name: str) -> None:
+        client = _client(self._vault_url)
+        secret_id = self._secret_id(name)
+        try:
+            client.begin_delete_secret(secret_id)
+            logger.info("Scheduled deletion of secret '%s' from Azure Key Vault", secret_id)
+        except Exception as exc:
+            if "ResourceNotFoundError" in type(exc).__name__ or "not found" in str(exc).lower():
+                raise KeyError(f"Secret '{name}' not found in Azure Key Vault") from exc
+            raise
+
+    async def list(self) -> list[SecretEntry]:
+        client = _client(self._vault_url)
+        entries: list[SecretEntry] = []
+        try:
+            for secret_properties in client.list_properties_of_secrets():
+                raw_name = secret_properties.name
+                if self._prefix and not raw_name.startswith(self._prefix):
+                    continue
+                logical = raw_name.removeprefix(self._prefix) if self._prefix else raw_name
+                created = secret_properties.created_on
+                updated = secret_properties.updated_on
+                entries.append(
+                    SecretEntry(
+                        name=logical,
+                        masked_value="••••(azure)",
+                        backend="azure",
+                        created_at=created.astimezone(UTC) if created else None,
+                        updated_at=updated.astimezone(UTC) if updated else None,
+                        tags=dict(secret_properties.tags or {}),
+                    )
+                )
+        except Exception as exc:
+            logger.error("Failed to list secrets from Azure Key Vault: %s", exc)
+            raise
+        return entries

--- a/engine/secrets/factory.py
+++ b/engine/secrets/factory.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 # Pattern for secret references in agent.yaml values: secret://KEY_NAME
 _SECRET_REF_RE = re.compile(r"^secret://(.+)$")
 
-SUPPORTED_BACKENDS = ("env", "keychain", "aws", "gcp", "vault")
+SUPPORTED_BACKENDS = ("env", "keychain", "aws", "gcp", "azure", "vault")
 
 
 def get_backend(backend: str | None = None, **kwargs: object) -> SecretsBackend:
@@ -73,6 +73,10 @@ def _instantiate(backend: str, kwargs: dict[str, Any]) -> SecretsBackend:
         from engine.secrets.gcp_backend import GCPSecretManagerBackend
 
         return GCPSecretManagerBackend(**kwargs)
+    if name in ("azure", "azure_key_vault"):
+        from engine.secrets.azure_backend import AzureKeyVaultBackend
+
+        return AzureKeyVaultBackend(**kwargs)
     if name in ("vault", "hashicorp_vault"):
         from engine.secrets.vault_backend import VaultBackend
 

--- a/engine/sidecar/config.py
+++ b/engine/sidecar/config.py
@@ -11,8 +11,11 @@ from dataclasses import dataclass, field
 from typing import Any
 
 # Single source of truth for the sidecar image — kept as a constant so deployers
-# never accidentally diverge.
-DEFAULT_SIDECAR_IMAGE = "agentbreeder/agentbreeder-sidecar:latest"
+# never accidentally diverge. Pinned to a concrete version (never ":latest") so
+# a deploy is reproducible and a re-pulled image can't silently change the
+# guardrail/auth behaviour fronting an agent. Bump this in lockstep with the
+# release that publishes the matching agentbreeder-sidecar tag.
+DEFAULT_SIDECAR_IMAGE = "agentbreeder/agentbreeder-sidecar:2.5.1"
 
 # Valid port range for sidecar port-number fields.
 _MIN_PORT = 1

--- a/engine/sidecar/injector.py
+++ b/engine/sidecar/injector.py
@@ -65,6 +65,10 @@ def inject_sidecar(task_definition: dict[str, Any], config: SidecarConfig) -> di
         "name": SIDECAR_NAME,
         "image": config.image,
         "essential": False,
+        # #500: least-privilege hardening — non-root, read-only root fs, no caps.
+        "user": "65532",
+        "readonlyRootFilesystem": True,
+        "linuxParameters": {"capabilities": {"drop": ["ALL"]}},
         "portMappings": [{"containerPort": config.health_port, "protocol": "tcp"}],
         "environment": [
             {"name": "OTEL_EXPORTER_OTLP_ENDPOINT", "value": config.otel_endpoint},

--- a/tests/unit/test_deployers_aws.py
+++ b/tests/unit/test_deployers_aws.py
@@ -1171,6 +1171,82 @@ class TestRegisterTaskDefinition:
 
 
 # ---------------------------------------------------------------------------
+# #400: ECS multi-container sidecar wiring
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterTaskDefinitionSidecar:
+    """When guardrails/tools/A2A are declared, the task def must carry both the
+    agent (essential, internal :8081) and the sidecar (non-essential, ingress
+    :8080) so inbound traffic terminates at the sidecar before the agent."""
+
+    @pytest.mark.asyncio
+    async def test_task_def_has_agent_and_sidecar_containers(self) -> None:
+        deployer = _make_deployer()
+        config = _make_agent_config()
+        config.guardrails = ["pii_detection"]
+
+        from engine.deployers.aws_ecs import _extract_ecs_config
+
+        deployer._aws_config = _extract_ecs_config(config)
+
+        ecs_mock = MagicMock()
+        ecs_mock.register_task_definition.return_value = {
+            "taskDefinition": {
+                "taskDefinitionArn": "arn:aws:ecs:us-east-1:123:task-definition/my-agent:1"
+            }
+        }
+
+        with patch.object(deployer, "_get_boto3_client", return_value=ecs_mock):
+            await deployer._register_task_definition(
+                config, "123.dkr.ecr.us-east-1.amazonaws.com/my-agent:1.0.0"
+            )
+
+        defs = ecs_mock.register_task_definition.call_args.kwargs["containerDefinitions"]
+        by_name = {c["name"]: c for c in defs}
+        assert "agentbreeder-sidecar" in by_name
+        agent = by_name[config.name]
+        sidecar = by_name["agentbreeder-sidecar"]
+
+        # Agent: essential, listens on the internal port, not the ingress port.
+        assert agent["essential"] is True
+        assert agent["portMappings"][0]["containerPort"] == 8081
+        agent_env = {e["name"]: e["value"] for e in agent["environment"]}
+        assert agent_env["PORT"] == "8081"
+
+        # Sidecar: non-essential ingress on 8080, proxying to the agent on 8081.
+        assert sidecar["essential"] is False
+        assert sidecar["portMappings"][0]["containerPort"] == 8080
+        sidecar_env = {e["name"]: e["value"] for e in sidecar["environment"]}
+        assert sidecar_env["AGENTBREEDER_SIDECAR_AGENT_URL"] == "http://localhost:8081"
+
+    @pytest.mark.asyncio
+    async def test_task_def_single_container_without_governance(self) -> None:
+        deployer = _make_deployer()
+        config = _make_agent_config()  # no guardrails → no sidecar
+
+        from engine.deployers.aws_ecs import _extract_ecs_config
+
+        deployer._aws_config = _extract_ecs_config(config)
+
+        ecs_mock = MagicMock()
+        ecs_mock.register_task_definition.return_value = {
+            "taskDefinition": {
+                "taskDefinitionArn": "arn:aws:ecs:us-east-1:123:task-definition/my-agent:1"
+            }
+        }
+
+        with patch.object(deployer, "_get_boto3_client", return_value=ecs_mock):
+            await deployer._register_task_definition(
+                config, "123.dkr.ecr.us-east-1.amazonaws.com/my-agent:1.0.0"
+            )
+
+        defs = ecs_mock.register_task_definition.call_args.kwargs["containerDefinitions"]
+        assert [c["name"] for c in defs] == [config.name]
+        assert defs[0]["portMappings"][0]["containerPort"] == 8080
+
+
+# ---------------------------------------------------------------------------
 # teardown() — scale-to-zero exception is swallowed, delete failure raises
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_deployers_aws_app_runner.py
+++ b/tests/unit/test_deployers_aws_app_runner.py
@@ -292,6 +292,38 @@ class TestProvision:
 # ---------------------------------------------------------------------------
 
 
+class TestAppRunnerFailFast:
+    """#501: App Runner is a single-container runtime — it cannot run the
+    sidecar. Declaring governance that needs the sidecar (guardrails/tools/A2A)
+    or secret mirroring must fail fast with a clear redirect to ECS Fargate,
+    before any cloud API call."""
+
+    @pytest.mark.asyncio
+    async def test_deploy_rejects_guardrails(self) -> None:
+        deployer = _make_deployer()
+        config = _make_agent_config()
+        config.guardrails = ["pii_detection"]
+        with pytest.raises(ValueError, match="App Runner does not natively support"):
+            await deployer.deploy(config, None)
+
+    @pytest.mark.asyncio
+    async def test_deploy_rejects_secrets(self) -> None:
+        deployer = _make_deployer()
+        config = _make_agent_config()
+        config.deploy.secrets = ["OPENAI_API_KEY"]
+        with pytest.raises(ValueError, match="Secret mirroring .* is not supported"):
+            await deployer.deploy(config, None)
+
+    @pytest.mark.asyncio
+    async def test_deploy_allows_plain_agent(self) -> None:
+        # No guardrails/secrets → the fail-fast guards must not trip; deploy
+        # proceeds past them (and then hits the normal provision-first assertion).
+        deployer = _make_deployer()
+        config = _make_agent_config()
+        with pytest.raises(AssertionError, match="provision"):
+            await deployer.deploy(config, None)
+
+
 class TestDeploy:
     def _make_image(self) -> MagicMock:
         from pathlib import Path

--- a/tests/unit/test_deployers_azure.py
+++ b/tests/unit/test_deployers_azure.py
@@ -933,3 +933,111 @@ class TestBuildContainerAppBody:
         assert tags["managed-by"] == "agentbreeder"
         assert tags["agent-name"] == "my-agent"
         assert tags["team"] == "engineering"
+
+    def test_sidecar_injected_when_guardrails_active(self) -> None:
+        deployer = AzureContainerAppsDeployer()
+        config = _make_agent_config()
+        # Add guardrails to activate sidecar injection
+        config.guardrails = ["pii-filter"]
+
+        azure = _extract_azure_config(config)
+        managed_env_id = "/subscriptions/.../managedEnvironments/aca-env-prod"
+
+        body = deployer._build_container_app_body(
+            config, azure, "myregistry.azurecr.io/my-agent:1.0.0", managed_env_id
+        )
+
+        containers = body["properties"]["template"]["containers"]
+        assert len(containers) == 2
+        assert containers[0]["name"] == "my-agent"
+        assert containers[1]["name"] == "agentbreeder-sidecar"
+
+        # Ingress targetPort must be set to 8080 (the sidecar port)
+        assert body["properties"]["configuration"]["ingress"]["targetPort"] == 8080
+
+        # Agent container must have PORT=8081 env var
+        env_vars = {e["name"]: e["value"] for e in containers[0]["env"] if "value" in e}
+        assert env_vars["PORT"] == "8081"
+
+    def test_secrets_mirrored_and_mapped_as_keyvault_references(self) -> None:
+        deployer = AzureContainerAppsDeployer()
+        config = _make_agent_config()
+        azure = _extract_azure_config(config)
+        managed_env_id = "/subscriptions/.../managedEnvironments/aca-env-prod"
+
+        from engine.secrets.auto_mirror import CloudSecretRef
+        mirrored_refs = [
+            CloudSecretRef(
+                logical_name="OPENAI_API_KEY",
+                cloud_name="agentbreeder-my-agent-OPENAI-API-KEY",
+                cloud="azure",
+            )
+        ]
+
+        identity_id = (
+            "/subscriptions/sub/resourceGroups/rg/providers/"
+            "Microsoft.ManagedIdentity/userAssignedIdentities/agentbreeder-my-agent-id"
+        )
+
+        # Temporarily inject AZURE_KEYVAULT_URL into environment
+        import os
+
+        with patch.dict(os.environ, {"AZURE_KEYVAULT_URL": "https://myvault.vault.azure.net/"}):
+            body = deployer._build_container_app_body(
+                config,
+                azure,
+                "myregistry.azurecr.io/my-agent:1.0.0",
+                managed_env_id,
+                mirrored_refs=mirrored_refs,
+                identity_resource_id=identity_id,
+            )
+
+        secrets = body["properties"]["configuration"]["secrets"]
+        assert len(secrets) == 1
+        assert secrets[0]["name"] == "openai-api-key"
+        assert secrets[0]["keyVaultUrl"] == (
+            "https://myvault.vault.azure.net/secrets/agentbreeder-my-agent-OPENAI-API-KEY"
+        )
+        # The secret is read via the per-agent user-assigned identity, not "System".
+        assert secrets[0]["identity"] == identity_id
+
+        # The app binds that identity at the resource level.
+        assert body["identity"]["type"] == "UserAssigned"
+        assert identity_id in body["identity"]["userAssignedIdentities"]
+
+        # Environment variable should reference the secret
+        env_list = body["properties"]["template"]["containers"][0]["env"]
+        matching_env = [e for e in env_list if e.get("name") == "OPENAI_API_KEY"]
+        assert len(matching_env) == 1
+        assert matching_env[0]["secretRef"] == "openai-api-key"
+
+    def test_secrets_fall_back_to_system_identity_when_unprovisioned(self) -> None:
+        # If no user-assigned identity was provisioned, the secret ref degrades
+        # to the system-assigned identity and no identity block is emitted.
+        deployer = AzureContainerAppsDeployer()
+        config = _make_agent_config()
+        azure = _extract_azure_config(config)
+        managed_env_id = "/subscriptions/.../managedEnvironments/aca-env-prod"
+
+        from engine.secrets.auto_mirror import CloudSecretRef
+        mirrored_refs = [
+            CloudSecretRef(
+                logical_name="OPENAI_API_KEY",
+                cloud_name="agentbreeder-my-agent-OPENAI-API-KEY",
+                cloud="azure",
+            )
+        ]
+
+        import os
+
+        with patch.dict(os.environ, {"AZURE_KEYVAULT_URL": "https://myvault.vault.azure.net/"}):
+            body = deployer._build_container_app_body(
+                config,
+                azure,
+                "myregistry.azurecr.io/my-agent:1.0.0",
+                managed_env_id,
+                mirrored_refs=mirrored_refs,
+            )
+
+        assert body["properties"]["configuration"]["secrets"][0]["identity"] == "System"
+        assert "identity" not in body

--- a/tests/unit/test_deployers_azure.py
+++ b/tests/unit/test_deployers_azure.py
@@ -966,6 +966,7 @@ class TestBuildContainerAppBody:
         managed_env_id = "/subscriptions/.../managedEnvironments/aca-env-prod"
 
         from engine.secrets.auto_mirror import CloudSecretRef
+
         mirrored_refs = [
             CloudSecretRef(
                 logical_name="OPENAI_API_KEY",
@@ -1020,6 +1021,7 @@ class TestBuildContainerAppBody:
         managed_env_id = "/subscriptions/.../managedEnvironments/aca-env-prod"
 
         from engine.secrets.auto_mirror import CloudSecretRef
+
         mirrored_refs = [
             CloudSecretRef(
                 logical_name="OPENAI_API_KEY",

--- a/tests/unit/test_gcp_cloudrun_deployer.py
+++ b/tests/unit/test_gcp_cloudrun_deployer.py
@@ -365,6 +365,67 @@ class TestBuildServiceTemplate:
 
 
 # ---------------------------------------------------------------------------
+# Track J — sidecar ingress routing (#203)
+# ---------------------------------------------------------------------------
+
+
+class TestSidecarIngressRouting:
+    """When the sidecar is injected it must front external traffic: Cloud Run
+    routes inbound to the sidecar (:8080), which proxies to the agent (:8081).
+    The agent must never be the ingress container.
+    """
+
+    def _injected_template(self) -> dict:
+        config = _make_config(guardrails=["pii_detection"])
+        gcp = _extract_cloudrun_config(config)
+        return _build_service_template(config, gcp, "img:1.0.0")
+
+    def _agent_container(self, template: dict) -> dict:
+        return next(
+            c for c in template["containers"] if c.get("name") != "agentbreeder-sidecar"
+        )
+
+    def _sidecar_container(self, template: dict) -> dict:
+        return next(
+            c for c in template["containers"] if c.get("name") == "agentbreeder-sidecar"
+        )
+
+    def test_sidecar_is_the_ingress_container(self) -> None:
+        template = self._injected_template()
+        assert len(template["containers"]) == 2
+        sidecar = self._sidecar_container(template)
+        agent = self._agent_container(template)
+        # Exactly one container declares the ingress port — it must be the sidecar.
+        assert sidecar["ports"] == [{"container_port": 8080}]
+        assert "ports" not in agent
+
+    def test_agent_listens_on_8081_with_matching_probes(self) -> None:
+        template = self._injected_template()
+        agent = self._agent_container(template)
+        env = {e["name"]: e.get("value") for e in agent["env"] if "value" in e}
+        assert env["PORT"] == "8081"
+        assert agent["startup_probe"]["http_get"]["port"] == 8081
+        assert agent["liveness_probe"]["http_get"]["port"] == 8081
+
+    def test_sidecar_proxies_to_agent_internal_port(self) -> None:
+        template = self._injected_template()
+        sidecar = self._sidecar_container(template)
+        env = {e["name"]: e.get("value") for e in sidecar["env"]}
+        assert env["AGENTBREEDER_SIDECAR_AGENT_URL"] == "http://localhost:8081"
+        assert env["AGENTBREEDER_SIDECAR_INBOUND_ADDR"] == ":8080"
+
+    def test_no_sidecar_keeps_agent_as_ingress_on_8080(self) -> None:
+        config = _make_config()  # no guardrails → no sidecar
+        gcp = _extract_cloudrun_config(config)
+        template = _build_service_template(config, gcp, "img:1.0.0")
+        assert len(template["containers"]) == 1
+        agent = template["containers"][0]
+        assert agent["ports"] == [{"container_port": 8080}]
+        # Cloud Run injects PORT for the ingress container — we must not override it.
+        assert all(e["name"] != "PORT" for e in agent["env"])
+
+
+# ---------------------------------------------------------------------------
 # GCPCloudRunDeployer.provision
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_gcp_cloudrun_deployer.py
+++ b/tests/unit/test_gcp_cloudrun_deployer.py
@@ -381,14 +381,10 @@ class TestSidecarIngressRouting:
         return _build_service_template(config, gcp, "img:1.0.0")
 
     def _agent_container(self, template: dict) -> dict:
-        return next(
-            c for c in template["containers"] if c.get("name") != "agentbreeder-sidecar"
-        )
+        return next(c for c in template["containers"] if c.get("name") != "agentbreeder-sidecar")
 
     def _sidecar_container(self, template: dict) -> dict:
-        return next(
-            c for c in template["containers"] if c.get("name") == "agentbreeder-sidecar"
-        )
+        return next(c for c in template["containers"] if c.get("name") == "agentbreeder-sidecar")
 
     def test_sidecar_is_the_ingress_container(self) -> None:
         template = self._injected_template()

--- a/tests/unit/test_multicloud_parity.py
+++ b/tests/unit/test_multicloud_parity.py
@@ -59,9 +59,7 @@ def _gcp_spec() -> dict:
         _extract_cloudrun_config,
     )
 
-    config = _governed_config(
-        env_vars={"GCP_PROJECT_ID": "my-project-123"}, runtime="cloud-run"
-    )
+    config = _governed_config(env_vars={"GCP_PROJECT_ID": "my-project-123"}, runtime="cloud-run")
     gcp = _extract_cloudrun_config(config)
     template = _build_service_template(config, gcp, "img:1.0.0")
     containers = template["containers"]

--- a/tests/unit/test_multicloud_parity.py
+++ b/tests/unit/test_multicloud_parity.py
@@ -1,0 +1,170 @@
+"""Cross-cloud parity matrix (#198, epic #505).
+
+One governed agent (guardrails declared) deployed to AWS ECS Fargate, GCP Cloud
+Run, and Azure Container Apps must produce the *same* governance topology: the
+AgentBreeder sidecar is the ingress container on :8080 and the agent listens on
+an internal :8081, with the sidecar reverse-proxying to it. This is the single
+source of truth that inbound guardrails / bearer-token enforcement fire
+identically on all three targets — if a deployer regresses to routing external
+traffic straight at the agent, the matrix breaks here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from engine.config_parser import (
+    AccessConfig,
+    AgentConfig,
+    CloudType,
+    DeployConfig,
+    FrameworkType,
+    ModelConfig,
+    ResourceConfig,
+    ScalingConfig,
+)
+
+SIDECAR = "agentbreeder-sidecar"
+
+
+def _governed_config(*, env_vars: dict[str, str], runtime: str) -> AgentConfig:
+    """A minimal agent that declares guardrails (→ sidecar required)."""
+    config = AgentConfig(
+        name="my-agent",
+        version="1.0.0",
+        team="engineering",
+        owner="dev@example.com",
+        framework=FrameworkType.langgraph,
+        model=ModelConfig(primary="claude-sonnet-4"),
+        deploy=DeployConfig(
+            cloud=CloudType.aws,
+            runtime=runtime,
+            region="us-east-1",
+            env_vars=env_vars,
+            resources=ResourceConfig(cpu="1", memory="1Gi"),
+            scaling=ScalingConfig(min=1, max=3),
+        ),
+        access=AccessConfig(),
+    )
+    config.guardrails = ["pii_detection"]
+    return config
+
+
+def _gcp_spec() -> dict:
+    from engine.deployers.gcp_cloudrun import (
+        _build_service_template,
+        _extract_cloudrun_config,
+    )
+
+    config = _governed_config(
+        env_vars={"GCP_PROJECT_ID": "my-project-123"}, runtime="cloud-run"
+    )
+    gcp = _extract_cloudrun_config(config)
+    template = _build_service_template(config, gcp, "img:1.0.0")
+    containers = template["containers"]
+    sidecar = next(c for c in containers if c.get("name") == SIDECAR)
+    agent = next(c for c in containers if c.get("name") != SIDECAR)
+    sc_env = {e["name"]: e.get("value") for e in sidecar["env"]}
+    agent_env = {e["name"]: e.get("value") for e in agent["env"] if "value" in e}
+    return {
+        "num_containers": len(containers),
+        "sidecar_ingress_port": sidecar["ports"][0]["container_port"],
+        "agent_internal_port": int(agent_env["PORT"]),
+        "agent_declares_ingress": "ports" in agent,
+        "sidecar_agent_url": sc_env["AGENTBREEDER_SIDECAR_AGENT_URL"],
+    }
+
+
+def _ecs_spec() -> dict:
+    from engine.deployers.aws_ecs import AWSECSDeployer, _extract_ecs_config
+
+    config = _governed_config(
+        env_vars={
+            "AWS_ACCOUNT_ID": "123456789012",
+            "AWS_REGION": "us-east-1",
+            "AWS_ECS_CLUSTER": "agentbreeder-cluster",
+            "AWS_EXECUTION_ROLE_ARN": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole",
+            "AWS_VPC_SUBNETS": "subnet-aaa,subnet-bbb",
+            "AWS_SECURITY_GROUPS": "sg-111",
+        },
+        runtime="ecs-fargate",
+    )
+    deployer = AWSECSDeployer()
+    deployer._aws_config = _extract_ecs_config(config)
+    ecs_mock = MagicMock()
+    ecs_mock.register_task_definition.return_value = {
+        "taskDefinition": {"taskDefinitionArn": "arn:aws:ecs:us-east-1:123:task-definition/x:1"}
+    }
+    with patch.object(deployer, "_get_boto3_client", return_value=ecs_mock):
+        asyncio.run(deployer._register_task_definition(config, "img:1.0.0"))
+    defs = ecs_mock.register_task_definition.call_args.kwargs["containerDefinitions"]
+    by_name = {c["name"]: c for c in defs}
+    sidecar = by_name[SIDECAR]
+    agent = by_name[config.name]
+    sc_env = {e["name"]: e["value"] for e in sidecar["environment"]}
+    return {
+        "num_containers": len(defs),
+        "sidecar_ingress_port": sidecar["portMappings"][0]["containerPort"],
+        "agent_internal_port": agent["portMappings"][0]["containerPort"],
+        # ECS has no ALB here (public-IP mode); the security group only exposes
+        # the sidecar's 8080. The agent's mapping is internal-only.
+        "agent_declares_ingress": False,
+        "sidecar_agent_url": sc_env["AGENTBREEDER_SIDECAR_AGENT_URL"],
+    }
+
+
+def _azure_spec() -> dict:
+    from engine.deployers.azure_container_apps import (
+        AzureContainerAppsDeployer,
+        _extract_azure_config,
+    )
+
+    config = _governed_config(
+        env_vars={
+            "AZURE_SUBSCRIPTION_ID": "sub-1234",
+            "AZURE_RESOURCE_GROUP": "rg-agents",
+            "AZURE_CONTAINER_APPS_ENV": "aca-env-prod",
+            "AZURE_REGISTRY_SERVER": "myregistry.azurecr.io",
+            "AZURE_LOCATION": "eastus",
+        },
+        runtime="container-apps",
+    )
+    azure = _extract_azure_config(config)
+    body = AzureContainerAppsDeployer()._build_container_app_body(
+        config, azure, "img:1.0.0", "env-id"
+    )
+    containers = body["properties"]["template"]["containers"]
+    sidecar = next(c for c in containers if c.get("name") == SIDECAR)
+    agent = next(c for c in containers if c.get("name") != SIDECAR)
+    agent_env = {e["name"]: e.get("value") for e in agent["env"] if "value" in e}
+    sc_env = {e["name"]: e.get("value") for e in sidecar["env"]}
+    return {
+        "num_containers": len(containers),
+        # Container Apps has one app-level ingress; it targets the sidecar port.
+        "sidecar_ingress_port": body["properties"]["configuration"]["ingress"]["targetPort"],
+        "agent_internal_port": int(agent_env["PORT"]),
+        "agent_declares_ingress": False,
+        "sidecar_agent_url": sc_env["AGENTBREEDER_SIDECAR_AGENT_URL"],
+    }
+
+
+@pytest.mark.parametrize(
+    "spec_fn",
+    [_gcp_spec, _ecs_spec, _azure_spec],
+    ids=["gcp_cloud_run", "aws_ecs_fargate", "azure_container_apps"],
+)
+def test_inbound_routes_through_sidecar_on_every_cloud(spec_fn) -> None:
+    spec = spec_fn()
+
+    # Agent + sidecar are both present.
+    assert spec["num_containers"] == 2
+    # External traffic terminates at the sidecar on 8080 …
+    assert spec["sidecar_ingress_port"] == 8080
+    # … the agent only listens on the internal port …
+    assert spec["agent_internal_port"] == 8081
+    assert spec["agent_declares_ingress"] is False
+    # … and the sidecar forwards to that internal port.
+    assert spec["sidecar_agent_url"] == "http://localhost:8081"

--- a/tests/unit/test_secrets_azure.py
+++ b/tests/unit/test_secrets_azure.py
@@ -1,0 +1,139 @@
+"""Tests for Azure Key Vault secrets backend using mocks."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def _make_azure_exception(name: str) -> type:
+    return type(name, (Exception,), {})
+
+
+def _make_azure_client(secrets: dict[str, str] | None = None) -> MagicMock:
+    secrets = secrets or {}
+    NotFound = _make_azure_exception("ResourceNotFoundError")
+    client = MagicMock()
+
+    class FakeSecret:
+        def __init__(self, name, value, tags=None):
+            self.name = name
+            self.value = value
+            self.properties = MagicMock()
+            self.properties.name = name
+            self.properties.created_on = datetime(2026, 1, 1, tzinfo=UTC)
+            self.properties.updated_on = datetime(2026, 3, 1, tzinfo=UTC)
+            self.properties.tags = tags or {}
+
+    def get_secret(name):
+        if name not in secrets:
+            raise NotFound("Secret not found")
+        return FakeSecret(name, secrets[name])
+
+    def set_secret(name, value, tags=None):
+        secrets[name] = value
+        return FakeSecret(name, value, tags)
+
+    def begin_delete_secret(name):
+        if name not in secrets:
+            raise NotFound("Secret not found")
+        del secrets[name]
+        poller = MagicMock()
+        return poller
+
+    def list_properties_of_secrets():
+        props = []
+        for k in secrets:
+            secret = FakeSecret(k, secrets[k])
+            props.append(secret.properties)
+        return props
+
+    client.get_secret.side_effect = get_secret
+    client.set_secret.side_effect = set_secret
+    client.begin_delete_secret.side_effect = begin_delete_secret
+    client.list_properties_of_secrets.side_effect = list_properties_of_secrets
+    return client
+
+
+class TestAzureBackend:
+    @pytest.fixture
+    def backend_with_secrets(self):
+        from engine.secrets.azure_backend import AzureKeyVaultBackend
+
+        store = {"agentbreeder-OPENAI-API-KEY": "sk-abc"}
+        mock_client = _make_azure_client(store)
+        with patch("engine.secrets.azure_backend._client", return_value=mock_client):
+            backend = AzureKeyVaultBackend(
+                vault_url="https://myvault.vault.azure.net/", prefix="agentbreeder-"
+            )
+            yield backend, store
+
+    def test_backend_name(self):
+        from engine.secrets.azure_backend import AzureKeyVaultBackend
+
+        b = AzureKeyVaultBackend(vault_url="https://myvault.vault.azure.net/")
+        assert b.backend_name == "azure"
+
+    def test_secret_id_sanitization(self):
+        from engine.secrets.azure_backend import AzureKeyVaultBackend
+
+        b = AzureKeyVaultBackend(vault_url="https://v.vault.azure.net/", prefix="ab-")
+        assert b._secret_id("my_secret/key") == "ab-my-secret-key"
+
+    def test_get_existing(self, backend_with_secrets):
+        backend, _ = backend_with_secrets
+        result = run(backend.get("OPENAI_API_KEY"))
+        assert result == "sk-abc"
+
+    def test_get_missing_returns_none(self, backend_with_secrets):
+        backend, _ = backend_with_secrets
+        result = run(backend.get("MISSING"))
+        assert result is None
+
+    def test_set_new_secret(self, backend_with_secrets):
+        backend, store = backend_with_secrets
+        run(backend.set("NEW_KEY", "new-value"))
+        assert store["agentbreeder-NEW-KEY"] == "new-value"
+
+    def test_delete_existing(self, backend_with_secrets):
+        backend, store = backend_with_secrets
+        run(backend.delete("OPENAI_API_KEY"))
+        assert "agentbreeder-OPENAI-API-KEY" not in store
+
+    def test_delete_missing_raises(self, backend_with_secrets):
+        backend, _ = backend_with_secrets
+        with pytest.raises(KeyError, match="not found"):
+            run(backend.delete("NO-SUCH"))
+
+    def test_list_returns_entries(self, backend_with_secrets):
+        backend, _ = backend_with_secrets
+        entries = run(backend.list())
+        assert len(entries) == 1
+        assert entries[0].name == "OPENAI-API-KEY"
+        assert entries[0].backend == "azure"
+
+    def test_import_error_propagates(self, monkeypatch):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            # Block only the azure SDK packages — not our own
+            # engine.secrets.azure_backend module (whose path contains "azure").
+            if name.startswith("azure"):
+                raise ImportError("No azure-keyvault-secrets")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        from engine.secrets.azure_backend import AzureKeyVaultBackend
+
+        b = AzureKeyVaultBackend(vault_url="https://v.vault.azure.net/")
+        with pytest.raises(ImportError, match="azure-keyvault-secrets"):
+            run(b.get("KEY"))

--- a/tests/unit/test_secrets_mirror.py
+++ b/tests/unit/test_secrets_mirror.py
@@ -101,6 +101,27 @@ def test_deterministic_name_gcp_substitutes_slash():
     )
 
 
+def test_deterministic_name_azure_sanitizes_to_kv_legal():
+    # Azure Key Vault names allow only alphanumerics + dashes — no slashes or
+    # underscores. The name must equal what AzureKeyVaultBackend would store so
+    # the deployer's keyVaultUrl reference resolves.
+    assert (
+        deterministic_name("my-agent", "OPENAI_API_KEY", cloud="azure")
+        == "agentbreeder-my-agent-OPENAI-API-KEY"
+    )
+
+
+def test_deterministic_name_azure_matches_backend_stored_name():
+    # Round-trip guarantee: the mirror writes via AzureKeyVaultBackend with an
+    # empty prefix (see _build_target_backend), so the stored secret id must
+    # equal the deterministic_name output exactly.
+    from engine.secrets.azure_backend import AzureKeyVaultBackend
+
+    name = deterministic_name("orders", "DB_PASSWORD", cloud="azure")
+    backend = AzureKeyVaultBackend(vault_url="https://v.vault.azure.net/", prefix="")
+    assert backend._secret_id(name) == name
+
+
 # ─── mirror_secrets_to_cloud ────────────────────────────────────────────────
 
 
@@ -288,6 +309,29 @@ class TestGrantDispatcher:
         )
         assert called[0][0] == "gcp"
 
+    def test_dispatch_azure(self, monkeypatch):
+        from engine.secrets import auto_mirror
+
+        called: list[Any] = []
+
+        def fake_azure(secret_name, principal, options):
+            called.append(("azure", secret_name, principal))
+
+        monkeypatch.setattr(auto_mirror, "_azure_grant", fake_azure)
+        _run(
+            auto_mirror._grant_secret_accessor(
+                target_cloud="azure",
+                cloud_name="agentbreeder-a-K",
+                principal="00000000-0000-0000-0000-000000000001",
+                target_options={
+                    "vault_url": "https://v.vault.azure.net/",
+                    "subscription_id": "sub",
+                    "resource_group": "rg",
+                },
+            )
+        )
+        assert called[0][0] == "azure"
+
     def test_dispatch_vault_is_noop(self):
         from engine.secrets import auto_mirror
 
@@ -301,6 +345,87 @@ class TestGrantDispatcher:
             )
         )
         assert result is None
+
+
+# ─── _azure_grant ────────────────────────────────────────────────────────────
+
+
+class TestAzureGrant:
+    def test_vault_name_parsed_from_url(self):
+        from engine.secrets.auto_mirror import _vault_name_from_url
+
+        assert _vault_name_from_url("https://myvault.vault.azure.net/") == "myvault"
+        assert _vault_name_from_url("https://my-kv-123.vault.azure.net") == "my-kv-123"
+
+    def test_vault_name_none_when_unparseable(self):
+        from engine.secrets.auto_mirror import _vault_name_from_url
+
+        assert _vault_name_from_url("") is None
+
+    def test_grant_skipped_when_options_missing(self, monkeypatch):
+        # Missing subscription_id/resource_group → non-fatal no-op; the SDK
+        # application path must never be reached.
+        from engine.secrets import auto_mirror
+
+        applied: list[Any] = []
+        monkeypatch.setattr(
+            auto_mirror,
+            "_azure_apply_grant",
+            lambda **kw: applied.append(kw),
+        )
+        monkeypatch.delenv("AZURE_SUBSCRIPTION_ID", raising=False)
+        monkeypatch.delenv("AZURE_RESOURCE_GROUP", raising=False)
+
+        auto_mirror._azure_grant(
+            "agentbreeder-a-K",
+            "00000000-0000-0000-0000-000000000001",
+            {"vault_url": "https://v.vault.azure.net/"},
+        )
+        assert applied == []
+
+    def test_grant_skipped_when_principal_missing(self, monkeypatch):
+        from engine.secrets import auto_mirror
+
+        applied: list[Any] = []
+        monkeypatch.setattr(
+            auto_mirror,
+            "_azure_apply_grant",
+            lambda **kw: applied.append(kw),
+        )
+        auto_mirror._azure_grant(
+            "agentbreeder-a-K",
+            "",
+            {
+                "vault_url": "https://v.vault.azure.net/",
+                "subscription_id": "sub",
+                "resource_group": "rg",
+            },
+        )
+        assert applied == []
+
+    def test_grant_applies_when_fully_specified(self, monkeypatch):
+        from engine.secrets import auto_mirror
+
+        applied: list[dict[str, Any]] = []
+        monkeypatch.setattr(
+            auto_mirror,
+            "_azure_apply_grant",
+            lambda **kw: applied.append(kw),
+        )
+        auto_mirror._azure_grant(
+            "agentbreeder-a-K",
+            "00000000-0000-0000-0000-000000000001",
+            {
+                "vault_url": "https://myvault.vault.azure.net/",
+                "subscription_id": "sub-123",
+                "resource_group": "rg-prod",
+            },
+        )
+        assert len(applied) == 1
+        assert applied[0]["vault_name"] == "myvault"
+        assert applied[0]["subscription_id"] == "sub-123"
+        assert applied[0]["resource_group"] == "rg-prod"
+        assert applied[0]["principal"] == "00000000-0000-0000-0000-000000000001"
 
 
 # ─── _build_target_backend ──────────────────────────────────────────────────

--- a/tests/unit/test_sidecar_injector.py
+++ b/tests/unit/test_sidecar_injector.py
@@ -57,6 +57,25 @@ def test_inject_sidecar_does_not_mutate_input() -> None:
     assert len(task_def["containerDefinitions"]) == original_len
 
 
+def test_default_sidecar_image_is_pinned_not_latest() -> None:
+    # #500: the injected image must be a concrete version so deploys are
+    # reproducible and a re-pulled :latest can't silently change behaviour.
+    from engine.sidecar.config import DEFAULT_SIDECAR_IMAGE
+
+    assert not DEFAULT_SIDECAR_IMAGE.endswith(":latest")
+    assert ":" in DEFAULT_SIDECAR_IMAGE
+
+
+def test_inject_sidecar_has_security_context() -> None:
+    # #500: least-privilege hardening on the ECS sidecar container.
+    task_def: dict = {"containerDefinitions": []}
+    result = inject_sidecar(task_def, SidecarConfig(enabled=True))
+    sidecar = next(c for c in result["containerDefinitions"] if c["name"] == SIDECAR_NAME)
+    assert sidecar["user"] == "65532"
+    assert sidecar["readonlyRootFilesystem"] is True
+    assert sidecar["linuxParameters"]["capabilities"]["drop"] == ["ALL"]
+
+
 def test_inject_sidecar_sidecar_is_non_essential() -> None:
     """The sidecar should be non-essential so it can't kill the agent container."""
     task_def: dict = {"containerDefinitions": []}


### PR DESCRIPTION
## Summary

Closes the **P0 correctness gate** of epic #505 ("One agent. Three clouds. One command.") and lands the P1 parity hardening, so the same governed `agent.yaml` deploys to **AWS ECS Fargate · GCP Cloud Run · Azure Container Apps** with identical Track J (sidecar) + Track K (secret mirroring) behaviour.

### P0 — correctness / merge-blockers
- **#499 — Azure Track K now functional.** The mirrored Key Vault secret name (sanitized on write) never matched the name the deployer referenced, and `_azure_grant` was a no-op. Fixed via a shared `sanitize_secret_name` (write name == reference name, `agentbreeder-<agent>-<KEY>`) and a real, idempotent **Key Vault Secrets User** role assignment with RBAC-vs-access-policy detection. The Container App now runs as a per-agent **user-assigned managed identity** (`agentbreeder-<agent>-id`) whose principal id is known before the app exists — so the grant is applied up front, no create-time race.
- **#203 — GCP inbound now goes through the sidecar.** Cloud Run was routing external traffic straight at the agent (:8080) with the sidecar side-by-side on :9080 — bearer-token + guardrail egress bypassed. The sidecar is now the ingress container (:8080), the agent moves to internal :8081, and the sidecar reverse-proxies to it. Matches the sidecar binary's own env defaults, so no Go change needed.

### P1 — parity hardening
- **#400 (container-level)** — sidecar fronts :8080 / agent on :8081 across GCP, ECS, and Azure. `AB_COST_TRACKING` emitted on all three sidecars.
- **#501** — AWS App Runner fails fast (before any cloud call) when guardrails/tools/A2A or secrets are declared, redirecting to ECS Fargate (App Runner can't host the sidecar).
- **#500** — injected sidecar image pinned to a concrete version (no `:latest`); ECS sidecar hardened (non-root, read-only root fs, all caps dropped); Cloud Run sidecar runs as the distroless non-root uid.
- **#198** — a cross-cloud parity matrix test asserts one governed agent routes inbound through the sidecar on all three targets.

## Not in this PR (tracked follow-ups)
- **#400 — ECS ALB target-group registration.** The ECS deployer is public-IP mode today (security group exposes only :8080); registering the sidecar as an ALB target is a separate provisioner↔deployer plumbing change.
- **#502 / #503** — dashboard capability-aware cloud selector + website "Deploy Anywhere" status chips. Per the epic's ship order these are gated on this correctness work landing.

## Test plan
- [x] `ruff` + `mypy` clean on all changed files
- [x] New unit tests: Azure name round-trip + `_azure_grant` (RBAC/access-policy/guards), GCP sidecar-ingress routing, ECS multi-container wiring, App Runner fail-fast, sidecar hardening, and the cross-cloud parity matrix
- [x] 261 unit tests pass across the affected deployer/secrets/sidecar suites on the rebased base
- [ ] Integration smoke test of a real deploy to each cloud (out of scope for unit CI; requires cloud creds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
