### PR TITLE
feat: cloud-agnostic deployment P2 — RAG retrieval from a managed pgvector store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 - `agent.yaml`: `knowledge_bases[].backend_url`, `memory.backend`, `memory.backend_url` for pointing
   agents at explicit, cloud-reachable RAG/memory backends. `knowledge_bases[].backend_url` is exposed
   to the agent as `KB_PGVECTOR_DSN`.
+- Cloud RAG retrieval (P2): a deployed agent now embeds the user query and retrieves from its
+  managed **pgvector** store at invoke time via `KB_PGVECTOR_DSN` (the in-container in-memory index is
+  empty in the cloud). The resolver also pins `KB_EMBEDDING_MODEL` so queries are embedded with the
+  same model used at ingest. GCP Cloud SQL now records its private IP, and Azure Flexible Server
+  allow-lists the `vector` extension (`azure.extensions`), so a provisioned Postgres can serve pgvector.
 
 ### Changed
 - Deploy no longer forwards the deploy host's local `REDIS_URL`/`DATABASE_URL`/`NEO4J_URL` to cloud

--- a/docs/superpowers/plans/2026-05-30-p2-rag-managed-backends.md
+++ b/docs/superpowers/plans/2026-05-30-p2-rag-managed-backends.md
@@ -1,0 +1,37 @@
+# P2 — RAG managed backends (pgvector on RDS / Cloud SQL / Azure PG)
+
+> Phase 2 of the cloud-agnostic deployment epic (#523). Branch `feat/cloud-agnostic-p2-rag-backends` off the merged P1 (#522). Each increment is a commit; PR opens when the whole phase is green.
+
+## Goal
+A deployed agent that declares `knowledge_bases` retrieves KB context **at runtime from a provisioned pgvector store** — on AWS, GCP, or Azure — with the connection string injected by the deployer, never scraped from the deploy host. `agentbreeder teardown` removes the provisioned DB.
+
+## What already exists (verified 2026-05-30)
+- **App-side pgvector backend** — `api/services/pgvector_rag_backend.py` (`connect`, `_ensure_table` per-dimension, `upsert_chunks`, `search` via `<=>` cosine). Factory `create_pgvector_backend()`; registry `registry/rag.py` `get_rag_backend("pgvector", ...)`.
+- **RAGStore dispatch (#423)** — `api/services/rag_service.py`: ingest mirrors to `backend.upsert_chunks()`; `search()` routes to `backend.search()` when a backend is configured.
+- **Managed Postgres provisioning, all 3 clouds** — `engine/provisioners/{aws._provision_rds, gcp._ensure_cloud_sql, azure._ensure_postgres_flexible}`. Each returns endpoint/host + db + secret in `InfraState.resources["rds"|"cloud_sql"|"postgres"]`.
+- **Backend-URL contract (P1)** — `engine/resolver.py:~284` sets `KB_PGVECTOR_DSN` from explicit `knowledge_bases[].backend_url`; localhost-on-cloud warning; scraping gated behind `AGENTBREEDER_ALLOW_LOCAL_BACKENDS`.
+- **Integration test** — `tests/integration/test_pgvector_testcontainers.py` (real pg+pgvector round-trip).
+
+## The 5 gaps P2 closes
+1. **Runtime never queries pgvector.** `engine/runtimes/templates/langgraph_server.py:_inject_kb_context` calls the in-memory `get_rag_store()`, which is empty in the deployed container. Must, when `KB_PGVECTOR_DSN` is set, embed the query and search the pgvector backend directly by index namespace.
+2. **Provisioned Postgres → `KB_PGVECTOR_DSN` is never wired.** Provisioner returns the endpoint in `InfraState.resources`, but nothing turns it into a DSN env var on the container. (Resolver only handles the *explicit* `backend_url` path.)
+3. **`vector` extension not allow-listed** on managed Postgres → `CREATE EXTENSION vector` fails. RDS needs a parameter group (`shared_preload_libraries`/`rds.allowed_extensions`); Cloud SQL needs `cloudsql.enable_pgvector` database flag; Azure needs the `azure.extensions` server parameter.
+4. **Provisioning is gated on memory flags, not RAG.** `AWS_HAS_MEMORY` / `GCP_PROVISION_CLOUD_SQL` / `AZURE_PROVISION_POSTGRES`. Declaring `knowledge_bases` (without `backend_url`) must request a pgvector DB.
+5. **Teardown coverage.** Orchestrator `destroy_partial()` calls `provisioner.destroy()`; ensure the RAG-provisioned DB is included and that CLI `agentbreeder teardown` reaches it.
+
+## Architecture (fixed by epic D3)
+New provisioning slots **inside `deployer.provision()`** (the sacred pipeline, `engine/builder.py` step 5) — NOT the separate wizard `InfraProvisioner` path. `deployer.provision()` will, when a managed pgvector is needed, provision the DB (reusing the per-cloud `_provision_*`/`_ensure_*` logic), build the DSN, and `config.deploy.env_vars.setdefault("KB_PGVECTOR_DSN", dsn)` so the existing P1 seam carries it to the container.
+
+## Increments (each a commit, TDD)
+1. **Runtime embed-on-query (gap 1).** New `KB_EMBEDDING_MODEL` env (resolver writes it from the KB index model). `_inject_kb_context`: when `KB_PGVECTOR_DSN` set → `embed_texts([query], model)` → cached pgvector backend `.search(vec, top_k)` → format. Unit test mocks the backend + embedder. *(start here — self-contained, no cloud)*
+2. **DSN builder (gap 2).** `engine/deployers/_pgvector_dsn.py`: `pgvector_dsn_from_resources(cloud, resources, password)` → `postgresql://…`. Pure, unit-tested per cloud shape.
+3. **Extension allow-listing (gap 3).** Per provisioner: RDS DB parameter group with `vector` allowed; Cloud SQL `database_flags`; Azure `azure.extensions`. Unit tests assert the SDK calls set the param.
+4. **Wire provision→DSN into `deployer.provision()` (gaps 2+4).** When `config.knowledge_bases` present and no explicit `backend_url`, request a pgvector DB, then set `KB_PGVECTOR_DSN`. Unit-test with mocked provisioner returning a resources dict.
+5. **Teardown (gap 5).** Ensure provisioned RAG DB is destroyed; cover CLI path. Test.
+6. **Docs + integration.** `website/content/docs/rag.mdx` (managed backends + per-cloud notes); extend testcontainers coverage; CHANGELOG.
+
+## P3 reuse note
+P3 (memory) reuses increments 2–5: the same per-cloud Postgres provisioning + DSN builder + teardown, plus Redis (ElastiCache/Memorystore/Azure Cache), wiring `MEMORY_BACKEND`/`REDIS_URL`/`MEMORY_DATABASE_URL`. `engine/runtimes/templates/memory_manager.py` already consumes those envs.
+
+## Cross-repo / governance
+Sacred pipeline order unchanged (D3). Cross-repo sync: re-grep `agentbreeder-cloud` for `KB_PGVECTOR_DSN` / provisioning before PR. Schema: no new `agent.yaml` field (uses P1's `backend_url`); if `KB_EMBEDDING_MODEL` becomes user-facing, document it.

--- a/engine/deployers/_pgvector_dsn.py
+++ b/engine/deployers/_pgvector_dsn.py
@@ -1,0 +1,87 @@
+"""Assemble a ``KB_PGVECTOR_DSN`` from a provisioned managed-Postgres resources dict.
+
+P2 of the cloud-agnostic deployment epic (#523). The infra provisioners
+(``engine/provisioners/{aws,gcp,azure}.py``) return a cloud-specific resources
+dict describing the Postgres they created. This module turns that — plus the
+password resolved from the cloud secret store at deploy time — into a uniform
+``postgresql://`` DSN that the agent container reads as ``KB_PGVECTOR_DSN``
+(consumed by the runtime in ``engine/runtimes/templates/langgraph_server.py``
+and the pgvector backend in ``api/services/pgvector_rag_backend.py``).
+
+Pure string assembly — no cloud SDK calls — so it is fully unit-testable. The
+host fields differ per cloud:
+
+* AWS RDS         → ``resources["endpoint"]``
+* GCP Cloud SQL   → ``resources["private_ip"]`` (captured by the provisioner)
+* Azure Flexible  → ``resources["fqdn"]``
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import quote
+
+DEFAULT_PG_PORT = 5432
+DEFAULT_DB_NAME = "agentbreeder"
+DEFAULT_DB_USER = "agentbreeder"
+
+
+def build_pgvector_dsn(
+    host: str,
+    database: str = DEFAULT_DB_NAME,
+    user: str = DEFAULT_DB_USER,
+    password: str = "",
+    port: int = DEFAULT_PG_PORT,
+) -> str:
+    """Build a ``postgresql://`` DSN with URL-encoded credentials.
+
+    User and password are percent-encoded so a generated password containing
+    ``@``, ``:``, ``/`` etc. cannot corrupt the URL.
+    """
+    if not host:
+        raise ValueError("pgvector DSN requires a host")
+    userinfo = f"{quote(user, safe='')}:{quote(password, safe='')}"
+    return f"postgresql://{userinfo}@{host}:{port}/{database}"
+
+
+def pgvector_host_from_resources(cloud: str, resources: dict[str, Any]) -> str | None:
+    """Return the connectable host for the provisioned DB, or ``None``."""
+    if cloud == "aws":
+        return resources.get("endpoint")
+    if cloud == "gcp":
+        return resources.get("private_ip")
+    if cloud == "azure":
+        return resources.get("fqdn")
+    return None
+
+
+def pgvector_dsn_from_resources(
+    cloud: str,
+    resources: dict[str, Any],
+    password: str,
+) -> str | None:
+    """Assemble a ``KB_PGVECTOR_DSN`` from a provisioner resources dict.
+
+    Returns ``None`` when the cloud is unknown or the host has not been
+    captured (so callers can fall back to the explicit ``backend_url`` path).
+    """
+    host = pgvector_host_from_resources(cloud, resources)
+    if not host:
+        return None
+
+    if cloud == "aws":
+        database = resources.get("db_name", DEFAULT_DB_NAME)
+        user = resources.get("user", DEFAULT_DB_USER)
+        port = int(resources.get("port", DEFAULT_PG_PORT))
+    elif cloud == "gcp":
+        database = resources.get("database", DEFAULT_DB_NAME)
+        user = resources.get("user", DEFAULT_DB_USER)
+        port = DEFAULT_PG_PORT
+    elif cloud == "azure":
+        database = resources.get("database", DEFAULT_DB_NAME)
+        user = resources.get("admin_user", DEFAULT_DB_USER)
+        port = DEFAULT_PG_PORT
+    else:
+        return None
+
+    return build_pgvector_dsn(host=host, database=database, user=user, password=password, port=port)

--- a/engine/deployers/_pgvector_dsn.py
+++ b/engine/deployers/_pgvector_dsn.py
@@ -118,4 +118,6 @@ def pgvector_dsn_from_resources(
     else:
         return None
 
-    return build_pgvector_dsn(host=host, database=database, user=user, password=password, port=port)
+    return build_pgvector_dsn(
+        host=host, database=database, user=user, password=password, port=port
+    )

--- a/engine/deployers/_pgvector_dsn.py
+++ b/engine/deployers/_pgvector_dsn.py
@@ -25,6 +25,40 @@ DEFAULT_PG_PORT = 5432
 DEFAULT_DB_NAME = "agentbreeder"
 DEFAULT_DB_USER = "agentbreeder"
 
+# Clouds for which we provision a managed Postgres for pgvector.
+_MANAGED_PG_CLOUDS = {"aws", "gcp", "azure"}
+
+# Where each provisioner stores the DB-password secret reference.
+_SECRET_REF_KEYS = {
+    "aws": "secret_arn",
+    "gcp": "password_secret",
+    "azure": "password_secret_uri",
+}
+
+
+def needs_managed_pgvector(config: Any) -> bool:
+    """Whether the deploy should provision a managed pgvector store.
+
+    True when the agent declares ``knowledge_bases``, none pins an explicit
+    ``backend_url`` (P1 contract: an explicit DSN always wins), and the target
+    is a managed cloud. Local / claude-managed / kubernetes are out of scope.
+    """
+    kbs = getattr(config, "knowledge_bases", None) or []
+    if not kbs:
+        return False
+    if any(getattr(kb, "backend_url", None) for kb in kbs):
+        return False
+    deploy = getattr(config, "deploy", None)
+    cloud = getattr(deploy, "cloud", None)
+    cloud_val = getattr(cloud, "value", cloud)
+    return cloud_val in _MANAGED_PG_CLOUDS
+
+
+def pgvector_secret_ref(cloud: str, resources: dict[str, Any]) -> str | None:
+    """Return the DB-password secret reference for the provisioned DB."""
+    key = _SECRET_REF_KEYS.get(cloud)
+    return resources.get(key) if key else None
+
 
 def build_pgvector_dsn(
     host: str,

--- a/engine/provisioners/azure.py
+++ b/engine/provisioners/azure.py
@@ -906,6 +906,29 @@ class AzureProvisioner(InfraProvisioner):
         poller = client.servers.begin_create(rg_name, db_name, server)
         # PG Flexible Server can take 15+ min on the first run.
         result = poller.result(timeout=_LRO_TIMEOUT_SEC)
+
+        # Allow-list the pgvector extension. Azure Flexible Server refuses
+        # CREATE EXTENSION unless the extension is present in the
+        # ``azure.extensions`` server parameter, so the agent's pgvector
+        # backend would otherwise fail to initialise. (#523)
+        try:
+            from azure.mgmt.rdbms.postgresql_flexibleservers.models import Configuration
+
+            cfg_poller = client.configurations.begin_update(
+                rg_name,
+                db_name,
+                "azure.extensions",
+                Configuration(value="VECTOR", source="user-override"),
+            )
+            cfg_poller.result(timeout=_LRO_TIMEOUT_SEC)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "postgres flexible: could not allow-list pgvector on %s "
+                "(azure.extensions); RAG retrieval may fail until it is set: %s",
+                db_name,
+                exc,
+            )
+
         return result.id, result.fully_qualified_domain_name
 
     async def _delete_postgres_flexible(

--- a/engine/provisioners/gcp.py
+++ b/engine/provisioners/gcp.py
@@ -20,6 +20,20 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 logger = logging.getLogger(__name__)
 
 
+def _select_private_ip(ip_addresses: Any) -> str | None:
+    """Return the PRIVATE IP from a Cloud SQL instance's ``ip_addresses`` list.
+
+    Robust to proto-plus enums (``ip.type_``) and plain objects (``ip.type``);
+    matches on the enum *name* so it works without importing the SDK in tests.
+    """
+    for ip in ip_addresses or []:
+        ip_type = getattr(ip, "type_", getattr(ip, "type", None))
+        name = getattr(ip_type, "name", None) or str(ip_type)
+        if name == "PRIVATE" or name.endswith(".PRIVATE"):
+            return getattr(ip, "ip_address", None)
+    return None
+
+
 def _check(resource: str, fn) -> ValidationCheck:  # noqa: ANN001
     """Run an SDK lookup, translating google-cloud exceptions into a ValidationCheck."""
     try:
@@ -563,10 +577,22 @@ class GCPProvisioner(InfraProvisioner):
                     _await_operation(op)
             raise
 
+        # Capture the private IP so the deployer can build a KB_PGVECTOR_DSN /
+        # MEMORY_DATABASE_URL without a Cloud SQL Auth Proxy. (#523)
+        private_ip: str | None = None
+        try:
+            inst = admin.get(
+                request=sql_v1.SqlInstancesGetRequest(project=project, instance=instance_id)
+            )
+            private_ip = _select_private_ip(getattr(inst, "ip_addresses", None))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("cloud sql: could not read private IP for %s: %s", instance_id, exc)
+
         return {
             "instance_id": instance_id,
             "instance_name": instance_resource_name,
             "connection_name": connection_name,
+            "private_ip": private_ip,
             "database": db_name,
             "user": db_user,
             "tier": tier,

--- a/engine/resolver.py
+++ b/engine/resolver.py
@@ -68,6 +68,33 @@ def _resolve_kb_index_ids(kb_refs: list[KnowledgeBaseRef]) -> list[str]:
     return resolved
 
 
+def _resolve_kb_embedding_model(kb_refs: list[KnowledgeBaseRef]) -> str | None:
+    """Return the embedding model of the first resolvable KB index.
+
+    The deployed runtime must embed queries with the SAME model used at
+    ingest time, otherwise vector similarity is meaningless. We pin it via
+    ``KB_EMBEDDING_MODEL``. Returns ``None`` when no index is resolvable (the
+    runtime then falls back to its built-in default).
+    """
+    if not kb_refs:
+        return None
+    try:
+        from api.services.rag_service import get_rag_store
+
+        store = get_rag_store()
+        all_indexes, _ = store.list_indexes(page=1, per_page=1000)
+        name_to_model = {idx.name: getattr(idx, "embedding_model", None) for idx in all_indexes}
+    except Exception:  # RAGStore unavailable (engine running standalone)
+        return None
+
+    for kb in kb_refs:
+        slug = kb.ref.split("/")[-1]
+        model = name_to_model.get(slug) or name_to_model.get(kb.ref)
+        if model:
+            return model
+    return None
+
+
 def _resolve_memory_config(store_refs: list[str]) -> tuple[str, int]:
     """Return (backend, ttl_seconds) for the agent's memory configuration.
 
@@ -269,6 +296,13 @@ def resolve_dependencies(config: AgentConfig, project_root: Path | None = None) 
                 len(kb_index_ids),
                 config.deploy.env_vars["KB_INDEX_IDS"],
             )
+
+        # Pin the embedding model so the runtime embeds queries the same way
+        # the documents were embedded at ingest (required for the pgvector
+        # retrieval path). Falls back to the runtime default when unknown.
+        embedding_model = _resolve_kb_embedding_model(config.knowledge_bases)
+        if embedding_model:
+            config.deploy.env_vars.setdefault("KB_EMBEDDING_MODEL", embedding_model)
 
         # D2 contract: explicit per-KB backend_url becomes the vector-store DSN seam
         # that managed provisioning fills when no explicit URL is given.

--- a/engine/resolver.py
+++ b/engine/resolver.py
@@ -83,7 +83,9 @@ def _resolve_kb_embedding_model(kb_refs: list[KnowledgeBaseRef]) -> str | None:
 
         store = get_rag_store()
         all_indexes, _ = store.list_indexes(page=1, per_page=1000)
-        name_to_model = {idx.name: getattr(idx, "embedding_model", None) for idx in all_indexes}
+        name_to_model: dict[str, str | None] = {
+            idx.name: getattr(idx, "embedding_model", None) for idx in all_indexes
+        }
     except Exception:  # RAGStore unavailable (engine running standalone)
         return None
 
@@ -91,7 +93,7 @@ def _resolve_kb_embedding_model(kb_refs: list[KnowledgeBaseRef]) -> str | None:
         slug = kb.ref.split("/")[-1]
         model = name_to_model.get(slug) or name_to_model.get(kb.ref)
         if model:
-            return model
+            return str(model)
     return None
 
 

--- a/engine/runtimes/templates/langgraph_server.py
+++ b/engine/runtimes/templates/langgraph_server.py
@@ -156,9 +156,56 @@ def _load_agent() -> Any:
 
 KB_TOP_K: int = int(os.getenv("KB_TOP_K", "5"))
 
+# When a managed vector store was provisioned (or an explicit backend_url was
+# given), the deployer injects its DSN here. The in-memory RAGStore is empty in
+# a deployed container, so KB retrieval must go straight to this store.
+KB_PGVECTOR_DSN: str = os.getenv("KB_PGVECTOR_DSN", "")
+KB_EMBEDDING_MODEL: str = os.getenv("KB_EMBEDDING_MODEL", "openai/text-embedding-3-small")
+
+# Cache of connected pgvector backends, keyed by RAG index id.
+_kb_pgvector_backends: dict[str, Any] = {}
+
 # ---------------------------------------------------------------------------
 # Knowledge-base context injection
 # ---------------------------------------------------------------------------
+
+
+async def _search_pgvector(query: str, kb_index_ids: list[str], top_k: int) -> list[str]:
+    """Embed the query and search the provisioned pgvector store per index.
+
+    Returns a list of ``[source: …]\\n{text}`` chunk strings (possibly empty).
+    Imports are deferred so the module loads without the engine present.
+    """
+    from api.services.pgvector_rag_backend import create_pgvector_backend
+    from api.services.rag_service import embed_texts
+
+    try:
+        embed_result = await embed_texts([query], model=KB_EMBEDDING_MODEL)
+        query_vec = embed_result.vectors[0]
+    except Exception as exc:
+        logger.warning("KB query embedding failed: %s", exc)
+        return []
+
+    hits: list[str] = []
+    for index_id in kb_index_ids:
+        backend = _kb_pgvector_backends.get(index_id)
+        if backend is None:
+            try:
+                backend = create_pgvector_backend({"dsn": KB_PGVECTOR_DSN}, index_id=index_id)
+                await backend.connect()
+                _kb_pgvector_backends[index_id] = backend
+            except Exception as exc:
+                logger.warning("pgvector backend unavailable for index %s: %s", index_id, exc)
+                continue
+        try:
+            results = await backend.search(query_vec, top_k=top_k)
+        except Exception as exc:
+            logger.warning("pgvector KB search failed for index %s: %s", index_id, exc)
+            continue
+        for r in results:
+            source = (r.get("metadata") or {}).get("source", index_id)
+            hits.append(f"[source: {source}]\n{r['text']}")
+    return hits
 
 
 async def _inject_kb_context(query: str, kb_index_ids: list[str], top_k: int = KB_TOP_K) -> str:
@@ -178,6 +225,15 @@ async def _inject_kb_context(query: str, kb_index_ids: list[str], top_k: int = K
     """
     if not kb_index_ids or not query:
         return ""
+
+    # Provisioned / explicit managed store: query pgvector directly. The
+    # in-memory RAGStore below is empty in a deployed container.
+    if KB_PGVECTOR_DSN:
+        pg_hits = await _search_pgvector(query, kb_index_ids, top_k)
+        if not pg_hits:
+            return ""
+        chunks_text = "\n\n---\n\n".join(pg_hits)
+        return f"<knowledge_base_context>\n{chunks_text}\n</knowledge_base_context>"
 
     try:
         from api.services.rag_service import get_rag_store

--- a/tests/unit/test_gcp_private_ip.py
+++ b/tests/unit/test_gcp_private_ip.py
@@ -1,0 +1,37 @@
+"""Unit tests for GCP Cloud SQL private-IP selection (P2).
+
+The SDK call is mocked out elsewhere; this covers the pure selection logic
+that turns a Cloud SQL instance's ``ip_addresses`` into a connectable host.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from engine.provisioners.gcp import _select_private_ip
+
+
+def _ip(addr: str, type_name: str) -> SimpleNamespace:
+    # Mimic a proto-plus enum whose .name is the type, plus .ip_address.
+    return SimpleNamespace(ip_address=addr, type_=SimpleNamespace(name=type_name))
+
+
+def test_selects_private_over_primary():
+    ips = [_ip("203.0.113.9", "PRIMARY"), _ip("10.1.2.3", "PRIVATE")]
+    assert _select_private_ip(ips) == "10.1.2.3"
+
+
+def test_returns_none_when_no_private():
+    ips = [_ip("203.0.113.9", "PRIMARY"), _ip("198.51.100.4", "OUTGOING")]
+    assert _select_private_ip(ips) is None
+
+
+def test_handles_plain_type_attribute_and_qualified_name():
+    # Object exposing `.type` (not `.type_`) and a stringified enum value.
+    plain = SimpleNamespace(ip_address="10.9.9.9", type="SqlIpAddressType.PRIVATE")
+    assert _select_private_ip([plain]) == "10.9.9.9"
+
+
+def test_empty_and_none():
+    assert _select_private_ip([]) is None
+    assert _select_private_ip(None) is None

--- a/tests/unit/test_langgraph_server.py
+++ b/tests/unit/test_langgraph_server.py
@@ -1019,3 +1019,80 @@ class TestInvokeHistoryField:
         assert resp.status_code == 200
         assert resp.json()["history"] == []
         srv._agent = None
+
+
+# ---------------------------------------------------------------------------
+# KB context injection from a provisioned pgvector store (P2)
+# ---------------------------------------------------------------------------
+
+
+class TestKBPgvectorInjection:
+    """When KB_PGVECTOR_DSN is set, the runtime embeds the query and searches
+    the provisioned pgvector store directly (the in-memory store is empty in a
+    deployed container)."""
+
+    async def test_inject_queries_pgvector_when_dsn_set(self, monkeypatch):
+        monkeypatch.setenv("KB_PGVECTOR_DSN", "postgresql://u:p@db.internal:5432/agentbreeder")
+        monkeypatch.setenv("KB_EMBEDDING_MODEL", "openai/text-embedding-3-small")
+        srv = _import_server()
+
+        embed_result = MagicMock()
+        embed_result.vectors = [[0.1, 0.2, 0.3]]
+
+        async def fake_embed(texts, model=None):
+            assert model == "openai/text-embedding-3-small"
+            return embed_result
+
+        backend = MagicMock()
+        backend.connect = AsyncMock()
+        backend.search = AsyncMock(
+            return_value=[
+                {
+                    "chunk_id": "c1",
+                    "text": "alpha document body",
+                    "metadata": {"source": "alpha.pdf"},
+                    "score": 0.92,
+                    "distance": 0.08,
+                }
+            ]
+        )
+
+        captured: dict = {}
+
+        def fake_create(config, index_id):
+            captured["dsn"] = config.get("dsn")
+            captured["index_id"] = index_id
+            return backend
+
+        monkeypatch.setattr("api.services.rag_service.embed_texts", fake_embed)
+        monkeypatch.setattr(
+            "api.services.pgvector_rag_backend.create_pgvector_backend", fake_create
+        )
+
+        out = await srv._inject_kb_context("find alpha", ["idx-uuid-1"], top_k=3)
+
+        assert "<knowledge_base_context>" in out
+        assert "alpha document body" in out
+        assert "[source: alpha.pdf]" in out
+        backend.connect.assert_awaited_once()
+        backend.search.assert_awaited_once()
+        assert captured["dsn"].startswith("postgresql://")
+        assert captured["index_id"] == "idx-uuid-1"
+
+    async def test_inject_falls_back_to_in_memory_without_dsn(self, monkeypatch):
+        monkeypatch.delenv("KB_PGVECTOR_DSN", raising=False)
+        srv = _import_server()
+
+        # No DSN → pgvector path must not be taken; create_pgvector_backend
+        # should never be called.
+        sentinel = MagicMock(side_effect=AssertionError("pgvector must not be used"))
+        monkeypatch.setattr("api.services.pgvector_rag_backend.create_pgvector_backend", sentinel)
+
+        store = MagicMock()
+        store.get_index.return_value = None
+        store.list_indexes.return_value = ([], 0)
+        monkeypatch.setattr("api.services.rag_service.get_rag_store", lambda: store)
+
+        out = await srv._inject_kb_context("q", ["missing-index"], top_k=2)
+        assert out == ""
+        sentinel.assert_not_called()

--- a/tests/unit/test_pgvector_dsn.py
+++ b/tests/unit/test_pgvector_dsn.py
@@ -1,0 +1,66 @@
+"""Unit tests for the KB_PGVECTOR_DSN builder (P2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.deployers._pgvector_dsn import (
+    build_pgvector_dsn,
+    pgvector_dsn_from_resources,
+    pgvector_host_from_resources,
+)
+
+
+def test_build_dsn_basic():
+    dsn = build_pgvector_dsn("db.host", database="kb", user="ab", password="pw", port=5432)
+    assert dsn == "postgresql://ab:pw@db.host:5432/kb"
+
+
+def test_build_dsn_url_encodes_password_special_chars():
+    # A generated password with @ : / must not corrupt the URL.
+    dsn = build_pgvector_dsn("h", database="d", user="u", password="p@ss:w/rd")
+    assert "p%40ss%3Aw%2Frd" in dsn
+    assert dsn == "postgresql://u:p%40ss%3Aw%2Frd@h:5432/d"
+
+
+def test_build_dsn_requires_host():
+    with pytest.raises(ValueError, match="host"):
+        build_pgvector_dsn("", password="x")
+
+
+@pytest.mark.parametrize(
+    "cloud,resources,expected_host",
+    [
+        ("aws", {"endpoint": "rds.aws"}, "rds.aws"),
+        ("gcp", {"private_ip": "10.0.0.5"}, "10.0.0.5"),
+        ("azure", {"fqdn": "pg.azure"}, "pg.azure"),
+        ("gcp", {"connection_name": "p:r:i"}, None),  # no private_ip captured
+        ("local", {"endpoint": "x"}, None),
+    ],
+)
+def test_host_from_resources(cloud, resources, expected_host):
+    assert pgvector_host_from_resources(cloud, resources) == expected_host
+
+
+def test_dsn_from_resources_aws():
+    res = {"endpoint": "rds.aws", "port": 5432, "db_name": "kb", "user": "ab"}
+    assert pgvector_dsn_from_resources("aws", res, "pw") == "postgresql://ab:pw@rds.aws:5432/kb"
+
+
+def test_dsn_from_resources_gcp_uses_private_ip():
+    res = {"private_ip": "10.0.0.5", "database": "kb", "user": "ab"}
+    assert pgvector_dsn_from_resources("gcp", res, "pw") == "postgresql://ab:pw@10.0.0.5:5432/kb"
+
+
+def test_dsn_from_resources_azure_uses_admin_user():
+    res = {"fqdn": "pg.azure", "database": "kb", "admin_user": "ab"}
+    assert pgvector_dsn_from_resources("azure", res, "pw") == "postgresql://ab:pw@pg.azure:5432/kb"
+
+
+def test_dsn_from_resources_returns_none_without_host():
+    # GCP without a captured private_ip → caller falls back to backend_url.
+    assert pgvector_dsn_from_resources("gcp", {"connection_name": "p:r:i"}, "pw") is None
+
+
+def test_dsn_from_resources_unknown_cloud():
+    assert pgvector_dsn_from_resources("digitalocean", {"endpoint": "x"}, "pw") is None

--- a/tests/unit/test_pgvector_dsn.py
+++ b/tests/unit/test_pgvector_dsn.py
@@ -64,3 +64,53 @@ def test_dsn_from_resources_returns_none_without_host():
 
 def test_dsn_from_resources_unknown_cloud():
     assert pgvector_dsn_from_resources("digitalocean", {"endpoint": "x"}, "pw") is None
+
+
+# ---------------------------------------------------------------------------
+# needs_managed_pgvector / pgvector_secret_ref
+# ---------------------------------------------------------------------------
+
+from types import SimpleNamespace  # noqa: E402
+
+from engine.deployers._pgvector_dsn import (  # noqa: E402
+    needs_managed_pgvector,
+    pgvector_secret_ref,
+)
+
+
+def _config(kbs, cloud):
+    return SimpleNamespace(
+        knowledge_bases=kbs,
+        deploy=SimpleNamespace(cloud=SimpleNamespace(value=cloud)),
+    )
+
+
+def test_needs_managed_pgvector_true_for_kb_without_backend_url_on_cloud():
+    cfg = _config([SimpleNamespace(ref="kb/docs", backend_url=None)], "aws")
+    assert needs_managed_pgvector(cfg) is True
+
+
+def test_needs_managed_pgvector_false_when_backend_url_pinned():
+    cfg = _config([SimpleNamespace(ref="kb/docs", backend_url="postgresql://x")], "gcp")
+    assert needs_managed_pgvector(cfg) is False
+
+
+def test_needs_managed_pgvector_false_without_kbs():
+    assert needs_managed_pgvector(_config([], "azure")) is False
+
+
+def test_needs_managed_pgvector_false_for_local():
+    cfg = _config([SimpleNamespace(ref="kb/docs", backend_url=None)], "local")
+    assert needs_managed_pgvector(cfg) is False
+
+
+def test_pgvector_secret_ref_per_cloud():
+    assert pgvector_secret_ref("aws", {"secret_arn": "arn:x"}) == "arn:x"
+    assert pgvector_secret_ref("gcp", {"password_secret": "projects/p/secrets/s"}) == (
+        "projects/p/secrets/s"
+    )
+    assert pgvector_secret_ref("azure", {"password_secret_uri": "https://v/secrets/s"}) == (
+        "https://v/secrets/s"
+    )
+    assert pgvector_secret_ref("aws", {}) is None
+    assert pgvector_secret_ref("nope", {"secret_arn": "x"}) is None

--- a/tests/unit/test_resolver_kb_embedding_model.py
+++ b/tests/unit/test_resolver_kb_embedding_model.py
@@ -20,7 +20,9 @@ def _store_with(indexes):
 
 
 def test_resolves_embedding_model_by_slug(monkeypatch):
-    idx = SimpleNamespace(name="product-docs", id="i1", embedding_model="openai/text-embedding-3-large")
+    idx = SimpleNamespace(
+        name="product-docs", id="i1", embedding_model="openai/text-embedding-3-large"
+    )
     monkeypatch.setattr("api.services.rag_service.get_rag_store", lambda: _store_with([idx]))
     assert (
         resolver._resolve_kb_embedding_model([KnowledgeBaseRef(ref="kb/product-docs")])

--- a/tests/unit/test_resolver_kb_embedding_model.py
+++ b/tests/unit/test_resolver_kb_embedding_model.py
@@ -1,0 +1,45 @@
+"""Unit tests for KB_EMBEDDING_MODEL resolution (P2).
+
+The deployed runtime must embed queries with the same model used at ingest;
+the resolver pins it from the resolved RAG index.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import engine.resolver as resolver
+from engine.config_parser import KnowledgeBaseRef
+
+
+def _store_with(indexes):
+    store = MagicMock()
+    store.list_indexes.return_value = (indexes, len(indexes))
+    return store
+
+
+def test_resolves_embedding_model_by_slug(monkeypatch):
+    idx = SimpleNamespace(name="product-docs", id="i1", embedding_model="openai/text-embedding-3-large")
+    monkeypatch.setattr("api.services.rag_service.get_rag_store", lambda: _store_with([idx]))
+    assert (
+        resolver._resolve_kb_embedding_model([KnowledgeBaseRef(ref="kb/product-docs")])
+        == "openai/text-embedding-3-large"
+    )
+
+
+def test_returns_none_when_index_unresolvable(monkeypatch):
+    monkeypatch.setattr("api.services.rag_service.get_rag_store", lambda: _store_with([]))
+    assert resolver._resolve_kb_embedding_model([KnowledgeBaseRef(ref="kb/missing")]) is None
+
+
+def test_returns_none_for_empty_refs():
+    assert resolver._resolve_kb_embedding_model([]) is None
+
+
+def test_returns_none_when_store_unavailable(monkeypatch):
+    def _boom():
+        raise RuntimeError("no store")
+
+    monkeypatch.setattr("api.services.rag_service.get_rag_store", _boom)
+    assert resolver._resolve_kb_embedding_model([KnowledgeBaseRef(ref="kb/x")]) is None

--- a/website/content/docs/rag.mdx
+++ b/website/content/docs/rag.mdx
@@ -364,6 +364,49 @@ directly via `api.services.pgvector_rag_backend.PgvectorRAGBackend`.
 
 ---
 
+## Deploying with a managed pgvector store (cloud)
+
+When you deploy an agent that declares `knowledge_bases`, retrieval runs **inside
+the agent container** — where the local in-process index is empty. To retrieve in
+the cloud, point the knowledge base at a managed Postgres + pgvector store with
+`backend_url`:
+
+```yaml
+knowledge_bases:
+  - ref: kb/product-docs
+    backend_url: postgresql://user:pass@db.internal:5432/agentbreeder
+```
+
+At deploy time the resolver exposes this to the container as two env vars:
+
+| Env var | Source | Purpose |
+|---------|--------|---------|
+| `KB_PGVECTOR_DSN` | `knowledge_bases[].backend_url` | Connection string the runtime uses to query pgvector |
+| `KB_EMBEDDING_MODEL` | the index's embedding model | Embeds queries the same way the documents were ingested |
+
+At invoke time the runtime embeds the user query with `KB_EMBEDDING_MODEL`, runs a
+cosine-similarity search against the pgvector store for each attached index, and
+prepends the top-k chunks as context — **nothing is read from the machine you
+deployed from**.
+
+### Per-cloud pgvector notes
+
+The `vector` extension must be available on the managed Postgres:
+
+- **AWS RDS** — supported on PostgreSQL ≥ 15.2; the extension is created via
+  `rds_superuser` (no parameter-group change needed).
+- **GCP Cloud SQL** — pgvector is built in; connect over the instance's private IP.
+- **Azure Database for PostgreSQL Flexible Server** — `VECTOR` must be in the
+  `azure.extensions` server parameter before `CREATE EXTENSION` succeeds.
+
+<Callout type="info" title="Automatic provisioning is on the roadmap">
+Today, supply an explicit `backend_url` to a Postgres you manage. Having
+`agentbreeder deploy` provision a managed pgvector store for you (no
+`backend_url` required) is planned — see the cloud-agnostic deployment epic.
+</Callout>
+
+---
+
 ## API Reference
 
 | Method | Path | Description |
@@ -382,12 +425,14 @@ directly via `api.services.pgvector_rag_backend.PgvectorRAGBackend`.
 
 ```yaml
 knowledge_bases:
-  - ref: string    # required — registry reference (kb/name)
+  - ref: string          # required — registry reference (kb/name)
+    backend_url: string  # optional — explicit pgvector DSN for cloud retrieval
 ```
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `ref` | string | Yes | Registry reference in format `kb/{name}` |
+| `backend_url` | string | No | Explicit cloud-reachable pgvector DSN. Exposed to the agent as `KB_PGVECTOR_DSN`; see [Deploying with a managed pgvector store](#deploying-with-a-managed-pgvector-store-cloud). |
 
 ---
 


### PR DESCRIPTION
## P2 — RAG retrieval from a managed pgvector store

Phase 2 of the cloud-agnostic deployment epic (#523), built on the merged P1 (#522). Plan: `docs/superpowers/plans/2026-05-30-p2-rag-managed-backends.md`.

### What works after this PR (end-to-end)
An agent that points a knowledge base at a managed Postgres + pgvector store now **retrieves at invoke time in the cloud**:

```yaml
knowledge_bases:
  - ref: kb/product-docs
    backend_url: postgresql://user:pass@db.internal:5432/agentbreeder
```

Resolver (P1) sets `KB_PGVECTOR_DSN` from `backend_url` and now also pins `KB_EMBEDDING_MODEL` → deployer injects both as container env → the runtime embeds the query and runs a cosine-similarity search against pgvector for each attached index. **Nothing is read from the deploy host.** Previously the runtime queried the in-process RAGStore, which is empty in a deployed container, so cloud retrieval silently returned nothing.

### Changes
- **Runtime** (`langgraph_server.py`): when `KB_PGVECTOR_DSN` is set, embed the query (`KB_EMBEDDING_MODEL`) and search the pgvector backend directly, per index, with connections cached; in-memory path retained for local/no-DSN deploys.
- **DSN builder** (`engine/deployers/_pgvector_dsn.py`): pure, tested assembly of a `postgresql://` DSN from a provisioner resources dict (URL-encoded creds) + `needs_managed_pgvector` / `pgvector_secret_ref` decision helpers for the future auto-provision path.
- **Provisioners**: GCP Cloud SQL records its **private IP** (needed to build a DSN); Azure Flexible Server allow-lists the `vector` extension via `azure.extensions` (otherwise `CREATE EXTENSION vector` is rejected). AWS RDS needs no change (PG ≥ 15.2).
- **Resolver**: pins `KB_EMBEDDING_MODEL` from the attached index so queries embed the same way as ingest.
- **Docs**: `rag.mdx` "Deploying with a managed pgvector store" + `backend_url` field; CHANGELOG.

### Scope (per maintainer decision)
This PR delivers the **explicit `backend_url`** path. **Automatic provisioning** (no `backend_url` → `agentbreeder deploy` provisions the DB for you) is intentionally **deferred**: the CLI deploy pipeline (`engine/builder.py`) never invokes the `InfraProvisioner`, so bridging it is a change to the sacred pipeline that overlaps #505 and needs real-cloud validation. The provisioner/DSN/extension groundwork here is what that follow-up will plug into.

### Testing
New unit tests for the runtime pgvector path, DSN builder, decision helpers, GCP private-IP selection, and `KB_EMBEDDING_MODEL` resolution. Full unit suite green (one unrelated local-only AWS-credentials flake). Per-cloud SDK calls (private-IP fetch, Azure extension allow-list) follow the existing mocked-at-the-method test layer and need live-cloud validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
