### PR TITLE
feat: cloud-agnostic deployment P3 — memory managed backends (explicit backend_url)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
   empty in the cloud). The resolver also pins `KB_EMBEDDING_MODEL` so queries are embedded with the
   same model used at ingest. GCP Cloud SQL now records its private IP, and Azure Flexible Server
   allow-lists the `vector` extension (`azure.extensions`), so a provisioned Postgres can serve pgvector.
+- Cloud memory (P3): `memory.backend_url` alone is now enough to target a managed Redis/Postgres —
+  the resolver infers `MEMORY_BACKEND` from the URL scheme (`redis(s)://` → redis, `postgres(ql)://`
+  → postgresql) and wires `REDIS_URL`/`DATABASE_URL` accordingly. The deployed runtime persists
+  conversation history to that managed store, with nothing read from the deploy host.
 
 ### Changed
 - Deploy no longer forwards the deploy host's local `REDIS_URL`/`DATABASE_URL`/`NEO4J_URL` to cloud

--- a/engine/resolver.py
+++ b/engine/resolver.py
@@ -126,6 +126,23 @@ def _resolve_memory_config(store_refs: list[str]) -> tuple[str, int]:
         return "postgresql", 0
 
 
+def _infer_memory_backend(backend_url: str | None) -> str | None:
+    """Infer the memory backend from an explicit ``backend_url`` scheme.
+
+    Lets a user point an agent at a managed store with just
+    ``memory.backend_url: redis://…`` (or ``postgresql://…``) — without also
+    restating ``memory.backend``. Returns ``None`` for an unknown/empty scheme.
+    """
+    if not backend_url:
+        return None
+    scheme = backend_url.split("://", 1)[0].lower()
+    if scheme in ("redis", "rediss"):
+        return "redis"
+    if scheme in ("postgres", "postgresql"):
+        return "postgresql"
+    return None
+
+
 class ResolutionError(Exception):
     """Raised when a registry reference cannot be resolved."""
 
@@ -263,7 +280,10 @@ def resolve_dependencies(config: AgentConfig, project_root: Path | None = None) 
             config.deploy.env_vars = {}
 
         backend, ttl_seconds = _resolve_memory_config(config.memory.stores)
-        backend = config.memory.backend or backend  # explicit agent.yaml wins
+        # Precedence: explicit agent.yaml backend > backend_url scheme > registry.
+        backend = (
+            config.memory.backend or _infer_memory_backend(config.memory.backend_url) or backend
+        )
         if backend:
             config.deploy.env_vars.setdefault("MEMORY_BACKEND", backend)
         if ttl_seconds and ttl_seconds > 0:

