### PR TITLE
chore(release): cut v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+## [2.6.0] — 2026-05-25
+
 ### Added
 - **Multi-cloud deploy parity (epic [#505](https://github.com/agentbreeder/agentbreeder/issues/505))** — the same `agent.yaml` now deploys to AWS ECS Fargate, GCP Cloud Run, and Azure Container Apps with identical Track J (sidecar: guardrails/cost/tracing) and Track K (secret mirroring) governance.
 - **Azure Key Vault auto-mirror ([#425](https://github.com/agentbreeder/agentbreeder/issues/425), [#197](https://github.com/agentbreeder/agentbreeder/issues/197))** — secrets declared in `agent.yaml` are mirrored to Key Vault at deploy with an idempotent "Key Vault Secrets User" RBAC grant (falls back to an access policy when the vault is in access-policy mode). The deploy uses a per-agent **user-assigned managed identity** so the principal is known before the app exists (no create-time grant race).

--- a/website/components/footer.tsx
+++ b/website/components/footer.tsx
@@ -86,7 +86,7 @@ export function Footer() {
               color: 'var(--accent)',
             }}
           >
-            v2.5.1
+            v2.6.0
           </span>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Release prep for **v2.6.0** (minor bump from v2.5.1).

- Version the `[Unreleased]` CHANGELOG section as `## [2.6.0] — 2026-05-25` so `release.yml` extracts clean GitHub Release notes.
- Bump the website footer version badge to `v2.6.0` (cross-repo sync).

v2.6.0 captures the multi-cloud deploy parity epic (#505), the studio UX simplification (#519), the `/builders/recommend` + `/builders/chat` endpoints, Anthropic prompt caching, and the env/namespace/compose fixes already listed under the changelog section.

The release is **tag-driven**: after this merges, pushing tag `v2.6.0` triggers `release.yml` to publish to PyPI (`agentbreeder` + `agentbreeder-sdk`), npm (`@agentbreeder/sdk`), Docker Hub (`rajits/*`), GHCR, Homebrew, and create the GitHub Release.

## Test plan

- [x] CHANGELOG `## [2.6.0]` heading present (release-notes extraction)
- [x] Docs-only change; `release.yml` pre-release-check (lint + unit tests) runs on the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
