### PR TITLE
feat(website): store Cloud waitlist in Vercel KV

### DIFF
--- a/website/app/api/waitlist/route.ts
+++ b/website/app/api/waitlist/route.ts
@@ -1,53 +1,64 @@
 import { NextResponse } from 'next/server';
+import { Redis } from '@upstash/redis';
 
-// Waitlist signups are emailed to the team via Resend (https://resend.com).
-// Required env: RESEND_API_KEY. Optional: RESEND_FROM (must be a verified
-// Resend sender; the agentbreeder.io domain has to be verified in Resend).
-const RESEND_ENDPOINT = 'https://api.resend.com/emails';
-const TO = 'hello@agentbreeder.io';
-const FROM = process.env.RESEND_FROM || 'AgentBreeder Waitlist <waitlist@agentbreeder.io>';
+// Waitlist signups are stored in Vercel KV / Upstash Redis as a sorted set
+// `waitlist` (member = email, score = signup timestamp → deduped + ordered).
+// Required env (auto-injected by the Vercel "Upstash for Redis" integration):
+//   KV_REST_API_URL + KV_REST_API_TOKEN  (UPSTASH_REDIS_REST_* also accepted).
+const WAITLIST_KEY = 'waitlist';
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const RATE_LIMIT = 5; // max signups...
+const RATE_WINDOW_S = 60; // ...per IP per minute
+
+function getRedis(): Redis | null {
+  const url = process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  return new Redis({ url, token });
+}
 
 export async function POST(request: Request) {
-  let email: unknown;
+  const redis = getRedis();
+  if (!redis) {
+    console.error('Vercel KV / Upstash env not set — cannot store waitlist signup.');
+    return NextResponse.json({ error: 'The waitlist is temporarily unavailable.' }, { status: 503 });
+  }
+
+  // Per-IP rate limit via INCR + EXPIRE (no extra dependency).
+  const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
   try {
-    ({ email } = await request.json());
+    const rlKey = `rl:waitlist:${ip}`;
+    const count = await redis.incr(rlKey);
+    if (count === 1) await redis.expire(rlKey, RATE_WINDOW_S);
+    if (count > RATE_LIMIT) {
+      return NextResponse.json({ error: 'Too many attempts. Please try again in a minute.' }, { status: 429 });
+    }
+  } catch (err) {
+    console.error('Waitlist rate-limit check failed', err);
+    return NextResponse.json({ error: 'Could not join the waitlist. Please try again.' }, { status: 502 });
+  }
+
+  let body: { email?: unknown; company?: unknown };
+  try {
+    body = await request.json();
   } catch {
     return NextResponse.json({ error: 'Invalid request body.' }, { status: 400 });
   }
 
-  if (typeof email !== 'string' || email.length > 254 || !EMAIL_RE.test(email)) {
+  // Honeypot: real users never see/fill `company`; bots do. Accept silently, store nothing.
+  if (typeof body.company === 'string' && body.company.trim() !== '') {
+    return NextResponse.json({ ok: true });
+  }
+
+  const email = typeof body.email === 'string' ? body.email.trim().toLowerCase() : '';
+  if (!email || email.length > 254 || !EMAIL_RE.test(email)) {
     return NextResponse.json({ error: 'Please enter a valid email address.' }, { status: 400 });
   }
 
-  const apiKey = process.env.RESEND_API_KEY;
-  if (!apiKey) {
-    console.error('RESEND_API_KEY is not set — cannot send waitlist email.');
-    return NextResponse.json({ error: 'The waitlist is temporarily unavailable.' }, { status: 503 });
-  }
-
   try {
-    const res = await fetch(RESEND_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        from: FROM,
-        to: [TO],
-        reply_to: email,
-        subject: 'New AgentBreeder Cloud waitlist signup',
-        text: `New waitlist signup for AgentBreeder Cloud:\n\n${email}\n\nReply to this email to reach them directly.`,
-      }),
-    });
-
-    if (!res.ok) {
-      console.error('Resend send failed', res.status, await res.text().catch(() => ''));
-      return NextResponse.json({ error: 'Could not join the waitlist. Please try again.' }, { status: 502 });
-    }
+    await redis.zadd(WAITLIST_KEY, { score: Date.now(), member: email });
   } catch (err) {
-    console.error('Resend request threw', err);
+    console.error('Failed to store waitlist signup', err);
     return NextResponse.json({ error: 'Could not join the waitlist. Please try again.' }, { status: 502 });
   }
 