--- a/tests/unit/test_resolver_memory_backend_infer.py
+++ b/tests/unit/test_resolver_memory_backend_infer.py
@@ -1,0 +1,71 @@
+"""P3 — infer the memory backend from an explicit backend_url scheme.
+
+A user should be able to point an agent at a managed store with just
+``memory.backend_url: redis://…`` (no separate ``memory.backend``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.config_parser import AgentConfig, DeployConfig, MemoryConfig, ModelConfig
+from engine.resolver import _infer_memory_backend, resolve_dependencies
+
+
+def _cfg(memory=None):
+    return AgentConfig(
+        name="x",
+        version="1.0.0",
+        team="t",
+        owner="o@e.com",
+        framework="langgraph",
+        model=ModelConfig(primary="claude-sonnet-4"),
+        deploy=DeployConfig(cloud="aws"),
+        memory=memory,
+    )
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("redis://h:6379", "redis"),
+        ("rediss://cache.aws:6379", "redis"),
+        ("postgresql://h/db", "postgresql"),
+        ("postgres://h/db", "postgresql"),
+        ("mysql://h/db", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_infer_memory_backend(url, expected):
+    assert _infer_memory_backend(url) == expected
+
+
+def test_backend_url_only_redis_infers_backend(monkeypatch, tmp_path):
+    monkeypatch.delenv("AGENTBREEDER_ALLOW_LOCAL_BACKENDS", raising=False)
+    cfg = resolve_dependencies(
+        _cfg(MemoryConfig(stores=[], backend_url="rediss://prod-cache.aws:6379")),
+        project_root=tmp_path,
+    )
+    assert cfg.deploy.env_vars["MEMORY_BACKEND"] == "redis"
+    assert cfg.deploy.env_vars["REDIS_URL"] == "rediss://prod-cache.aws:6379"
+
+
+def test_backend_url_only_postgres_infers_backend(monkeypatch, tmp_path):
+    monkeypatch.delenv("AGENTBREEDER_ALLOW_LOCAL_BACKENDS", raising=False)
+    cfg = resolve_dependencies(
+        _cfg(MemoryConfig(stores=[], backend_url="postgresql://prod-db.aws:5432/mem")),
+        project_root=tmp_path,
+    )
+    assert cfg.deploy.env_vars["MEMORY_BACKEND"] == "postgresql"
+    assert cfg.deploy.env_vars["DATABASE_URL"] == "postgresql://prod-db.aws:5432/mem"
+
+
+def test_explicit_backend_wins_over_url_scheme(monkeypatch, tmp_path):
+    monkeypatch.delenv("AGENTBREEDER_ALLOW_LOCAL_BACKENDS", raising=False)
+    cfg = resolve_dependencies(
+        _cfg(MemoryConfig(stores=[], backend="postgresql", backend_url="postgresql://db/mem")),
+        project_root=tmp_path,
+    )
+    assert cfg.deploy.env_vars["MEMORY_BACKEND"] == "postgresql"
+    assert cfg.deploy.env_vars["DATABASE_URL"] == "postgresql://db/mem"

--- a/website/content/docs/memory.mdx
+++ b/website/content/docs/memory.mdx
@@ -83,6 +83,40 @@ That's it. The agent now has a sliding window of the last 50 messages per sessio
 
 ---
 
+## Deploying with a managed memory backend (cloud)
+
+For a deployed agent, point memory at a managed Redis or Postgres you control with
+`backend_url`. AgentBreeder infers the backend from the URL scheme, so you don't
+need to restate `backend`:
+
+```yaml
+memory:
+  backend_url: rediss://prod-cache.aws:6379         # → MEMORY_BACKEND=redis
+  # or:
+  # backend_url: postgresql://user:pass@db.internal:5432/mem   # → MEMORY_BACKEND=postgresql
+```
+
+At deploy time the resolver injects these into the agent container:
+
+| Env var | Source |
+|---------|--------|
+| `MEMORY_BACKEND` | explicit `memory.backend`, else inferred from the `backend_url` scheme |
+| `REDIS_URL` / `DATABASE_URL` | `memory.backend_url` (Redis vs Postgres, by scheme) |
+| `MEMORY_TTL_SECONDS` | the memory store's TTL |
+
+The runtime's MemoryManager connects to that backend on startup and persists
+conversation turns there — **no connection string is read from the machine you
+deployed from**. A `backend_url` pointing at `localhost` while deploying to a real
+cloud is flagged at deploy time.
+
+<Callout type="info" title="Automatic provisioning is on the roadmap">
+Today, supply an explicit `backend_url` to a Redis/Postgres you manage. Having
+`agentbreeder deploy` provision a managed cache/database for you is planned — see
+the cloud-agnostic deployment epic.
+</Callout>
+
+---
+
 ## Patterns
 
 ### Single-agent conversation history


### PR DESCRIPTION
## P3 — Memory managed backends (explicit `backend_url`)

Phase 3 of the cloud-agnostic deployment epic (#523), off the merged P1 (#522). Sibling of P2 (#525); independent of it.

### What works after this PR
P1 already wired `memory.backend_url` → `REDIS_URL`/`DATABASE_URL` + `MEMORY_BACKEND`, and the runtime `MemoryManager` already consumes those. The missing piece: a user had to **also** restate `memory.backend`, or the `backend_url` was dropped / assigned to the wrong env var. Now `backend_url` alone is enough:

```yaml
memory:
  backend_url: rediss://prod-cache.aws:6379   # → MEMORY_BACKEND=redis, REDIS_URL set
  # or: postgresql://user:pass@db:5432/mem    # → MEMORY_BACKEND=postgresql, DATABASE_URL set
```

The resolver infers the backend from the URL scheme (`redis(s)://` → redis, `postgres(ql)://` → postgresql). Precedence: explicit `memory.backend` > `backend_url` scheme > registry default. The deployed agent then persists conversation history to that managed store — **nothing is read from the deploy host**, and a `localhost` URL on a cloud target is flagged at deploy.

### Changes
- **Resolver** (`engine/resolver.py`): `_infer_memory_backend()` + wire it into the memory block.
- **Docs**: `memory.mdx` "Deploying with a managed memory backend" section; CHANGELOG.

### Scope (per maintainer decision, same as P2)
Delivers the **explicit `backend_url`** path. **Automatic provisioning** (`agentbreeder deploy` spins up ElastiCache/Memorystore/Azure Cache + managed Postgres) is **deferred** to a dedicated phase — the CLI deploy pipeline doesn't invoke the `InfraProvisioner` (see #525 for the full analysis); that bridge overlaps #505 and needs real-cloud validation.

### Testing
New unit tests for scheme inference and the resolver wiring (redis-only / postgres-only `backend_url`, explicit-backend precedence). Full unit suite green (one unrelated local-only AWS-credentials flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