--- a/website/app/privacy/page.tsx
+++ b/website/app/privacy/page.tsx
@@ -61,6 +61,13 @@ export default function PrivacyPage() {
               message and your email address to reply and to keep a record of the
               conversation.
             </li>
+            <li>
+              <strong>Waitlist signups</strong> — if you join the AgentBreeder Cloud
+              waitlist, we store the email address you submit so we can notify you when
+              access opens. We use it for that purpose only. Email{' '}
+              <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a> any time to be
+              removed.
+            </li>
           </ul>
           <p>The marketing site does <strong>not</strong> use third-party analytics, advertising trackers, or marketing cookies.</p>
         </Section>

--- a/website/components/cloud-coming.tsx
+++ b/website/components/cloud-coming.tsx
@@ -8,16 +8,17 @@ export function WaitlistForm() {
   const [error, setError] = useState('');
   const loading = status === 'loading';
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     if (!email || loading) return;
+    const company = (e.currentTarget.elements.namedItem('company') as HTMLInputElement | null)?.value ?? '';
     setStatus('loading');
     setError('');
     try {
       const res = await fetch('/api/waitlist', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({ email, company }),
       });
       if (!res.ok) {
         const data = (await res.json().catch(() => ({}))) as { error?: string };
@@ -43,6 +44,8 @@ export function WaitlistForm() {
         </div>
       ) : (
         <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row items-stretch sm:items-center gap-3">
+          {/* Honeypot — hidden from users; bots that fill it are silently dropped. */}
+          <input type="text" name="company" tabIndex={-1} autoComplete="off" aria-hidden="true" className="hidden" />
           <input
             type="email"
             required

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,6 +8,7 @@
       "name": "website",
       "version": "0.1.0",
       "dependencies": {
+        "@upstash/redis": "^1.38.0",
         "fumadocs-core": "^16.7.14",
         "fumadocs-mdx": "^14.2.13",
         "fumadocs-ui": "^16.7.14",
@@ -3662,6 +3663,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
+      "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -10333,6 +10343,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/website/package.json
+++ b/website/package.json
@@ -6,9 +6,11 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "waitlist:export": "node --env-file=.env.local scripts/export-waitlist.mjs"
   },
   "dependencies": {
+    "@upstash/redis": "^1.38.0",
     "fumadocs-core": "^16.7.14",
     "fumadocs-mdx": "^14.2.13",
     "fumadocs-ui": "^16.7.14",

--- a/website/scripts/export-waitlist.mjs
+++ b/website/scripts/export-waitlist.mjs
@@ -1,0 +1,32 @@
+// Export the Cloud waitlist from Vercel KV / Upstash Redis to CSV (stdout).
+//
+// Usage:
+//   vercel env pull .env.local          # one-time: pull KV creds locally
+//   npm run waitlist:export             # prints email,signed_up_at CSV
+//   npm run waitlist:export > waitlist.csv
+//
+// You can also read it without this script: Vercel → Storage → your KV →
+// Data Browser → `ZRANGE waitlist 0 -1 REV WITHSCORES`.
+import { Redis } from '@upstash/redis';
+
+const url = process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL;
+const token = process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN;
+
+if (!url || !token) {
+  console.error(
+    'Missing KV credentials. Run `vercel env pull .env.local` (or copy KV_REST_API_URL ' +
+      'and KV_REST_API_TOKEN from Vercel → Storage → your KV) and retry.',
+  );
+  process.exit(1);
+}
+
+const redis = new Redis({ url, token });
+const rows = await redis.zrange('waitlist', 0, -1, { withScores: true });
+
+process.stdout.write('email,signed_up_at\n');
+for (let i = 0; i < rows.length; i += 2) {
+  const email = String(rows[i]);
+  const signedUpAt = new Date(Number(rows[i + 1])).toISOString();
+  process.stdout.write(`${email},${signedUpAt}\n`);
+}
+process.stderr.write(`\n${rows.length / 2} signup(s).\n`);


### PR DESCRIPTION
## Summary
- Replace the Resend email relay with a **Vercel KV / Upstash Redis** store for Cloud waitlist signups, so emails are deduped, time-ordered, and persisted for export instead of landing in an inbox.
- Add bot protection: a per-IP **rate limit** (5/min via `INCR`+`EXPIRE`) and a hidden **honeypot** field (`company`) that silently drops bots — no captcha.
- Add a `waitlist:export` script and a privacy-policy note covering stored signup emails.

## Changes
- `website/app/api/waitlist/route.ts` — sorted set `waitlist` (member = lowercased email, score = `Date.now()`); 503 when KV env missing, 429 on rate limit, 502 on store failure.
- `website/components/cloud-coming.tsx` — form posts `{ email, company }`; honeypot field is `aria-hidden` + `tabIndex={-1}`.
- `website/app/privacy/page.tsx` — note that waitlist emails are stored and how to be removed.
- `website/scripts/export-waitlist.mjs` (new) — `ZRANGE waitlist 0 -1 WITHSCORES` → `email,signed_up_at` CSV.
- `website/package.json` / lock — add `@upstash/redis`, `waitlist:export` script.

## Operational note
Requires `KV_REST_API_URL` + `KV_REST_API_TOKEN` in the Vercel env (auto-injected by the "Upstash for Redis" integration). Without them the route returns 503. The old `RESEND_API_KEY` path is fully removed.

## Test plan
- [ ] `npm run build` in `website/` passes (Next.js + tsc) — verified locally.
- [ ] With KV env set: submit the form, confirm email appears via `npm run waitlist:export`.
- [ ] Submit twice with same email → single entry (dedup).
- [ ] >5 submits/min from one IP → 429.
- [ ] Fill hidden `company` field → 200 `{ ok: true }`, nothing stored.
- [ ] Unset KV env → 503 with friendly message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)