### PR TITLE
feat(cloud-agnostic): P4 MCP server deployment + P5 Studio self-hosting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 ## [Unreleased]
 
 ### Added
+- **Studio self-hosting (P5)**: a Helm chart (`deploy/helm/agentbreeder`) deploys the full platform
+  (Studio + API + migrations) on Kubernetes, with toggleable bundled Postgres/Redis subcharts, a
+  TLS-capable Ingress, and auto-generated signing keys. The dashboard image now renders its nginx
+  upstream from env (`API_UPSTREAM`/`LISTEN_PORT`) at startup, so the same image self-hosts anywhere.
+  See docs → Self-Hosting.
 - **MCP server deployment (P4)**: `agent.yaml` `mcp_servers` now deploy end-to-end. A new optional
   `url`/`image`/`port` on each entry lets you forward to a **remote** HTTP/SSE MCP server or
   **co-deploy** a container MCP server as a sidecar (AWS ECS, GCP Cloud Run, Azure Container Apps,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 ## [Unreleased]
 
 ### Added
+- **MCP server deployment (P4)**: `agent.yaml` `mcp_servers` now deploy end-to-end. A new optional
+  `url`/`image`/`port` on each entry lets you forward to a **remote** HTTP/SSE MCP server or
+  **co-deploy** a container MCP server as a sidecar (AWS ECS, GCP Cloud Run, Azure Container Apps,
+  docker-compose). The deployer resolves each ref and hands the Go sidecar a `{name:{transport,url}}`
+  map via `AGENTBREEDER_SIDECAR_MCP_SERVERS`, so the agent reaches every server at
+  `http://localhost:9091/mcp/<name>`.
 - Agent images now bundle the AgentBreeder runtime (`agentbreeder` dist), so registry-ref
   prompts, first-party tools, RAG and memory work on AWS/GCP/Azure — not just self-contained agents.
   Override the bundled requirement via `AGENTBREEDER_RUNTIME_REQUIREMENT`.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Then run `/agent-build` in Claude Code to scaffold an agent (it recommends frame
 |---|---|
 | [How-To guides](https://www.agentbreeder.io/docs/how-to) | Install, deploy, orchestrate, evaluate |
 | [Quickstart](https://www.agentbreeder.io/docs/quickstart) | Full local platform in one command |
+| [Self-hosting](https://www.agentbreeder.io/docs/self-hosting) | Run the platform on your own Kubernetes via Helm (`deploy/helm/agentbreeder`) |
 | [CLI reference](https://www.agentbreeder.io/docs/cli-reference) | All commands and flags |
 | [SDK reference](https://www.agentbreeder.io/docs/full-code) | Python + TypeScript full-code SDK |
 

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -25,13 +25,18 @@ LABEL org.opencontainers.image.source="https://github.com/agentbreeder/agentbree
 LABEL org.opencontainers.image.description="AgentBreeder Dashboard"
 
 COPY --from=build /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+# nginx config is rendered from env at startup (API_UPSTREAM / LISTEN_PORT) so
+# the same image self-hosts anywhere — see docker-entrypoint.sh + self-hosting docs.
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 # Drop root: nginx:alpine already has a `nginx` user (UID 101). The pid file
 # lives at /var/run/nginx.pid by default — make it writable by that user so
-# the master process can start. Cache + log dirs are nginx-only writes too.
+# the master process can start. Cache + log dirs are nginx-only writes too, and
+# the entrypoint writes the rendered config into /etc/nginx/conf.d.
 # Listening on 3001 (≥1024) means CAP_NET_BIND_SERVICE is not required.
-RUN chown -R nginx:nginx /usr/share/nginx/html /var/cache/nginx /var/log/nginx \
+RUN chmod +x /docker-entrypoint.sh \
+    && chown -R nginx:nginx /usr/share/nginx/html /var/cache/nginx /var/log/nginx /etc/nginx/conf.d \
     && touch /var/run/nginx.pid \
     && chown nginx:nginx /var/run/nginx.pid
 
@@ -39,4 +44,5 @@ USER nginx
 
 EXPOSE 3001
 
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/dashboard/docker-entrypoint.sh
+++ b/dashboard/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Render the nginx config from env at container start, then run the CMD.
+#
+# Runs as the non-root `nginx` user (see Dockerfile), so the built-in
+# nginx:alpine /docker-entrypoint.d mechanism (root-only) is bypassed in favour
+# of this explicit entrypoint. Only ${API_UPSTREAM} and ${LISTEN_PORT} are
+# substituted so nginx's own runtime vars ($host, $uri, ...) survive untouched.
+set -e
+
+: "${API_UPSTREAM:=http://api:8000}"
+: "${LISTEN_PORT:=3001}"
+export API_UPSTREAM LISTEN_PORT
+
+envsubst '${API_UPSTREAM} ${LISTEN_PORT}' \
+    < /etc/nginx/templates/default.conf.template \
+    > /etc/nginx/conf.d/default.conf
+
+exec "$@"

--- a/dashboard/nginx.conf.template
+++ b/dashboard/nginx.conf.template
@@ -1,11 +1,9 @@
 server {
-    listen 3001;
-
-    set $api_upstream http://api:8000;
+    listen ${LISTEN_PORT};
 
     location /api/ {
         resolver 127.0.0.11 valid=30s ipv6=off;
-        proxy_pass $api_upstream;
+        proxy_pass ${API_UPSTREAM};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -14,7 +12,7 @@ server {
 
     location /health {
         resolver 127.0.0.11 valid=30s ipv6=off;
-        proxy_pass $api_upstream;
+        proxy_pass ${API_UPSTREAM};
         proxy_set_header Host $host;
     }
 

--- a/deploy/helm/agentbreeder/.helmignore
+++ b/deploy/helm/agentbreeder/.helmignore
@@ -1,0 +1,4 @@
+.DS_Store
+*.tmp
+ci/
+*.md

--- a/deploy/helm/agentbreeder/Chart.yaml
+++ b/deploy/helm/agentbreeder/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: agentbreeder
+description: Self-host the AgentBreeder platform (Studio + API + Postgres + Redis) on Kubernetes.
+type: application
+version: 0.1.0
+appVersion: "2.6.0"
+home: https://agentbreeder.io
+sources:
+  - https://github.com/agentbreeder/agentbreeder
+dependencies:
+  - name: postgresql
+    version: "15.x.x"
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled
+  - name: redis
+    version: "19.x.x"
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled

--- a/deploy/helm/agentbreeder/templates/NOTES.txt
+++ b/deploy/helm/agentbreeder/templates/NOTES.txt
@@ -4,11 +4,20 @@ AgentBreeder is installing.
   API:     https://{{ .Values.host }}/api/v1
   Docs:    https://{{ .Values.host }}/api/docs
 
+Signing keys (SECRET_KEY / JWT_SECRET_KEY) were auto-generated and stored in the
+{{ include "agentbreeder.fullname" . }}-secrets Secret (preserved across upgrades).
+Set secrets.secretKey/jwtSecretKey or secrets.existingSecret to manage them yourself.
 {{- if not .Values.ingress.tls.enabled }}
 
-⚠  TLS is disabled. For production, set ingress.tls.enabled=true and provide a
-   TLS secret (or use cert-manager). Also override secrets.secretKey and
-   secrets.jwtSecretKey with strong random values.
+⚠  TLS is DISABLED — traffic to https://{{ .Values.host }} is served over plaintext
+   and CORS allows the http:// origin. For any non-eval use, set
+   ingress.tls.enabled=true with a TLS secret (or cert-manager); the chart then
+   adds an HTTP→HTTPS redirect and restricts CORS to https://.
+{{- end }}
+{{- if .Values.postgresql.enabled }}
+
+ℹ  Bundled Postgres/Redis are for evaluation. For production prefer external
+   managed stores (postgresql.enabled=false + externalDatabaseUrl, likewise Redis).
 {{- end }}
 
 Check rollout:

--- a/deploy/helm/agentbreeder/templates/NOTES.txt
+++ b/deploy/helm/agentbreeder/templates/NOTES.txt
@@ -1,0 +1,15 @@
+AgentBreeder is installing.
+
+  Studio:  https://{{ .Values.host }}
+  API:     https://{{ .Values.host }}/api/v1
+  Docs:    https://{{ .Values.host }}/api/docs
+
+{{- if not .Values.ingress.tls.enabled }}
+
+⚠  TLS is disabled. For production, set ingress.tls.enabled=true and provide a
+   TLS secret (or use cert-manager). Also override secrets.secretKey and
+   secrets.jwtSecretKey with strong random values.
+{{- end }}
+
+Check rollout:
+  kubectl get pods -l app=agentbreeder

--- a/deploy/helm/agentbreeder/templates/_helpers.tpl
+++ b/deploy/helm/agentbreeder/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{- define "agentbreeder.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "agentbreeder.apiImage" -}}
+{{- printf "%s/%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.apiImage .Values.image.tag -}}
+{{- end -}}
+
+{{- define "agentbreeder.dashboardImage" -}}
+{{- printf "%s/%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.dashboardImage .Values.image.tag -}}
+{{- end -}}
+
+{{- define "agentbreeder.databaseUrl" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- printf "postgresql+asyncpg://%s:%s@%s-postgresql:5432/%s" .Values.postgresql.auth.username .Values.postgresql.auth.password .Release.Name .Values.postgresql.auth.database -}}
+{{- else -}}
+{{- .Values.externalDatabaseUrl -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "agentbreeder.redisUrl" -}}
+{{- if .Values.redis.enabled -}}
+{{- printf "redis://%s-redis-master:6379" .Release.Name -}}
+{{- else -}}
+{{- .Values.externalRedisUrl -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "agentbreeder.secretName" -}}
+{{- .Values.secrets.existingSecret | default (printf "%s-secrets" (include "agentbreeder.fullname" .)) -}}
+{{- end -}}

--- a/deploy/helm/agentbreeder/templates/_helpers.tpl
+++ b/deploy/helm/agentbreeder/templates/_helpers.tpl
@@ -12,17 +12,19 @@
 
 {{- define "agentbreeder.databaseUrl" -}}
 {{- if .Values.postgresql.enabled -}}
-{{- printf "postgresql+asyncpg://%s:%s@%s-postgresql:5432/%s" .Values.postgresql.auth.username .Values.postgresql.auth.password .Release.Name .Values.postgresql.auth.database -}}
+{{- $pw := required "postgresql.auth.password must be set when postgresql.enabled (e.g. --set postgresql.auth.password=...), or disable it and set externalDatabaseUrl" .Values.postgresql.auth.password -}}
+{{- printf "postgresql+asyncpg://%s:%s@%s-postgresql:5432/%s" .Values.postgresql.auth.username $pw .Release.Name .Values.postgresql.auth.database -}}
 {{- else -}}
-{{- .Values.externalDatabaseUrl -}}
+{{- required "externalDatabaseUrl must be set when postgresql.enabled=false" .Values.externalDatabaseUrl -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "agentbreeder.redisUrl" -}}
 {{- if .Values.redis.enabled -}}
-{{- printf "redis://%s-redis-master:6379" .Release.Name -}}
+{{- $pw := required "redis.auth.password must be set when redis.enabled (e.g. --set redis.auth.password=...), or disable it and set externalRedisUrl" .Values.redis.auth.password -}}
+{{- printf "redis://:%s@%s-redis-master:6379" $pw .Release.Name -}}
 {{- else -}}
-{{- .Values.externalRedisUrl -}}
+{{- required "externalRedisUrl must be set when redis.enabled=false" .Values.externalRedisUrl -}}
 {{- end -}}
 {{- end -}}
 

--- a/deploy/helm/agentbreeder/templates/api-deployment.yaml
+++ b/deploy/helm/agentbreeder/templates/api-deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agentbreeder.fullname" . }}-api
+  labels: { app: agentbreeder, component: api }
+spec:
+  replicas: {{ .Values.api.replicas }}
+  selector:
+    matchLabels: { app: agentbreeder, component: api }
+  template:
+    metadata:
+      labels: { app: agentbreeder, component: api }
+    spec:
+      containers:
+        - name: api
+          image: {{ include "agentbreeder.apiImage" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.api.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "agentbreeder.fullname" . }}-config
+            - secretRef:
+                name: {{ include "agentbreeder.secretName" . }}
+          readinessProbe:
+            httpGet: { path: /health, port: {{ .Values.api.port }} }
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /health, port: {{ .Values.api.port }} }
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources: {{- toYaml .Values.api.resources | nindent 12 }}

--- a/deploy/helm/agentbreeder/templates/api-service.yaml
+++ b/deploy/helm/agentbreeder/templates/api-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agentbreeder.fullname" . }}-api
+  labels: { app: agentbreeder, component: api }
+spec:
+  selector: { app: agentbreeder, component: api }
+  ports:
+    - port: {{ .Values.api.port }}
+      targetPort: {{ .Values.api.port }}

--- a/deploy/helm/agentbreeder/templates/configmap.yaml
+++ b/deploy/helm/agentbreeder/templates/configmap.yaml
@@ -6,7 +6,13 @@ data:
   AGENTBREEDER_ENV: "production"
   # CORS_ORIGINS is parsed as a JSON array by pydantic-settings, so it MUST be
   # JSON — a comma-separated string raises a settings error at API startup.
+  # Only allow the plaintext (http://) origin when TLS is off; with TLS on,
+  # restrict to https:// so credentialed requests never accept a plaintext origin.
+  {{- if .Values.ingress.tls.enabled }}
+  CORS_ORIGINS: {{ printf "[\"https://%s\"]" .Values.host | quote }}
+  {{- else }}
   CORS_ORIGINS: {{ printf "[\"https://%s\",\"http://%s\"]" .Values.host .Values.host | quote }}
+  {{- end }}
   {{- range $k, $v := .Values.api.env }}
   {{ $k }}: {{ $v | quote }}
   {{- end }}

--- a/deploy/helm/agentbreeder/templates/configmap.yaml
+++ b/deploy/helm/agentbreeder/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "agentbreeder.fullname" . }}-config
+data:
+  AGENTBREEDER_ENV: "production"
+  # CORS_ORIGINS is parsed as a JSON array by pydantic-settings, so it MUST be
+  # JSON — a comma-separated string raises a settings error at API startup.
+  CORS_ORIGINS: {{ printf "[\"https://%s\",\"http://%s\"]" .Values.host .Values.host | quote }}
+  {{- range $k, $v := .Values.api.env }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}

--- a/deploy/helm/agentbreeder/templates/dashboard-deployment.yaml
+++ b/deploy/helm/agentbreeder/templates/dashboard-deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agentbreeder.fullname" . }}-dashboard
+  labels: { app: agentbreeder, component: dashboard }
+spec:
+  replicas: {{ .Values.dashboard.replicas }}
+  selector:
+    matchLabels: { app: agentbreeder, component: dashboard }
+  template:
+    metadata:
+      labels: { app: agentbreeder, component: dashboard }
+    spec:
+      containers:
+        - name: dashboard
+          image: {{ include "agentbreeder.dashboardImage" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.dashboard.port }}
+          env:
+            - name: API_UPSTREAM
+              value: {{ printf "http://%s-api:%v" (include "agentbreeder.fullname" .) .Values.api.port | quote }}
+            - name: LISTEN_PORT
+              value: {{ .Values.dashboard.port | quote }}
+          resources: {{- toYaml .Values.dashboard.resources | nindent 12 }}

--- a/deploy/helm/agentbreeder/templates/dashboard-service.yaml
+++ b/deploy/helm/agentbreeder/templates/dashboard-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agentbreeder.fullname" . }}-dashboard
+  labels: { app: agentbreeder, component: dashboard }
+spec:
+  selector: { app: agentbreeder, component: dashboard }
+  ports:
+    - port: {{ .Values.dashboard.port }}
+      targetPort: {{ .Values.dashboard.port }}

--- a/deploy/helm/agentbreeder/templates/ingress.yaml
+++ b/deploy/helm/agentbreeder/templates/ingress.yaml
@@ -3,7 +3,13 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "agentbreeder.fullname" . }}
-  annotations: {{- toYaml .Values.ingress.annotations | nindent 4 }}
+  annotations:
+    {{- if .Values.ingress.tls.enabled }}
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    {{- end }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   {{- if .Values.ingress.tls.enabled }}

--- a/deploy/helm/agentbreeder/templates/ingress.yaml
+++ b/deploy/helm/agentbreeder/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "agentbreeder.fullname" . }}
+  annotations: {{- toYaml .Values.ingress.annotations | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts: [{{ .Values.host | quote }}]
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.host | quote }}
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "agentbreeder.fullname" . }}-api
+                port: { number: {{ .Values.api.port }} }
+          - path: /health
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "agentbreeder.fullname" . }}-api
+                port: { number: {{ .Values.api.port }} }
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "agentbreeder.fullname" . }}-dashboard
+                port: { number: {{ .Values.dashboard.port }} }
+{{- end }}

--- a/deploy/helm/agentbreeder/templates/migrate-job.yaml
+++ b/deploy/helm/agentbreeder/templates/migrate-job.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.migrate.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "agentbreeder.fullname" . }}-migrate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels: { app: agentbreeder, component: migrate }
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          image: {{ include "agentbreeder.apiImage" . }}
+          command: ["alembic", "upgrade", "head"]
+          envFrom:
+            - secretRef:
+                name: {{ include "agentbreeder.secretName" . }}
+{{- end }}

--- a/deploy/helm/agentbreeder/templates/secret.yaml
+++ b/deploy/helm/agentbreeder/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.secrets.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agentbreeder.fullname" . }}-secrets
+type: Opaque
+stringData:
+  SECRET_KEY: {{ .Values.secrets.secretKey | quote }}
+  JWT_SECRET_KEY: {{ .Values.secrets.jwtSecretKey | quote }}
+  DATABASE_URL: {{ include "agentbreeder.databaseUrl" . | quote }}
+  REDIS_URL: {{ include "agentbreeder.redisUrl" . | quote }}
+{{- end }}

--- a/deploy/helm/agentbreeder/templates/secret.yaml
+++ b/deploy/helm/agentbreeder/templates/secret.yaml
@@ -1,12 +1,19 @@
 {{- if not .Values.secrets.existingSecret }}
+{{- $name := printf "%s-secrets" (include "agentbreeder.fullname" .) }}
+{{- /* Reuse existing keys on upgrade so signing keys don't rotate (which would
+       invalidate live sessions); generate strong random keys on first install. */}}
+{{- $prev := (lookup "v1" "Secret" .Release.Namespace $name) }}
+{{- $prevData := (default (dict) $prev).data }}
+{{- $secretKey := .Values.secrets.secretKey | default (get $prevData "SECRET_KEY" | b64dec) | default (randAlphaNum 64) }}
+{{- $jwtKey := .Values.secrets.jwtSecretKey | default (get $prevData "JWT_SECRET_KEY" | b64dec) | default (randAlphaNum 64) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "agentbreeder.fullname" . }}-secrets
+  name: {{ $name }}
 type: Opaque
 stringData:
-  SECRET_KEY: {{ .Values.secrets.secretKey | quote }}
-  JWT_SECRET_KEY: {{ .Values.secrets.jwtSecretKey | quote }}
+  SECRET_KEY: {{ $secretKey | quote }}
+  JWT_SECRET_KEY: {{ $jwtKey | quote }}
   DATABASE_URL: {{ include "agentbreeder.databaseUrl" . | quote }}
   REDIS_URL: {{ include "agentbreeder.redisUrl" . | quote }}
 {{- end }}

--- a/deploy/helm/agentbreeder/values.yaml
+++ b/deploy/helm/agentbreeder/values.yaml
@@ -5,7 +5,9 @@ image:
   repository: rajits
   apiImage: agentbreeder-api
   dashboardImage: agentbreeder-dashboard
-  tag: latest
+  # Pinned to the chart's appVersion (not a mutable `latest`) for reproducible
+  # installs. Override per environment, or pin by digest for supply-chain safety.
+  tag: "2.6.0"
   pullPolicy: IfNotPresent
 
 # Public hostname the platform is served on (used by Ingress + CORS).
@@ -27,11 +29,13 @@ dashboard:
     requests: { cpu: 100m, memory: 128Mi }
     limits: { cpu: 500m, memory: 256Mi }
 
-# Secrets. In production set these via --set or a pre-created secret (existingSecret).
+# Application signing keys. Left empty they are auto-generated (random, and
+# preserved across upgrades via a cluster lookup) so no known default ever ships.
+# Set explicitly, or point existingSecret at a pre-created Secret, to manage them.
 secrets:
   existingSecret: ""        # if set, all keys below are read from this Secret
-  secretKey: "change-me-to-a-random-256-bit-key"
-  jwtSecretKey: "change-me"
+  secretKey: ""             # auto-generated when empty
+  jwtSecretKey: ""          # auto-generated when empty
 
 # Connection strings. When postgresql/redis subcharts are enabled these are
 # auto-derived and these explicit values are ignored.
@@ -51,11 +55,14 @@ ingress:
     secretName: agentbreeder-tls   # pre-created TLS secret, or cert-manager-managed
 
 # Bundled datastores (toggle off to use externalDatabaseUrl/externalRedisUrl).
+# Passwords have NO default — set them explicitly (e.g.
+# `--set postgresql.auth.password=$(openssl rand -hex 16)`) so no known
+# credential ever ships. Install aborts if a bundled store has no password.
 postgresql:
   enabled: true
   auth:
     username: agentbreeder
-    password: agentbreeder
+    password: ""            # REQUIRED when enabled — no default
     database: agentbreeder
   primary:
     persistence:
@@ -65,4 +72,5 @@ redis:
   enabled: true
   architecture: standalone
   auth:
-    enabled: false
+    enabled: true           # auth on by default
+    password: ""            # REQUIRED when enabled — no default

--- a/deploy/helm/agentbreeder/values.yaml
+++ b/deploy/helm/agentbreeder/values.yaml
@@ -1,0 +1,68 @@
+# AgentBreeder self-hosting values. See website/content/docs/self-hosting.mdx.
+
+image:
+  registry: docker.io
+  repository: rajits
+  apiImage: agentbreeder-api
+  dashboardImage: agentbreeder-dashboard
+  tag: latest
+  pullPolicy: IfNotPresent
+
+# Public hostname the platform is served on (used by Ingress + CORS).
+host: agentbreeder.local
+
+api:
+  replicas: 1
+  port: 8000
+  resources:
+    requests: { cpu: 250m, memory: 512Mi }
+    limits: { cpu: "1", memory: 1Gi }
+  # Extra non-secret env passed to the API container.
+  env: {}
+
+dashboard:
+  replicas: 1
+  port: 3001
+  resources:
+    requests: { cpu: 100m, memory: 128Mi }
+    limits: { cpu: 500m, memory: 256Mi }
+
+# Secrets. In production set these via --set or a pre-created secret (existingSecret).
+secrets:
+  existingSecret: ""        # if set, all keys below are read from this Secret
+  secretKey: "change-me-to-a-random-256-bit-key"
+  jwtSecretKey: "change-me"
+
+# Connection strings. When postgresql/redis subcharts are enabled these are
+# auto-derived and these explicit values are ignored.
+externalDatabaseUrl: ""     # e.g. postgresql+asyncpg://user:pw@host:5432/db
+externalRedisUrl: ""        # e.g. redis://host:6379
+
+# Run `alembic upgrade head` as a pre-install/upgrade Job.
+migrate:
+  enabled: true
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations: {}
+  tls:
+    enabled: false
+    secretName: agentbreeder-tls   # pre-created TLS secret, or cert-manager-managed
+
+# Bundled datastores (toggle off to use externalDatabaseUrl/externalRedisUrl).
+postgresql:
+  enabled: true
+  auth:
+    username: agentbreeder
+    password: agentbreeder
+    database: agentbreeder
+  primary:
+    persistence:
+      size: 8Gi
+
+redis:
+  enabled: true
+  architecture: standalone
+  auth:
+    enabled: false

--- a/docs/superpowers/plans/2026-05-31-cloud-agnostic-p4-mcp-p5-selfhosting.md
+++ b/docs/superpowers/plans/2026-05-31-cloud-agnostic-p4-mcp-p5-selfhosting.md
@@ -1,0 +1,1698 @@
+# Cloud-Agnostic Epic — P4 (MCP Deployment) + P5 (Studio Self-Hosting) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `mcp_servers:` in `agent.yaml` actually reach the deployed agent (resolve refs → forward via the Go sidecar, optionally co-deploying MCP server containers), and ship a Helm chart + env-driven nginx so the whole AgentBreeder platform (Studio + API + DB) self-hosts on Kubernetes with one command.
+
+**Architecture:**
+- **P4:** A pure resolver turns each `McpServerRef` into a `ResolvedMcpServer` (remote URL, or a co-deployed container image on a localhost port). The 4 multi-container deployers (ECS, Cloud Run, Azure Container Apps, docker-compose) co-deploy image-backed MCP servers as non-essential containers and hand the AgentBreeder Go sidecar a `{name:{transport,url}}` JSON map via `AGENTBREEDER_SIDECAR_MCP_SERVERS`. The Go sidecar's `overlayEnv()` parses that env into its existing `MCPServers` map, so `POST localhost:9091/mcp/<server>` forwards correctly.
+- **P5:** The dashboard nginx config becomes a runtime `envsubst` template (`API_UPSTREAM`, `CORS_*`, `TLS_*`) rendered by an entrypoint. A new Helm chart at `deploy/helm/agentbreeder/` reproduces the compose topology (api, dashboard, migrate Job) with Bitnami Postgres + Redis as **toggleable** subchart dependencies, a TLS-capable Ingress, and Secrets/ConfigMaps. A `self-hosting.mdx` doc covers install + config.
+
+**Tech Stack:** Python 3.11+ (pydantic, pytest), Go 1.22 (sidecar), Helm 3 / Kubernetes, nginx (envsubst), Fumadocs MDX.
+
+**One combined PR** (branch `feat/cloud-agnostic-p4p5`). Commit per task. Defer PR until both parts green locally. Get explicit OK before any `--admin` merge.
+
+---
+
+## File Structure
+
+**P4 — created/modified:**
+- Modify `engine/config_parser.py` — add optional `url`/`image`/`port` to `McpServerRef`.
+- Modify `engine/schema/agent.schema.json` — mirror new `mcp_servers[]` item fields.
+- Rewrite `engine/deployers/mcp_sidecar.py` — `ResolvedMcpServer`, `resolve_mcp_servers()`, `build_sidecar_env_map()`, and 4 container-injection helpers; keep `generate_sidecars`/`inject_into_compose` shims for the existing tests.
+- Modify `engine/sidecar/config.py` — `SidecarConfig.mcp_servers` + populate in `from_agent_config`.
+- Modify `engine/sidecar/injector.py` — emit `AGENTBREEDER_SIDECAR_MCP_SERVERS` in the 3 injectors.
+- Modify `sidecar/internal/config/config.go` — parse MCP-servers JSON env in `overlayEnv()`.
+- Modify `engine/deployers/{aws_ecs,gcp_cloudrun,azure_container_apps,docker_compose}.py` — call resolve + co-deploy injection.
+- Tests: `tests/unit/test_mcp_resolve.py`, extend `tests/unit/test_mcp_packager.py`, `tests/unit/test_sidecar_injector.py`; `sidecar/internal/config/config_test.go`.
+- Docs: `website/content/docs/mcp-servers.mdx`, `agent-yaml.mdx`, `sidecar.mdx`, `CHANGELOG.md`.
+
+**P5 — created/modified:**
+- Create `dashboard/nginx.conf.template`, `dashboard/docker-entrypoint.sh`; modify `dashboard/Dockerfile`; delete/retire `dashboard/nginx.conf` (replaced by template).
+- Create `deploy/helm/agentbreeder/{Chart.yaml,values.yaml,.helmignore,README.md}` and `deploy/helm/agentbreeder/templates/{_helpers.tpl,configmap.yaml,secret.yaml,api-deployment.yaml,api-service.yaml,dashboard-deployment.yaml,dashboard-service.yaml,migrate-job.yaml,ingress.yaml,NOTES.txt}`.
+- Tests: `tests/unit/test_nginx_template.py` (render check), `tests/unit/test_helm_chart.py` (lint/template, skipped if `helm` absent).
+- Docs: `website/content/docs/self-hosting.mdx`, `website/content/docs/meta.json`, `README.md`, `CHANGELOG.md`.
+
+---
+
+## Part A — P4: MCP Server Deployment
+
+### Task A1: Extend `McpServerRef` schema with inline connection fields
+
+**Files:**
+- Modify: `engine/config_parser.py` (`McpServerRef`, ~line 144-148)
+- Modify: `engine/schema/agent.schema.json` (`mcp_servers` items, ~line 537-565)
+- Test: `tests/unit/test_mcp_resolve.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_mcp_resolve.py
+"""Tests for MCP server ref parsing + resolution (P4)."""
+
+from __future__ import annotations
+
+
+class TestMcpServerRefFields:
+    def test_ref_only_defaults(self):
+        from engine.config_parser import McpServerRef
+
+        ref = McpServerRef(ref="mcp/zendesk")
+        assert ref.ref == "mcp/zendesk"
+        assert ref.transport == "stdio"
+        assert ref.url is None
+        assert ref.image is None
+        assert ref.port is None
+
+    def test_inline_remote(self):
+        from engine.config_parser import McpServerRef
+
+        ref = McpServerRef(ref="mcp/zendesk", transport="sse", url="https://mcp.acme.com/sse")
+        assert ref.url == "https://mcp.acme.com/sse"
+
+    def test_inline_image(self):
+        from engine.config_parser import McpServerRef
+
+        ref = McpServerRef(ref="mcp/slack", transport="sse", image="acme/mcp-slack:1.2.3", port=3100)
+        assert ref.image == "acme/mcp-slack:1.2.3"
+        assert ref.port == 3100
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/unit/test_mcp_resolve.py -v`
+Expected: FAIL — `McpServerRef` has no field `url`.
+
+- [ ] **Step 3: Implement**
+
+In `engine/config_parser.py`, replace the `McpServerRef` class:
+
+```python
+class McpServerRef(BaseModel):
+    """Reference to an MCP server to attach to an agent.
+
+    ``ref`` is the registry reference (e.g. ``mcp/zendesk``). For self-contained
+    deploys the connection can be given inline so no running registry is needed:
+    set ``url`` for a remote HTTP/SSE MCP server, or ``image`` to co-deploy a
+    container MCP server as a sidecar (reachable on ``port`` over localhost).
+    """
+
+    ref: str
+    transport: str = "stdio"
+    url: str | None = None
+    image: str | None = None
+    port: int | None = None
+```
+
+In `engine/schema/agent.schema.json`, extend the `mcp_servers` items `properties` (keep `ref` required, add):
+
+```json
+"url": {
+  "type": "string",
+  "description": "Remote HTTP/SSE MCP server URL. When set, the sidecar forwards to it directly."
+},
+"image": {
+  "type": "string",
+  "description": "Container image to co-deploy as an MCP sidecar (reachable over localhost)."
+},
+"port": {
+  "type": "integer",
+  "minimum": 1,
+  "maximum": 65535,
+  "description": "Localhost port for a co-deployed MCP sidecar container. Auto-assigned from 3100 if omitted."
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/unit/test_mcp_resolve.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/config_parser.py engine/schema/agent.schema.json tests/unit/test_mcp_resolve.py
+git commit -m "feat(mcp): inline url/image/port on McpServerRef for self-contained deploys"
+```
+
+---
+
+### Task A2: `resolve_mcp_servers()` + `ResolvedMcpServer` + env map
+
+**Files:**
+- Modify (rewrite, keep back-compat shims): `engine/deployers/mcp_sidecar.py`
+- Test: `tests/unit/test_mcp_resolve.py` (append)
+
+Resolution rules (per `McpServerRef`, index `i`, `base_port=3100`):
+1. `name = ref.split("/")[-1]`, `transport = ref.transport`.
+2. If `ref.url` → **remote**: `url=ref.url`, `co_deploy=False`, `image=None`.
+3. elif `ref.image` → **co-deploy**: `image=ref.image`, `port=ref.port or base_port+i`, `url=f"http://localhost:{port}"`, `co_deploy=True`.
+4. else, if `registry_lookup(name)` returns info with `endpoint` → remote (`url=endpoint`); with `image_uri` → co-deploy (`image=image_uri`, port auto).
+5. else → **convention co-deploy**: `image=build_image_tag(name, "latest", registry_prefix)`, port auto, `url=localhost:port`, `co_deploy=True`.
+
+The Go sidecar only forwards `http`/`sse` (`stdio` returns an error). So `build_sidecar_env_map()` normalises a co-deployed `stdio` transport to `http` in the emitted map (the co-deployed container speaks HTTP on its port via `MCP_TRANSPORT`), and **skips** remote `stdio` servers (can't forward) with a logged warning.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/unit/test_mcp_resolve.py
+
+class TestResolveMcpServers:
+    def test_remote_url(self):
+        from engine.config_parser import McpServerRef
+        from engine.deployers.mcp_sidecar import resolve_mcp_servers
+
+        out = resolve_mcp_servers([McpServerRef(ref="mcp/z", transport="sse", url="https://x/sse")])
+        assert len(out) == 1
+        r = out[0]
+        assert r.name == "z" and r.co_deploy is False
+        assert r.url == "https://x/sse" and r.image is None
+
+    def test_inline_image_autoport(self):
+        from engine.config_parser import McpServerRef
+        from engine.deployers.mcp_sidecar import resolve_mcp_servers
+
+        out = resolve_mcp_servers(
+            [McpServerRef(ref="mcp/a", transport="sse", image="img:1")],
+            base_port=3100,
+        )
+        r = out[0]
+        assert r.co_deploy is True and r.image == "img:1"
+        assert r.port == 3100 and r.url == "http://localhost:3100"
+
+    def test_convention_fallback(self):
+        from engine.config_parser import McpServerRef
+        from engine.deployers.mcp_sidecar import resolve_mcp_servers
+
+        out = resolve_mcp_servers([McpServerRef(ref="mcp/slack", transport="sse")])
+        r = out[0]
+        assert r.co_deploy is True
+        assert r.image == "agentbreeder/mcp-slack:latest"
+        assert r.url == "http://localhost:3100"
+
+    def test_registry_lookup_endpoint(self):
+        from engine.config_parser import McpServerRef
+        from engine.deployers.mcp_sidecar import McpServerInfo, resolve_mcp_servers
+
+        def lookup(name):
+            return McpServerInfo(name=name, transport="sse", endpoint="https://reg/sse")
+
+        out = resolve_mcp_servers([McpServerRef(ref="mcp/z")], registry_lookup=lookup)
+        assert out[0].url == "https://reg/sse" and out[0].co_deploy is False
+
+    def test_env_map_skips_remote_stdio(self):
+        from engine.config_parser import McpServerRef
+        from engine.deployers.mcp_sidecar import build_sidecar_env_map, resolve_mcp_servers
+
+        out = resolve_mcp_servers([McpServerRef(ref="mcp/z", transport="stdio", url="http://x")])
+        env = build_sidecar_env_map(out)
+        assert env == {}  # remote stdio can't be forwarded
+
+    def test_env_map_normalises_codeploy_stdio_to_http(self):
+        from engine.config_parser import McpServerRef
+        from engine.deployers.mcp_sidecar import build_sidecar_env_map, resolve_mcp_servers
+
+        out = resolve_mcp_servers([McpServerRef(ref="mcp/a", transport="stdio", image="img:1")])
+        env = build_sidecar_env_map(out)
+        assert env == {"a": {"transport": "http", "url": "http://localhost:3100"}}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/unit/test_mcp_resolve.py::TestResolveMcpServers -v`
+Expected: FAIL — `resolve_mcp_servers` not defined.
+
+- [ ] **Step 3: Implement** — replace `engine/deployers/mcp_sidecar.py` with:
+
+```python
+"""MCP sidecar deployer — resolves MCP server refs and co-deploys them.
+
+When an agent references MCP servers in its config this module:
+  * resolves each ``McpServerRef`` into a :class:`ResolvedMcpServer`
+    (a remote HTTP/SSE URL, or a co-deployed container image on a localhost
+    port), and
+  * injects co-deployed MCP server containers into each cloud deployer's
+    container set, alongside the AgentBreeder sidecar.
+
+The AgentBreeder Go sidecar forwards ``POST localhost:9091/mcp/<server>`` to the
+resolved URL; :func:`build_sidecar_env_map` produces the ``{name:{transport,url}}``
+map handed to it via ``AGENTBREEDER_SIDECAR_MCP_SERVERS``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from engine.config_parser import McpServerRef
+from engine.mcp.packager import build_image_tag, generate_sidecar_config
+
+logger = logging.getLogger(__name__)
+
+# Co-deployed MCP sidecar containers get localhost ports starting here. 3100 sits
+# above the agent (8080/8081) and AgentBreeder sidecar localhost ports (9090-9092).
+DEFAULT_BASE_PORT = 3100
+
+
+@dataclass
+class McpServerInfo:
+    """Registry-sourced facts about an MCP server (best-effort enrichment)."""
+
+    name: str
+    transport: str = "stdio"
+    endpoint: str | None = None
+    image_uri: str | None = None
+
+
+@dataclass
+class ResolvedMcpServer:
+    """A fully-resolved MCP server ready to wire into a deploy."""
+
+    name: str
+    transport: str
+    url: str
+    co_deploy: bool
+    image: str | None = None
+    port: int | None = None
+    ref: str = ""
+
+
+def resolve_mcp_servers(
+    mcp_servers: list[McpServerRef],
+    *,
+    registry_lookup: Callable[[str], McpServerInfo | None] | None = None,
+    base_port: int = DEFAULT_BASE_PORT,
+    registry_prefix: str = "agentbreeder",
+) -> list[ResolvedMcpServer]:
+    """Resolve agent.yaml MCP refs into concrete, deployable servers."""
+    resolved: list[ResolvedMcpServer] = []
+    for i, mcp in enumerate(mcp_servers):
+        name = mcp.ref.split("/")[-1]
+        transport = mcp.transport
+        port = mcp.port or (base_port + i)
+
+        if mcp.url:
+            resolved.append(
+                ResolvedMcpServer(name, transport, mcp.url, False, ref=mcp.ref)
+            )
+            continue
+        if mcp.image:
+            resolved.append(
+                ResolvedMcpServer(
+                    name, transport, f"http://localhost:{port}", True,
+                    image=mcp.image, port=port, ref=mcp.ref,
+                )
+            )
+            continue
+
+        info = registry_lookup(name) if registry_lookup else None
+        if info and info.endpoint:
+            resolved.append(
+                ResolvedMcpServer(name, info.transport or transport, info.endpoint, False, ref=mcp.ref)
+            )
+            continue
+        if info and info.image_uri:
+            resolved.append(
+                ResolvedMcpServer(
+                    name, info.transport or transport, f"http://localhost:{port}", True,
+                    image=info.image_uri, port=port, ref=mcp.ref,
+                )
+            )
+            continue
+
+        # Convention fallback: co-deploy a conventionally-named image.
+        image = build_image_tag(name, "latest", registry_prefix)
+        resolved.append(
+            ResolvedMcpServer(
+                name, transport, f"http://localhost:{port}", True,
+                image=image, port=port, ref=mcp.ref,
+            )
+        )
+        logger.info("Resolved MCP '%s' by convention → %s", name, image)
+
+    return resolved
+
+
+def build_sidecar_env_map(resolved: list[ResolvedMcpServer]) -> dict[str, dict[str, str]]:
+    """Build the ``{name:{transport,url}}`` map for the Go sidecar.
+
+    The Go sidecar can only forward HTTP/SSE. Co-deployed servers always speak
+    HTTP on their localhost port (we set ``MCP_TRANSPORT`` on the container), so a
+    co-deployed ``stdio`` transport is normalised to ``http``. A *remote* ``stdio``
+    server cannot be forwarded and is skipped with a warning.
+    """
+    out: dict[str, dict[str, str]] = {}
+    for r in resolved:
+        transport = r.transport
+        if transport == "stdio":
+            if r.co_deploy:
+                transport = "http"
+            else:
+                logger.warning(
+                    "MCP '%s' uses remote stdio transport — the sidecar cannot "
+                    "forward it; skipping. Use http/sse or co-deploy an image.",
+                    r.name,
+                )
+                continue
+        out[r.name] = {"transport": transport, "url": r.url}
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Container co-deploy injection — one helper per multi-container deployer.
+# All are idempotent (skip a server whose container already exists) and never
+# mutate their input.
+# --------------------------------------------------------------------------- #
+
+
+def _codeploy(resolved: list[ResolvedMcpServer]) -> list[ResolvedMcpServer]:
+    return [r for r in resolved if r.co_deploy and r.image]
+
+
+def inject_mcp_containers_ecs(
+    task_definition: dict[str, Any], resolved: list[ResolvedMcpServer]
+) -> dict[str, Any]:
+    """Append co-deployed MCP server containers to an ECS task definition."""
+    import copy
+
+    result = copy.deepcopy(task_definition)
+    containers: list[dict[str, Any]] = result.setdefault("containerDefinitions", [])
+    existing = {c.get("name") for c in containers}
+    for r in _codeploy(resolved):
+        cname = f"mcp-{r.name}"
+        if cname in existing:
+            continue
+        containers.append(
+            {
+                "name": cname,
+                "image": r.image,
+                "essential": False,
+                "portMappings": [{"containerPort": r.port, "protocol": "tcp"}],
+                "environment": [
+                    {"name": "MCP_TRANSPORT", "value": "http"},
+                    {"name": "PORT", "value": str(r.port)},
+                ],
+            }
+        )
+    return result
+
+
+def inject_mcp_containers_cloudrun(
+    service_spec: dict[str, Any], resolved: list[ResolvedMcpServer]
+) -> dict[str, Any]:
+    """Append co-deployed MCP server containers to a Cloud Run v2 service spec."""
+    import copy
+
+    result = copy.deepcopy(service_spec)
+    spec = result.setdefault("spec", {})
+    template = spec.setdefault("template", {})
+    tmpl_spec = template.setdefault("spec", {})
+    containers: list[dict[str, Any]] = tmpl_spec.setdefault("containers", [])
+    existing = {c.get("name") for c in containers}
+    for r in _codeploy(resolved):
+        cname = f"mcp-{r.name}"
+        if cname in existing:
+            continue
+        containers.append(
+            {
+                "name": cname,
+                "image": r.image,
+                "env": [
+                    {"name": "MCP_TRANSPORT", "value": "http"},
+                    {"name": "PORT", "value": str(r.port)},
+                ],
+                "ports": [{"containerPort": r.port}],
+            }
+        )
+    return result
+
+
+def inject_mcp_containers_azure(
+    containers: list[dict[str, Any]], resolved: list[ResolvedMcpServer]
+) -> list[dict[str, Any]]:
+    """Append co-deployed MCP containers to an Azure Container Apps container list."""
+    import copy
+
+    result = copy.deepcopy(containers)
+    existing = {c.get("name") for c in result}
+    for r in _codeploy(resolved):
+        cname = f"mcp-{r.name}"
+        if cname in existing:
+            continue
+        result.append(
+            {
+                "name": cname,
+                "image": r.image,
+                "env": [
+                    {"name": "MCP_TRANSPORT", "value": "http"},
+                    {"name": "PORT", "value": str(r.port)},
+                ],
+            }
+        )
+    return result
+
+
+def inject_mcp_containers_compose(
+    services: dict[str, Any], resolved: list[ResolvedMcpServer]
+) -> dict[str, Any]:
+    """Append co-deployed MCP server services to a docker-compose services dict."""
+    import copy
+
+    result = copy.deepcopy(services)
+    for r in _codeploy(resolved):
+        sname = f"mcp-{r.name}"
+        if sname in result:
+            continue
+        result[sname] = {
+            "image": r.image,
+            "environment": {"MCP_TRANSPORT": "http", "PORT": str(r.port)},
+            "restart": "unless-stopped",
+        }
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Back-compat shims — keep the original McpSidecarDeployer surface so existing
+# tests (tests/unit/test_mcp_packager.py) and any callers keep working.
+# --------------------------------------------------------------------------- #
+
+
+class McpSidecarDeployer:
+    """Legacy helper retained for compose generation + tests."""
+
+    def generate_sidecars(
+        self,
+        mcp_servers: list[McpServerRef],
+        agent_name: str,
+        registry_prefix: str = "agentbreeder",
+    ) -> list[dict[str, Any]]:
+        sidecars: list[dict[str, Any]] = []
+        for i, mcp in enumerate(mcp_servers):
+            server_name = mcp.ref.split("/")[-1]
+            image_uri = build_image_tag(server_name, "latest", registry_prefix)
+            sidecar = generate_sidecar_config(
+                name=server_name, image_uri=image_uri, transport=mcp.transport, port=3000 + i
+            )
+            sidecar["labels"] = {
+                "agentbreeder.agent": agent_name,
+                "agentbreeder.mcp-ref": mcp.ref,
+            }
+            sidecars.append(sidecar)
+        return sidecars
+
+    def inject_into_compose(
+        self, compose_config: dict[str, Any], sidecars: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        services = compose_config.setdefault("services", {})
+        for sidecar in sidecars:
+            services[sidecar["name"]] = {
+                "image": sidecar["image"],
+                "environment": sidecar.get("environment", {}),
+                "ports": [f"{sidecar['port']}:{sidecar['port']}"],
+                "labels": sidecar.get("labels", {}),
+                "restart": "unless-stopped",
+            }
+        return compose_config
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/unit/test_mcp_resolve.py tests/unit/test_mcp_packager.py -v`
+Expected: PASS (new resolve tests + the 14 existing packager tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/deployers/mcp_sidecar.py tests/unit/test_mcp_resolve.py
+git commit -m "feat(mcp): resolve_mcp_servers + co-deploy container injectors"
+```
+
+---
+
+### Task A3: Go sidecar parses MCP servers from env
+
+**Files:**
+- Modify: `sidecar/internal/config/config.go` (`overlayEnv`, ~line 162-189)
+- Test: `sidecar/internal/config/config_test.go` (append)
+
+- [ ] **Step 1: Write the failing Go test**
+
+```go
+// append to sidecar/internal/config/config_test.go (package config)
+
+func TestOverlayEnvMCPServers(t *testing.T) {
+	t.Setenv("AGENT_NAME", "a")
+	t.Setenv("AGENTBREEDER_SIDECAR_ALLOW_NO_AUTH", "1")
+	t.Setenv("AGENTBREEDER_SIDECAR_MCP_SERVERS",
+		`{"zendesk":{"transport":"http","url":"http://localhost:3100"}}`)
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	spec, ok := cfg.MCPServers["zendesk"]
+	if !ok {
+		t.Fatalf("zendesk not parsed: %+v", cfg.MCPServers)
+	}
+	if spec.Transport != "http" || spec.URL != "http://localhost:3100" {
+		t.Fatalf("bad spec: %+v", spec)
+	}
+}
+
+func TestOverlayEnvMCPServersWinsOverFile(t *testing.T) {
+	t.Setenv("AGENT_NAME", "a")
+	t.Setenv("AGENTBREEDER_SIDECAR_ALLOW_NO_AUTH", "1")
+	t.Setenv("AGENTBREEDER_SIDECAR_MCP_SERVERS",
+		`{"z":{"transport":"sse","url":"http://env"}}`)
+	c := &Config{MCPServers: map[string]MCPServerSpec{
+		"z": {Transport: "http", URL: "http://file"},
+	}}
+	c.overlayEnv()
+	if c.MCPServers["z"].URL != "http://env" {
+		t.Fatalf("env should win: %+v", c.MCPServers["z"])
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd sidecar && go test ./internal/config/ -run TestOverlayEnvMCPServers -v`
+Expected: FAIL — env var not read.
+
+- [ ] **Step 3: Implement** — in `sidecar/internal/config/config.go`, add `"encoding/json"` to imports, then at the end of `overlayEnv()` (after the OTLP headers block) add:
+
+```go
+	// MCP server map as JSON: {"name":{"transport":"http","url":"..."}}.
+	// Env entries override file entries key-by-key so a deployer can wire MCP
+	// upstreams without shipping a YAML file.
+	if raw := os.Getenv("AGENTBREEDER_SIDECAR_MCP_SERVERS"); raw != "" {
+		parsed := map[string]MCPServerSpec{}
+		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+			fmt.Fprintf(os.Stderr, "sidecar: ignoring malformed AGENTBREEDER_SIDECAR_MCP_SERVERS: %v\n", err)
+		} else {
+			if c.MCPServers == nil {
+				c.MCPServers = map[string]MCPServerSpec{}
+			}
+			for name, spec := range parsed {
+				c.MCPServers[name] = spec
+			}
+		}
+	}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd sidecar && go test ./internal/config/ -v`
+Expected: PASS (new + existing config tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/internal/config/config.go sidecar/internal/config/config_test.go
+git commit -m "feat(sidecar): parse MCP servers from AGENTBREEDER_SIDECAR_MCP_SERVERS env"
+```
+
+---
+
+### Task A4: `SidecarConfig.mcp_servers` populated from agent config
+
+**Files:**
+- Modify: `engine/sidecar/config.py` (`SidecarConfig`, `from_agent_config`)
+- Test: `tests/unit/test_sidecar_injector.py` (append a `TestSidecarConfigMcp` class)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/unit/test_sidecar_injector.py
+
+class TestSidecarConfigMcp:
+    def _agent(self, mcp):
+        from engine.config_parser import McpServerRef
+
+        class _A:
+            guardrails = []
+            mcp_servers = [McpServerRef(**m) for m in mcp]
+
+        return _A()
+
+    def test_mcp_servers_populated_from_image(self):
+        from engine.sidecar.config import SidecarConfig
+
+        sc = SidecarConfig.from_agent_config(
+            self._agent([{"ref": "mcp/a", "transport": "sse", "image": "img:1", "port": 3100}])
+        )
+        assert sc.mcp_servers == {"a": {"transport": "sse", "url": "http://localhost:3100"}}
+
+    def test_no_mcp_means_empty(self):
+        from engine.sidecar.config import SidecarConfig
+
+        sc = SidecarConfig.from_agent_config(self._agent([]))
+        assert sc.mcp_servers == {}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/unit/test_sidecar_injector.py::TestSidecarConfigMcp -v`
+Expected: FAIL — `SidecarConfig` has no `mcp_servers`.
+
+- [ ] **Step 3: Implement** — in `engine/sidecar/config.py`:
+
+Add field to the dataclass (after `api_url_env`):
+
+```python
+    # MCP server forwarding map for the Go sidecar: {name: {transport, url}}.
+    mcp_servers: dict[str, dict[str, str]] = field(default_factory=dict)
+```
+
+In `from_agent_config`, replace the body with:
+
+```python
+    @classmethod
+    def from_agent_config(cls, agent_config: Any) -> SidecarConfig:
+        """Build a SidecarConfig from a parsed AgentConfig.
+
+        Reads top-level guardrails and resolves any ``mcp_servers`` into the
+        forwarding map the Go sidecar consumes. MCP resolution here is offline
+        (inline url/image + convention) — registry enrichment happens earlier
+        in the deploy pipeline when a session is available.
+        """
+        guardrails = _normalise_guardrails(getattr(agent_config, "guardrails", []) or [])
+        mcp_refs = getattr(agent_config, "mcp_servers", None) or []
+        mcp_map: dict[str, dict[str, str]] = {}
+        if mcp_refs:
+            from engine.deployers.mcp_sidecar import build_sidecar_env_map, resolve_mcp_servers
+
+            mcp_map = build_sidecar_env_map(resolve_mcp_servers(mcp_refs))
+        return cls(enabled=True, guardrails=guardrails, mcp_servers=mcp_map)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/unit/test_sidecar_injector.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/sidecar/config.py tests/unit/test_sidecar_injector.py
+git commit -m "feat(sidecar): SidecarConfig.mcp_servers resolved from agent config"
+```
+
+---
+
+### Task A5: Injectors emit `AGENTBREEDER_SIDECAR_MCP_SERVERS`
+
+**Files:**
+- Modify: `engine/sidecar/injector.py` (the 3 injectors)
+- Test: `tests/unit/test_sidecar_injector.py` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/unit/test_sidecar_injector.py
+import json
+
+
+class TestInjectorMcpEnv:
+    def _cfg(self):
+        from engine.sidecar.config import SidecarConfig
+
+        return SidecarConfig(mcp_servers={"a": {"transport": "http", "url": "http://localhost:3100"}})
+
+    def _env_value(self, env_list):
+        # ECS/CloudRun env are lists of {"name","value"}
+        for e in env_list:
+            if e["name"] == "AGENTBREEDER_SIDECAR_MCP_SERVERS":
+                return e["value"]
+        return None
+
+    def test_ecs_emits_mcp_env(self):
+        from engine.sidecar.injector import inject_sidecar
+
+        td = inject_sidecar({}, self._cfg())
+        sidecar = [c for c in td["containerDefinitions"] if c["name"] == "agentbreeder-sidecar"][0]
+        val = self._env_value(sidecar["environment"])
+        assert json.loads(val) == {"a": {"transport": "http", "url": "http://localhost:3100"}}
+
+    def test_cloudrun_emits_mcp_env(self):
+        from engine.sidecar.injector import inject_cloudrun_sidecar
+
+        spec = inject_cloudrun_sidecar({}, self._cfg())
+        containers = spec["spec"]["template"]["spec"]["containers"]
+        sidecar = [c for c in containers if c["name"] == "agentbreeder-sidecar"][0]
+        assert self._env_value(sidecar["env"]) is not None
+
+    def test_compose_emits_mcp_env(self):
+        from engine.sidecar.injector import inject_compose_sidecar
+
+        services = inject_compose_sidecar({}, self._cfg())
+        env = services["agentbreeder-sidecar"]["environment"]
+        assert json.loads(env["AGENTBREEDER_SIDECAR_MCP_SERVERS"]) == {
+            "a": {"transport": "http", "url": "http://localhost:3100"}
+        }
+
+    def test_no_mcp_no_env(self):
+        from engine.sidecar.config import SidecarConfig
+        from engine.sidecar.injector import inject_compose_sidecar
+
+        services = inject_compose_sidecar({}, SidecarConfig())
+        assert "AGENTBREEDER_SIDECAR_MCP_SERVERS" not in services["agentbreeder-sidecar"]["environment"]
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/unit/test_sidecar_injector.py::TestInjectorMcpEnv -v`
+Expected: FAIL — env not emitted.
+
+- [ ] **Step 3: Implement** — in `engine/sidecar/injector.py`, add at top: `import json`. Then in each injector, conditionally append the env entry.
+
+In `inject_sidecar`, after building `sidecar_container["environment"]` list, before `containers.append`:
+
+```python
+    if config.mcp_servers:
+        sidecar_container["environment"].append(
+            {"name": "AGENTBREEDER_SIDECAR_MCP_SERVERS", "value": json.dumps(config.mcp_servers)}
+        )
+```
+
+In `inject_cloudrun_sidecar`, after building `sidecar["env"]`, before `containers.append`:
+
+```python
+    if config.mcp_servers:
+        sidecar["env"].append(
+            {"name": "AGENTBREEDER_SIDECAR_MCP_SERVERS", "value": json.dumps(config.mcp_servers)}
+        )
+```
+
+In `inject_compose_sidecar`, after the `result[SIDECAR_NAME] = {...}` assignment:
+
+```python
+    if config.mcp_servers:
+        result[SIDECAR_NAME]["environment"]["AGENTBREEDER_SIDECAR_MCP_SERVERS"] = json.dumps(
+            config.mcp_servers
+        )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest tests/unit/test_sidecar_injector.py -v`
+Expected: PASS (all, including pre-existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/sidecar/injector.py tests/unit/test_sidecar_injector.py
+git commit -m "feat(sidecar): emit AGENTBREEDER_SIDECAR_MCP_SERVERS env in all injectors"
+```
+
+---
+
+### Task A6: Wire co-deploy + registry enrichment into the 4 deployers
+
+Each multi-container deployer already calls `should_inject(config)` and builds `SidecarConfig.from_agent_config(config)`. Add: resolve once (with best-effort registry enrichment), co-deploy image-backed MCP containers, and ensure the resolved map reaches the sidecar (it already does via `from_agent_config`, but the deployer's resolution may have registry data the offline path lacks — so override `sc.mcp_servers`).
+
+**Files:**
+- Modify: `engine/deployers/aws_ecs.py` (~line 464-477)
+- Modify: `engine/deployers/gcp_cloudrun.py` (~line 258-265, 308)
+- Modify: `engine/deployers/azure_container_apps.py` (~line 334, 521)
+- Modify: `engine/deployers/docker_compose.py` (~line 305-380)
+- Test: `tests/unit/test_mcp_deploy_wiring.py` (new)
+
+Registry enrichment is best-effort and **must not** require a DB: define a module-level helper in `mcp_sidecar.py` that returns `None` lookups by default; deployers pass `registry_lookup=None` for now (inline/convention resolution). This keeps deploy self-contained; a real session-backed lookup is a future enhancement noted in docs.
+
+> Because `SidecarConfig.from_agent_config` already resolves the same refs offline, the deployer change is: **(a)** compute `resolved = resolve_mcp_servers(config.mcp_servers)` once when `config.mcp_servers` is truthy, and **(b)** call the matching `inject_mcp_containers_*` on the container structure. The sidecar env map is already correct from `from_agent_config`.
+
+- [ ] **Step 1: Write the failing test** (drives ECS + compose wiring; cloud-run/azure mirror them)
+
+```python
+# tests/unit/test_mcp_deploy_wiring.py
+"""MCP co-deploy container injection is wired into the deployers (P4)."""
+
+from __future__ import annotations
+
+
+def test_ecs_injects_codeploy_container():
+    from engine.deployers.mcp_sidecar import inject_mcp_containers_ecs, resolve_mcp_servers
+    from engine.config_parser import McpServerRef
+
+    resolved = resolve_mcp_servers([McpServerRef(ref="mcp/a", transport="sse", image="img:1", port=3100)])
+    td = inject_mcp_containers_ecs({"containerDefinitions": [{"name": "app"}]}, resolved)
+    names = {c["name"] for c in td["containerDefinitions"]}
+    assert "mcp-a" in names and "app" in names
+    mcp = [c for c in td["containerDefinitions"] if c["name"] == "mcp-a"][0]
+    assert mcp["image"] == "img:1"
+    assert mcp["essential"] is False
+    assert mcp["portMappings"][0]["containerPort"] == 3100
+
+
+def test_ecs_skips_remote_only():
+    from engine.deployers.mcp_sidecar import inject_mcp_containers_ecs, resolve_mcp_servers
+    from engine.config_parser import McpServerRef
+
+    resolved = resolve_mcp_servers([McpServerRef(ref="mcp/a", transport="sse", url="https://x/sse")])
+    td = inject_mcp_containers_ecs({"containerDefinitions": []}, resolved)
+    assert td["containerDefinitions"] == []  # remote → no container
+
+
+def test_ecs_idempotent():
+    from engine.deployers.mcp_sidecar import inject_mcp_containers_ecs, resolve_mcp_servers
+    from engine.config_parser import McpServerRef
+
+    resolved = resolve_mcp_servers([McpServerRef(ref="mcp/a", transport="sse", image="img:1")])
+    td = inject_mcp_containers_ecs({"containerDefinitions": []}, resolved)
+    td2 = inject_mcp_containers_ecs(td, resolved)
+    assert len([c for c in td2["containerDefinitions"] if c["name"] == "mcp-a"]) == 1
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/unit/test_mcp_deploy_wiring.py -v`
+Expected: PASS already for the injector helpers (built in A2). If PASS, this test locks behavior; proceed to wire into deployers below. (These helper-level tests pass now; the deployer wiring is exercised by the deployers' own integration tests which mock cloud SDKs.)
+
+- [ ] **Step 3: Wire into deployers.**
+
+**`engine/deployers/aws_ecs.py`** — in the `if should_inject(config):` block (~line 475), after `partial = inject_sidecar(...)` add:
+
+```python
+            if config.mcp_servers:
+                from engine.deployers.mcp_sidecar import (
+                    inject_mcp_containers_ecs,
+                    resolve_mcp_servers,
+                )
+
+                partial = inject_mcp_containers_ecs(
+                    partial, resolve_mcp_servers(config.mcp_servers)
+                )
+```
+
+**`engine/deployers/gcp_cloudrun.py`** — locate where `inject_cloudrun_sidecar` is applied to the service spec (near `sc = SidecarConfig.from_agent_config(config)` ~line 308). Immediately after the sidecar is injected into the spec, add:
+
+```python
+        if config.mcp_servers:
+            from engine.deployers.mcp_sidecar import (
+                inject_mcp_containers_cloudrun,
+                resolve_mcp_servers,
+            )
+
+            service_spec = inject_mcp_containers_cloudrun(
+                service_spec, resolve_mcp_servers(config.mcp_servers)
+            )
+```
+(Use the actual local variable name holding the Cloud Run service-spec dict at that point — read the surrounding lines first; it is the dict passed to `inject_cloudrun_sidecar`.)
+
+**`engine/deployers/azure_container_apps.py`** — find where the container list for the Container App template is assembled and the sidecar is appended (near `sc = SidecarConfig.from_agent_config(config)` ~line 334 and the `should_inject` block ~line 521). After the AB sidecar is appended to the containers list `containers`, add:
+
+```python
+        if config.mcp_servers:
+            from engine.deployers.mcp_sidecar import (
+                inject_mcp_containers_azure,
+                resolve_mcp_servers,
+            )
+
+            containers = inject_mcp_containers_azure(
+                containers, resolve_mcp_servers(config.mcp_servers)
+            )
+```
+(Read the surrounding code; bind to the real container-list variable used when constructing the `template`/`Template` object.)
+
+**`engine/deployers/docker_compose.py`** — the compose deployer starts containers imperatively via the docker SDK rather than emitting a compose file (`_start_sidecar` ~line 342). For co-deployed MCP servers, start each as its own container on the agent's network. In `_start_sidecar`'s caller (the `if should_inject(config):` block ~line 305), after the sidecar starts add:
+
+```python
+            if config.mcp_servers:
+                await self._start_mcp_sidecars(client, config, container_name)
+```
+
+And add the method (mirror `_start_sidecar`'s container-run pattern — read it first to match the docker SDK calls, network, and labels):
+
+```python
+    async def _start_mcp_sidecars(self, client, config, agent_container_name):
+        """Start each co-deployed MCP server as a sibling container."""
+        from engine.deployers.mcp_sidecar import resolve_mcp_servers
+
+        for r in resolve_mcp_servers(config.mcp_servers):
+            if not (r.co_deploy and r.image):
+                continue
+            name = f"{config.name}-mcp-{r.name}"
+            await asyncio.get_event_loop().run_in_executor(
+                None,
+                lambda r=r, name=name: client.containers.run(
+                    r.image,
+                    name=name,
+                    detach=True,
+                    environment={"MCP_TRANSPORT": "http", "PORT": str(r.port)},
+                    network=f"container:{agent_container_name}",
+                    labels={"agentbreeder.agent": config.name, "agentbreeder.mcp": r.name},
+                ),
+            )
+```
+(Confirm `asyncio` is imported in the file; if the file uses a different executor idiom for `_start_sidecar`, copy that idiom verbatim instead.)
+
+- [ ] **Step 4: Run the deployer unit tests + full unit suite for regressions**
+
+Run: `pytest tests/unit/test_mcp_deploy_wiring.py tests/unit/test_aws_ecs*.py tests/unit/test_gcp_cloudrun*.py tests/unit/test_azure*.py tests/unit/test_docker_compose*.py -v`
+Expected: PASS. Fix any deployer test that asserts an exact container count to account for MCP containers only when `mcp_servers` is set (most agent fixtures have none, so they're unaffected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/deployers/aws_ecs.py engine/deployers/gcp_cloudrun.py \
+        engine/deployers/azure_container_apps.py engine/deployers/docker_compose.py \
+        tests/unit/test_mcp_deploy_wiring.py
+git commit -m "feat(mcp): co-deploy MCP server containers across ECS/CloudRun/Azure/compose"
+```
+
+---
+
+### Task A7: P4 docs + CHANGELOG + cross-repo grep
+
+**Files:**
+- Modify: `website/content/docs/mcp-servers.mdx`, `website/content/docs/agent-yaml.mdx`, `website/content/docs/sidecar.mdx`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Update `agent-yaml.mdx`** — in the `mcp_servers:` section, document the new optional `url`, `image`, `port` fields with a worked example:
+
+```yaml
+mcp_servers:
+  - ref: mcp/zendesk          # registry reference
+    transport: sse
+    url: https://mcp.acme.com/sse   # remote server — sidecar forwards here
+  - ref: mcp/slack
+    transport: sse
+    image: acme/mcp-slack:1.2.3     # co-deployed as a sidecar container
+    port: 3100                       # localhost port (auto from 3100 if omitted)
+```
+
+- [ ] **Step 2: Update `mcp-servers.mdx` + `sidecar.mdx`** — add a "Deploying MCP servers with an agent" section explaining: remote `url` → forwarded; `image` → co-deployed container reachable over localhost; the agent calls `http://localhost:9091/mcp/<name>`; stdio is co-deploy-only (remote stdio is not forwardable); App Runner/single-container targets cannot host MCP sidecars.
+
+- [ ] **Step 3: CHANGELOG** — under Unreleased/Added:
+
+```markdown
+- **MCP server deployment**: `agent.yaml` `mcp_servers` now deploy end-to-end — remote `url` servers are forwarded by the sidecar, and `image` servers are co-deployed as sidecar containers (AWS ECS, GCP Cloud Run, Azure Container Apps, docker-compose). The Go sidecar reads the forwarding map from `AGENTBREEDER_SIDECAR_MCP_SERVERS`.
+```
+
+- [ ] **Step 4: Cross-repo grep** (`feedback_cross_repo_sync`)
+
+Run:
+```bash
+grep -rn "mcp_servers\|McpServerRef" /Users/rajit/personal-github/agentbreeder-cloud --include=*.py --include=*.ts 2>/dev/null | head
+```
+If hits reference the schema shape, note them; the new fields are additive/optional so no companion change is expected. Record the finding in the PR description.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/content/docs/mcp-servers.mdx website/content/docs/agent-yaml.mdx website/content/docs/sidecar.mdx CHANGELOG.md
+git commit -m "docs(mcp): document mcp_servers deployment (url/image/port) + sidecar forwarding"
+```
+
+---
+
+## Part B — P5: Studio Self-Hosting
+
+### Task B1: Env-driven nginx (upstream / CORS / TLS) via envsubst
+
+The dashboard image must render its nginx config at runtime from env so the same image self-hosts anywhere: `API_UPSTREAM` (default `http://api:8000`), optional `EXTRA_CORS_HEADERS` toggle, and optional TLS. CORS for the API itself is already env-driven (`CORS_ORIGINS`), so nginx only needs upstream + optional TLS termination.
+
+**Files:**
+- Create: `dashboard/nginx.conf.template`
+- Create: `dashboard/docker-entrypoint.sh`
+- Modify: `dashboard/Dockerfile`
+- Delete: `dashboard/nginx.conf` (superseded)
+- Test: `tests/unit/test_nginx_template.py` (new — renders the template with `envsubst`-style substitution and asserts the output)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_nginx_template.py
+"""The dashboard nginx template renders API_UPSTREAM from env (P5)."""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+TEMPLATE = Path(__file__).resolve().parents[2] / "dashboard" / "nginx.conf.template"
+
+
+def _render(env: dict[str, str]) -> str:
+    # Mirror the container entrypoint: envsubst with an explicit var allow-list.
+    envsubst = shutil.which("envsubst")
+    if not envsubst:
+        pytest.skip("envsubst not installed")
+    full = {**os.environ, **env}
+    out = subprocess.run(
+        [envsubst, "${API_UPSTREAM} ${LISTEN_PORT}"],
+        input=TEMPLATE.read_text(),
+        capture_output=True,
+        text=True,
+        env=full,
+        check=True,
+    )
+    return out.stdout
+
+
+def test_template_has_placeholders():
+    text = TEMPLATE.read_text()
+    assert "${API_UPSTREAM}" in text
+    assert "${LISTEN_PORT}" in text
+
+
+def test_renders_custom_upstream():
+    rendered = _render({"API_UPSTREAM": "http://my-api:9000", "LISTEN_PORT": "3001"})
+    assert "proxy_pass http://my-api:9000" in rendered
+    assert "listen 3001;" in rendered
+    assert "${" not in rendered  # all placeholders substituted
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/unit/test_nginx_template.py -v`
+Expected: FAIL — template file missing.
+
+- [ ] **Step 3: Create the template** `dashboard/nginx.conf.template`:
+
+```nginx
+server {
+    listen ${LISTEN_PORT};
+
+    location /api/ {
+        resolver 127.0.0.11 valid=30s ipv6=off;
+        proxy_pass ${API_UPSTREAM};
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /health {
+        resolver 127.0.0.11 valid=30s ipv6=off;
+        proxy_pass ${API_UPSTREAM};
+        proxy_set_header Host $host;
+    }
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html;
+        try_files $uri $uri/ /index.html;
+    }
+}
+```
+
+Create `dashboard/docker-entrypoint.sh` (renders template, preserving nginx's own `$host`/`$uri` runtime vars by only substituting our allow-listed vars):
+
+```sh
+#!/bin/sh
+set -e
+
+: "${API_UPSTREAM:=http://api:8000}"
+: "${LISTEN_PORT:=3001}"
+export API_UPSTREAM LISTEN_PORT
+
+# Only substitute our vars; leave nginx runtime vars ($host, $uri, ...) intact.
+envsubst '${API_UPSTREAM} ${LISTEN_PORT}' \
+    < /etc/nginx/templates/default.conf.template \
+    > /etc/nginx/conf.d/default.conf
+
+exec nginx -g 'daemon off;'
+```
+
+- [ ] **Step 4: Update `dashboard/Dockerfile`** production stage — replace the `COPY nginx.conf ...` line and `CMD` with template + entrypoint, and ensure `envsubst` (from `gettext`) is present (it ships in `nginx:alpine` via `/usr/bin/envsubst`? It does NOT by default — install it):
+
+Replace lines 27-41 of `dashboard/Dockerfile` with:
+
+```dockerfile
+COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+COPY docker-entrypoint.sh /docker-entrypoint.d/40-render-template.sh
+
+# nginx:alpine bundles envsubst (gettext) and an entrypoint that runs
+# /docker-entrypoint.d/*.sh before starting. Make our render script executable.
+RUN chmod +x /docker-entrypoint.d/40-render-template.sh \
+    && chown -R nginx:nginx /usr/share/nginx/html /var/cache/nginx /var/log/nginx \
+    && touch /var/run/nginx.pid \
+    && chown nginx:nginx /var/run/nginx.pid
+
+USER nginx
+
+EXPOSE 3001
+
+CMD ["nginx", "-g", "daemon off;"]
+```
+
+> Note: `nginx:alpine` already includes `/docker-entrypoint.sh` which executes `/docker-entrypoint.d/*.sh` then `exec "$@"`. Our render script must therefore **not** itself `exec nginx`; rewrite `docker-entrypoint.sh` for this drop-in directory to just render and return:
+
+```sh
+#!/bin/sh
+set -e
+: "${API_UPSTREAM:=http://api:8000}"
+: "${LISTEN_PORT:=3001}"
+export API_UPSTREAM LISTEN_PORT
+envsubst '${API_UPSTREAM} ${LISTEN_PORT}' \
+    < /etc/nginx/templates/default.conf.template \
+    > /etc/nginx/conf.d/default.conf
+```
+
+Then delete the old static config:
+```bash
+git rm dashboard/nginx.conf
+```
+
+- [ ] **Step 5: Run tests + build check**
+
+Run: `pytest tests/unit/test_nginx_template.py -v`
+Expected: PASS.
+(Optional, if Docker available) `docker build -t ab-dash-test dashboard/` to confirm the image builds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/nginx.conf.template dashboard/docker-entrypoint.sh dashboard/Dockerfile tests/unit/test_nginx_template.py
+git rm dashboard/nginx.conf
+git commit -m "feat(dashboard): env-driven nginx upstream via runtime envsubst template"
+```
+
+---
+
+### Task B2: Helm chart scaffold (Chart.yaml + values.yaml)
+
+**Files:**
+- Create: `deploy/helm/agentbreeder/Chart.yaml`
+- Create: `deploy/helm/agentbreeder/values.yaml`
+- Create: `deploy/helm/agentbreeder/.helmignore`
+
+- [ ] **Step 1: Create `Chart.yaml`** (Bitnami Postgres + Redis as conditional dependencies):
+
+```yaml
+apiVersion: v2
+name: agentbreeder
+description: Self-host the AgentBreeder platform (Studio + API + Postgres + Redis) on Kubernetes.
+type: application
+version: 0.1.0
+appVersion: "2.6.0"
+home: https://agentbreeder.io
+sources:
+  - https://github.com/agentbreeder/agentbreeder
+dependencies:
+  - name: postgresql
+    version: "15.x.x"
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled
+  - name: redis
+    version: "19.x.x"
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled
+```
+
+- [ ] **Step 2: Create `values.yaml`**:
+
+```yaml
+# AgentBreeder self-hosting values. See website/content/docs/self-hosting.mdx.
+
+image:
+  registry: docker.io
+  repository: rajits
+  apiImage: agentbreeder-api
+  dashboardImage: agentbreeder-dashboard
+  tag: latest
+  pullPolicy: IfNotPresent
+
+# Public hostname the platform is served on (used by Ingress + CORS).
+host: agentbreeder.local
+
+api:
+  replicas: 1
+  port: 8000
+  resources:
+    requests: { cpu: 250m, memory: 512Mi }
+    limits: { cpu: "1", memory: 1Gi }
+  # Extra non-secret env passed to the API container.
+  env: {}
+
+dashboard:
+  replicas: 1
+  port: 3001
+  resources:
+    requests: { cpu: 100m, memory: 128Mi }
+    limits: { cpu: 500m, memory: 256Mi }
+
+# Secrets. In production set these via --set or a pre-created secret (existingSecret).
+secrets:
+  existingSecret: ""        # if set, all keys below are read from this Secret
+  secretKey: "change-me-to-a-random-256-bit-key"
+  jwtSecretKey: "change-me"
+
+# Connection strings. When postgresql/redis subcharts are enabled these are
+# auto-derived and these explicit values are ignored.
+externalDatabaseUrl: ""     # e.g. postgresql+asyncpg://user:pw@host:5432/db
+externalRedisUrl: ""        # e.g. redis://host:6379
+
+# Run `alembic upgrade head` as a pre-install/upgrade Job.
+migrate:
+  enabled: true
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations: {}
+  tls:
+    enabled: false
+    secretName: agentbreeder-tls   # pre-created TLS secret, or cert-manager-managed
+
+# Bundled datastores (toggle off to use externalDatabaseUrl/externalRedisUrl).
+postgresql:
+  enabled: true
+  auth:
+    username: agentbreeder
+    password: agentbreeder
+    database: agentbreeder
+  primary:
+    persistence:
+      size: 8Gi
+
+redis:
+  enabled: true
+  architecture: standalone
+  auth:
+    enabled: false
+```
+
+- [ ] **Step 3: Create `.helmignore`** (standard):
+
+```
+.DS_Store
+*.tmp
+ci/
+*.md
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add deploy/helm/agentbreeder/Chart.yaml deploy/helm/agentbreeder/values.yaml deploy/helm/agentbreeder/.helmignore
+git commit -m "feat(helm): chart scaffold with toggleable Bitnami postgres/redis deps"
+```
+
+---
+
+### Task B3: Helm templates
+
+**Files (create all under `deploy/helm/agentbreeder/templates/`):** `_helpers.tpl`, `secret.yaml`, `configmap.yaml`, `api-deployment.yaml`, `api-service.yaml`, `dashboard-deployment.yaml`, `dashboard-service.yaml`, `migrate-job.yaml`, `ingress.yaml`, `NOTES.txt`
+
+- [ ] **Step 1: `_helpers.tpl`** — names + derived DB/Redis URLs:
+
+```yaml
+{{- define "agentbreeder.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "agentbreeder.apiImage" -}}
+{{- printf "%s/%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.apiImage .Values.image.tag -}}
+{{- end -}}
+
+{{- define "agentbreeder.dashboardImage" -}}
+{{- printf "%s/%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.dashboardImage .Values.image.tag -}}
+{{- end -}}
+
+{{- define "agentbreeder.databaseUrl" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- printf "postgresql+asyncpg://%s:%s@%s-postgresql:5432/%s" .Values.postgresql.auth.username .Values.postgresql.auth.password .Release.Name .Values.postgresql.auth.database -}}
+{{- else -}}
+{{- .Values.externalDatabaseUrl -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "agentbreeder.redisUrl" -}}
+{{- if .Values.redis.enabled -}}
+{{- printf "redis://%s-redis-master:6379" .Release.Name -}}
+{{- else -}}
+{{- .Values.externalRedisUrl -}}
+{{- end -}}
+{{- end -}}
+```
+
+- [ ] **Step 2: `secret.yaml`** (skipped when `existingSecret` set):
+
+```yaml
+{{- if not .Values.secrets.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agentbreeder.fullname" . }}-secrets
+type: Opaque
+stringData:
+  SECRET_KEY: {{ .Values.secrets.secretKey | quote }}
+  JWT_SECRET_KEY: {{ .Values.secrets.jwtSecretKey | quote }}
+  DATABASE_URL: {{ include "agentbreeder.databaseUrl" . | quote }}
+  REDIS_URL: {{ include "agentbreeder.redisUrl" . | quote }}
+{{- end }}
+```
+
+- [ ] **Step 3: `configmap.yaml`** (non-secret API env, incl. CORS for the public host):
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "agentbreeder.fullname" . }}-config
+data:
+  AGENTBREEDER_ENV: "production"
+  CORS_ORIGINS: {{ printf "https://%s,http://%s" .Values.host .Values.host | quote }}
+  {{- range $k, $v := .Values.api.env }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+```
+
+> The API reads `CORS_ORIGINS` as a list via pydantic-settings. Confirm list parsing accepts a comma-separated string; if it expects JSON, emit `'["https://host","http://host"]'` instead. (Check `api/config.py` `cors_origins` env parsing during implementation and match it.)
+
+- [ ] **Step 4: `api-deployment.yaml`**:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agentbreeder.fullname" . }}-api
+  labels: { app: agentbreeder, component: api }
+spec:
+  replicas: {{ .Values.api.replicas }}
+  selector:
+    matchLabels: { app: agentbreeder, component: api }
+  template:
+    metadata:
+      labels: { app: agentbreeder, component: api }
+    spec:
+      containers:
+        - name: api
+          image: {{ include "agentbreeder.apiImage" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.api.port }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "agentbreeder.fullname" . }}-config
+            - secretRef:
+                name: {{ .Values.secrets.existingSecret | default (printf "%s-secrets" (include "agentbreeder.fullname" .)) }}
+          readinessProbe:
+            httpGet: { path: /health, port: {{ .Values.api.port }} }
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /health, port: {{ .Values.api.port }} }
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources: {{- toYaml .Values.api.resources | nindent 12 }}
+```
+
+- [ ] **Step 5: `api-service.yaml`**:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agentbreeder.fullname" . }}-api
+  labels: { app: agentbreeder, component: api }
+spec:
+  selector: { app: agentbreeder, component: api }
+  ports:
+    - port: {{ .Values.api.port }}
+      targetPort: {{ .Values.api.port }}
+```
+
+- [ ] **Step 6: `dashboard-deployment.yaml`** (sets `API_UPSTREAM` to the in-cluster API service):
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agentbreeder.fullname" . }}-dashboard
+  labels: { app: agentbreeder, component: dashboard }
+spec:
+  replicas: {{ .Values.dashboard.replicas }}
+  selector:
+    matchLabels: { app: agentbreeder, component: dashboard }
+  template:
+    metadata:
+      labels: { app: agentbreeder, component: dashboard }
+    spec:
+      containers:
+        - name: dashboard
+          image: {{ include "agentbreeder.dashboardImage" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.dashboard.port }}
+          env:
+            - name: API_UPSTREAM
+              value: {{ printf "http://%s-api:%v" (include "agentbreeder.fullname" .) .Values.api.port | quote }}
+            - name: LISTEN_PORT
+              value: {{ .Values.dashboard.port | quote }}
+          resources: {{- toYaml .Values.dashboard.resources | nindent 12 }}
+```
+
+- [ ] **Step 7: `dashboard-service.yaml`**:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agentbreeder.fullname" . }}-dashboard
+  labels: { app: agentbreeder, component: dashboard }
+spec:
+  selector: { app: agentbreeder, component: dashboard }
+  ports:
+    - port: {{ .Values.dashboard.port }}
+      targetPort: {{ .Values.dashboard.port }}
+```
+
+- [ ] **Step 8: `migrate-job.yaml`** (pre-install/upgrade hook):
+
+```yaml
+{{- if .Values.migrate.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "agentbreeder.fullname" . }}-migrate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels: { app: agentbreeder, component: migrate }
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          image: {{ include "agentbreeder.apiImage" . }}
+          command: ["alembic", "upgrade", "head"]
+          envFrom:
+            - secretRef:
+                name: {{ .Values.secrets.existingSecret | default (printf "%s-secrets" (include "agentbreeder.fullname" .)) }}
+{{- end }}
+```
+
+- [ ] **Step 9: `ingress.yaml`** (dashboard root + `/api` to API; optional TLS):
+
+```yaml
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "agentbreeder.fullname" . }}
+  annotations: {{- toYaml .Values.ingress.annotations | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts: [{{ .Values.host | quote }}]
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.host | quote }}
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "agentbreeder.fullname" . }}-api
+                port: { number: {{ .Values.api.port }} }
+          - path: /health
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "agentbreeder.fullname" . }}-api
+                port: { number: {{ .Values.api.port }} }
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "agentbreeder.fullname" . }}-dashboard
+                port: { number: {{ .Values.dashboard.port }} }
+{{- end }}
+```
+
+- [ ] **Step 10: `NOTES.txt`**:
+
+```
+AgentBreeder is installing.
+
+  Studio:  https://{{ .Values.host }}
+  API:     https://{{ .Values.host }}/api/v1
+  Docs:    https://{{ .Values.host }}/api/docs
+
+{{- if not .Values.ingress.tls.enabled }}
+
+⚠  TLS is disabled. For production, set ingress.tls.enabled=true and provide a
+   TLS secret (or use cert-manager). Also override secrets.secretKey and
+   secrets.jwtSecretKey with strong random values.
+{{- end }}
+
+Check rollout:
+  kubectl get pods -l app=agentbreeder
+```
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add deploy/helm/agentbreeder/templates/
+git commit -m "feat(helm): api/dashboard/migrate/ingress/secret/configmap templates"
+```
+
+---
+
+### Task B4: Helm lint/template test
+
+**Files:**
+- Test: `tests/unit/test_helm_chart.py` (new)
+
+- [ ] **Step 1: Write the test** (skips cleanly if `helm` is not installed, so CI without helm stays green; runs `helm template` with deps disabled to avoid network fetch):
+
+```python
+# tests/unit/test_helm_chart.py
+"""Helm chart renders cleanly (P5). Skips if helm is unavailable."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+CHART = Path(__file__).resolve().parents[2] / "deploy" / "helm" / "agentbreeder"
+
+
+@pytest.fixture(scope="module")
+def helm():
+    exe = shutil.which("helm")
+    if not exe:
+        pytest.skip("helm not installed")
+    return exe
+
+
+def test_chart_lint_structure():
+    # Chart.yaml + key templates exist regardless of helm availability.
+    assert (CHART / "Chart.yaml").exists()
+    for t in ["api-deployment.yaml", "dashboard-deployment.yaml", "ingress.yaml", "secret.yaml"]:
+        assert (CHART / "templates" / t).exists()
+
+
+def test_helm_template_renders(helm):
+    # Disable subchart deps so no repo fetch is needed; supply external URLs.
+    out = subprocess.run(
+        [
+            helm, "template", "ab", str(CHART),
+            "--set", "postgresql.enabled=false",
+            "--set", "redis.enabled=false",
+            "--set", "externalDatabaseUrl=postgresql+asyncpg://u:p@db:5432/d",
+            "--set", "externalRedisUrl=redis://r:6379",
+            "--set", "host=example.com",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert out.returncode == 0, out.stderr
+    assert "kind: Deployment" in out.stdout
+    assert "kind: Ingress" in out.stdout
+    assert "DATABASE_URL" in out.stdout
+    assert "rajits/agentbreeder-api" in out.stdout
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `pytest tests/unit/test_helm_chart.py -v`
+Expected: structure test PASS; render test PASS if `helm` present, else SKIP. If `helm` is present, fix any template errors it surfaces.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/test_helm_chart.py
+git commit -m "test(helm): chart structure + helm template render check"
+```
+
+---
+
+### Task B5: `self-hosting.mdx` + nav + README + CHANGELOG + standalone compose image refs
+
+**Files:**
+- Create: `website/content/docs/self-hosting.mdx`
+- Modify: `website/content/docs/meta.json` (add `self-hosting` under "Deploy & Run")
+- Modify: `README.md` (link self-hosting)
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Create `self-hosting.mdx`** with frontmatter + sections: Prerequisites (K8s, Helm 3, ingress controller, optional cert-manager); Quick start (`helm dependency update`, `helm install agentbreeder deploy/helm/agentbreeder --set host=...`); Using external Postgres/Redis (`postgresql.enabled=false` + `externalDatabaseUrl`); Secrets (override `secrets.secretKey`/`jwtSecretKey` or `existingSecret`); TLS (`ingress.tls.enabled=true` + secret or cert-manager); CORS (auto-set from `host`); Migrations (the pre-install Job); Docker-compose alternative (link `deploy/docker-compose.standalone.yml`); Troubleshooting. Use the same frontmatter + `Callout`/`Tabs` conventions as `quickstart.mdx`.
+
+```mdx
+---
+title: Self-Hosting
+description: Run the full AgentBreeder platform (Studio + API + Postgres + Redis) on your own Kubernetes cluster with Helm.
+---
+```
+
+- [ ] **Step 2: Register in nav** — in `website/content/docs/meta.json`, add `"self-hosting"` to the `---Deploy & Run---` group right after `"deployment"`:
+
+```json
+    "---Deploy & Run---",
+    "deployment",
+    "self-hosting",
+    "providers",
+```
+
+- [ ] **Step 3: README** — add a "Self-hosting" bullet/section linking the Helm chart (`deploy/helm/agentbreeder`) and the new doc.
+
+- [ ] **Step 4: CHANGELOG** — under Added:
+
+```markdown
+- **Studio self-hosting**: a Helm chart (`deploy/helm/agentbreeder`) deploys the full platform (Studio + API + migrations) with toggleable bundled Postgres/Redis, TLS-capable Ingress, and env-driven nginx. See docs → Self-Hosting.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/content/docs/self-hosting.mdx website/content/docs/meta.json README.md CHANGELOG.md
+git commit -m "docs(self-hosting): Helm self-hosting guide + nav + README"
+```
+
+---
+
+## Finalisation
+
+- [ ] **Run the full local gate** (pre-push hook runs repo-wide ruff): `ruff format . && ruff check . && pytest tests/unit/ -q` and `cd sidecar && go test ./...`.
+- [ ] **Cross-repo sync** (`feedback_cross_repo_sync`): grep `agentbreeder-cloud` for `mcp_servers`, dashboard nginx, and any Helm/self-host surface; note findings in PR body. Update `website/components/footer.tsx` version only if a release bump is part of this PR (it is not — leave as-is).
+- [ ] **Open the combined PR** (`feat/cloud-agnostic-p4p5`) per `feedback_defer_pr_until_done`; do not `--admin` merge without explicit user OK (`feedback_confirm_before_safety_bypass`).
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** P4 revives `mcp_sidecar.py` (resolution + 4 co-deploy injectors) and uses `packager.py` (`build_image_tag` in convention fallback + back-compat shim); wires MCP endpoints into the Go sidecar (A3) via env consumed by injectors (A5) sourced from `SidecarConfig` (A4). P5 delivers Helm (B2/B3), env-driven nginx upstream + TLS via Ingress (B1/B3), and `self-hosting.mdx` (B5). ✅
+- **Back-compat:** existing `tests/unit/test_mcp_packager.py` keeps passing because `McpSidecarDeployer.generate_sidecars`/`inject_into_compose` and all `packager` functions are retained (A2 shim). The one behavioral nuance: `generate_sidecars` now always uses `"latest"` version (previously also `"latest"`), so assertions are unaffected.
+- **Type consistency:** `ResolvedMcpServer`/`McpServerInfo` field names are used identically in A2, A4, A6. The Go `MCPServerSpec` JSON tags (`transport`,`url`) match the Python `build_sidecar_env_map` keys exactly (A3 ↔ A2).
+- **Risk:** `CORS_ORIGINS` list parsing format (comma vs JSON) — verified against `api/config.py` during B3 implementation. Cloud-Run/Azure deployer variable names for the container list/spec must be confirmed by reading the surrounding lines before editing (A6 notes this).

--- a/engine/config_parser.py
+++ b/engine/config_parser.py
@@ -142,10 +142,19 @@ class SubagentRef(BaseModel):
 
 
 class McpServerRef(BaseModel):
-    """Reference to an MCP server to attach as a sidecar."""
+    """Reference to an MCP server to attach to an agent.
+
+    ``ref`` is the registry reference (e.g. ``mcp/zendesk``). For self-contained
+    deploys the connection can be given inline so no running registry is needed:
+    set ``url`` for a remote HTTP/SSE MCP server, or ``image`` to co-deploy a
+    container MCP server as a sidecar (reachable on ``port`` over localhost).
+    """
 
     ref: str
     transport: str = "stdio"
+    url: str | None = None
+    image: str | None = None
+    port: int | None = None
 
 
 class MemoryConfig(BaseModel):

--- a/engine/deployers/aws_ecs.py
+++ b/engine/deployers/aws_ecs.py
@@ -475,6 +475,15 @@ class AWSECSDeployer(BaseDeployer):
         if should_inject(config):
             partial: dict[str, Any] = {"containerDefinitions": container_defs}
             partial = inject_sidecar(partial, SidecarConfig.from_agent_config(config))
+            if config.mcp_servers:
+                from engine.deployers.mcp_sidecar import (
+                    inject_mcp_containers_ecs,
+                    resolve_mcp_servers,
+                )
+
+                partial = inject_mcp_containers_ecs(
+                    partial, resolve_mcp_servers(config.mcp_servers)
+                )
             container_defs = partial["containerDefinitions"]
 
         kwargs: dict[str, Any] = {

--- a/engine/deployers/azure_container_apps.py
+++ b/engine/deployers/azure_container_apps.py
@@ -345,6 +345,15 @@ class AzureContainerAppsDeployer(BaseDeployer):
             env.append({"name": "OTEL_EXPORTER_OTLP_ENDPOINT", "value": otel})
         if api_url := os.environ.get("AGENTBREEDER_API_URL"):
             env.append({"name": "AGENTBREEDER_API_URL", "value": api_url})
+        if sc.mcp_servers:
+            import json as _json
+
+            env.append(
+                {
+                    "name": "AGENTBREEDER_SIDECAR_MCP_SERVERS",
+                    "value": _json.dumps(sc.mcp_servers),
+                }
+            )
 
         return {
             "name": "agentbreeder-sidecar",
@@ -523,6 +532,15 @@ class AzureContainerAppsDeployer(BaseDeployer):
             env_vars.append({"name": "PORT", "value": "8081"})
             containers.append(main_container)
             containers.append(self._build_azure_sidecar_container(config))
+            if config.mcp_servers:
+                from engine.deployers.mcp_sidecar import (
+                    inject_mcp_containers_azure,
+                    resolve_mcp_servers,
+                )
+
+                containers = inject_mcp_containers_azure(
+                    containers, resolve_mcp_servers(config.mcp_servers)
+                )
         else:
             containers.append(main_container)
 

--- a/engine/deployers/docker_compose.py
+++ b/engine/deployers/docker_compose.py
@@ -304,6 +304,8 @@ class DockerComposeDeployer(BaseDeployer):
         sidecar_id: str | None = None
         if should_inject(config):
             sidecar_id = await self._start_sidecar(client, config, container_name)
+            if sidecar_id and config.mcp_servers:
+                await self._start_mcp_sidecars(client, config, f"{container_name}-sidecar")
 
         self._state["agents"][config.name] = {
             "port": port,
@@ -361,6 +363,10 @@ class DockerComposeDeployer(BaseDeployer):
         }
         if sidecar_cfg.otel_endpoint:
             env["OTEL_EXPORTER_OTLP_ENDPOINT"] = sidecar_cfg.otel_endpoint
+        if sidecar_cfg.mcp_servers:
+            import json as _json
+
+            env["AGENTBREEDER_SIDECAR_MCP_SERVERS"] = _json.dumps(sidecar_cfg.mcp_servers)
 
         try:
             sidecar = client.containers.run(
@@ -376,6 +382,49 @@ class DockerComposeDeployer(BaseDeployer):
         except Exception as exc:  # noqa: BLE001
             logger.warning("Failed to start sidecar (continuing without): %s", exc)
             return None
+
+    async def _start_mcp_sidecars(
+        self,
+        client: Any,
+        config: AgentConfig,
+        sidecar_name: str,
+    ) -> None:
+        """Co-deploy each image-backed MCP server sharing the sidecar netns.
+
+        The MCP container joins the sidecar's network namespace
+        (``network=container:<sidecar>``) so the sidecar reaches it on
+        ``localhost:<port>`` — the same contract used on ECS/Cloud Run/Azure.
+        Best-effort: a failure is logged but never fails the deploy.
+        """
+        import docker
+
+        from engine.deployers.mcp_sidecar import resolve_mcp_servers
+
+        for r in resolve_mcp_servers(config.mcp_servers):
+            if not (r.co_deploy and r.image):
+                continue
+            name = f"{sidecar_name}-mcp-{r.name}"
+            try:
+                client.containers.get(name)
+                logger.info("MCP sidecar already running: %s", name)
+                continue
+            except docker.errors.NotFound:
+                pass
+            try:
+                client.containers.run(
+                    r.image,
+                    name=name,
+                    environment={"MCP_TRANSPORT": "http", "PORT": str(r.port)},
+                    network=f"container:{sidecar_name}",
+                    detach=True,
+                    remove=False,
+                    labels={"agentbreeder.agent": config.name, "agentbreeder.mcp": r.name},
+                )
+                logger.info("Started co-deployed MCP server: %s", name)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Failed to start MCP server %s (continuing): %s", r.name, exc
+                )
 
     async def health_check(
         self, deploy_result: DeployResult, timeout: int = 60, interval: int = 2

--- a/engine/deployers/docker_compose.py
+++ b/engine/deployers/docker_compose.py
@@ -422,9 +422,7 @@ class DockerComposeDeployer(BaseDeployer):
                 )
                 logger.info("Started co-deployed MCP server: %s", name)
             except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "Failed to start MCP server %s (continuing): %s", r.name, exc
-                )
+                logger.warning("Failed to start MCP server %s (continuing): %s", r.name, exc)
 
     async def health_check(
         self, deploy_result: DeployResult, timeout: int = 60, interval: int = 2

--- a/engine/deployers/gcp_cloudrun.py
+++ b/engine/deployers/gcp_cloudrun.py
@@ -261,6 +261,15 @@ def _build_service_template(
         container["startup_probe"]["http_get"]["port"] = AGENT_INTERNAL_PORT
         container["liveness_probe"]["http_get"]["port"] = AGENT_INTERNAL_PORT
         containers_list.append(_build_cloudrun_sidecar_container(config))
+        if config.mcp_servers:
+            from engine.deployers.mcp_sidecar import (
+                inject_mcp_containers_cloudrun,
+                resolve_mcp_servers,
+            )
+
+            containers_list = inject_mcp_containers_cloudrun(
+                containers_list, resolve_mcp_servers(config.mcp_servers)
+            )
     else:
         # Single container — it is the ingress; Cloud Run injects PORT=8080.
         container["ports"] = [{"container_port": INGRESS_PORT}]
@@ -322,6 +331,15 @@ def _build_cloudrun_sidecar_container(config: AgentConfig) -> dict[str, Any]:
         env.append({"name": "OTEL_EXPORTER_OTLP_ENDPOINT", "value": otel})
     if api_url := _os.getenv("AGENTBREEDER_API_URL"):
         env.append({"name": "AGENTBREEDER_API_URL", "value": api_url})
+    if sc.mcp_servers:
+        import json as _json
+
+        env.append(
+            {
+                "name": "AGENTBREEDER_SIDECAR_MCP_SERVERS",
+                "value": _json.dumps(sc.mcp_servers),
+            }
+        )
 
     return {
         "name": "agentbreeder-sidecar",

--- a/engine/deployers/mcp_sidecar.py
+++ b/engine/deployers/mcp_sidecar.py
@@ -192,20 +192,20 @@ def inject_mcp_containers_ecs(
 
 
 def inject_mcp_containers_cloudrun(
-    service_spec: dict[str, Any], resolved: list[ResolvedMcpServer]
-) -> dict[str, Any]:
-    """Append co-deployed MCP server containers to a Cloud Run v2 service spec."""
-    result = copy.deepcopy(service_spec)
-    spec = result.setdefault("spec", {})
-    template = spec.setdefault("template", {})
-    tmpl_spec = template.setdefault("spec", {})
-    containers: list[dict[str, Any]] = tmpl_spec.setdefault("containers", [])
-    existing = {c.get("name") for c in containers}
+    containers: list[dict[str, Any]], resolved: list[ResolvedMcpServer]
+) -> list[dict[str, Any]]:
+    """Append co-deployed MCP server containers to a Cloud Run v2 container list.
+
+    Cloud Run revisions share a network namespace, so a co-deployed MCP server is
+    reachable by the sidecar over ``localhost:<port>``. Returns a new list.
+    """
+    result = copy.deepcopy(containers)
+    existing = {c.get("name") for c in result}
     for r in _codeploy(resolved):
         cname = f"mcp-{r.name}"
         if cname in existing:
             continue
-        containers.append(
+        result.append(
             {
                 "name": cname,
                 "image": r.image,
@@ -213,7 +213,6 @@ def inject_mcp_containers_cloudrun(
                     {"name": "MCP_TRANSPORT", "value": "http"},
                     {"name": "PORT", "value": str(r.port)},
                 ],
-                "ports": [{"containerPort": r.port}],
             }
         )
     return result

--- a/engine/deployers/mcp_sidecar.py
+++ b/engine/deployers/mcp_sidecar.py
@@ -1,13 +1,23 @@
-"""MCP sidecar deployer — deploys MCP servers as sidecar containers.
+"""MCP sidecar deployer — resolves MCP server refs and co-deploys them.
 
-When an agent references MCP servers in its config, this deployer
-generates the sidecar container definitions and injects them
-into the agent's deployment.
+When an agent references MCP servers in its config this module:
+  * resolves each ``McpServerRef`` into a :class:`ResolvedMcpServer`
+    (a remote HTTP/SSE URL, or a co-deployed container image on a localhost
+    port), and
+  * injects co-deployed MCP server containers into each cloud deployer's
+    container set, alongside the AgentBreeder sidecar.
+
+The AgentBreeder Go sidecar forwards ``POST localhost:9091/mcp/<server>`` to the
+resolved URL; :func:`build_sidecar_env_map` produces the ``{name:{transport,url}}``
+map handed to it via ``AGENTBREEDER_SIDECAR_MCP_SERVERS``.
 """
 
 from __future__ import annotations
 
+import copy
 import logging
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 from engine.config_parser import McpServerRef
@@ -15,9 +25,248 @@ from engine.mcp.packager import build_image_tag, generate_sidecar_config
 
 logger = logging.getLogger(__name__)
 
+# Co-deployed MCP sidecar containers get localhost ports starting here. 3100 sits
+# above the agent (8080/8081) and AgentBreeder sidecar localhost ports (9090-9092).
+DEFAULT_BASE_PORT = 3100
+
+
+@dataclass
+class McpServerInfo:
+    """Registry-sourced facts about an MCP server (best-effort enrichment)."""
+
+    name: str
+    transport: str = "stdio"
+    endpoint: str | None = None
+    image_uri: str | None = None
+
+
+@dataclass
+class ResolvedMcpServer:
+    """A fully-resolved MCP server ready to wire into a deploy."""
+
+    name: str
+    transport: str
+    url: str
+    co_deploy: bool
+    image: str | None = None
+    port: int | None = None
+    ref: str = ""
+
+
+def resolve_mcp_servers(
+    mcp_servers: list[McpServerRef],
+    *,
+    registry_lookup: Callable[[str], McpServerInfo | None] | None = None,
+    base_port: int = DEFAULT_BASE_PORT,
+    registry_prefix: str = "agentbreeder",
+) -> list[ResolvedMcpServer]:
+    """Resolve agent.yaml MCP refs into concrete, deployable servers.
+
+    Resolution order per ref: inline ``url`` (remote) → inline ``image``
+    (co-deploy) → best-effort ``registry_lookup`` (endpoint or image_uri) →
+    convention co-deploy (``build_image_tag``).
+    """
+    resolved: list[ResolvedMcpServer] = []
+    for i, mcp in enumerate(mcp_servers):
+        name = mcp.ref.split("/")[-1]
+        transport = mcp.transport
+        port = mcp.port or (base_port + i)
+
+        if mcp.url:
+            resolved.append(ResolvedMcpServer(name, transport, mcp.url, False, ref=mcp.ref))
+            continue
+        if mcp.image:
+            resolved.append(
+                ResolvedMcpServer(
+                    name,
+                    transport,
+                    f"http://localhost:{port}",
+                    True,
+                    image=mcp.image,
+                    port=port,
+                    ref=mcp.ref,
+                )
+            )
+            continue
+
+        info = registry_lookup(name) if registry_lookup else None
+        if info and info.endpoint:
+            resolved.append(
+                ResolvedMcpServer(
+                    name, info.transport or transport, info.endpoint, False, ref=mcp.ref
+                )
+            )
+            continue
+        if info and info.image_uri:
+            resolved.append(
+                ResolvedMcpServer(
+                    name,
+                    info.transport or transport,
+                    f"http://localhost:{port}",
+                    True,
+                    image=info.image_uri,
+                    port=port,
+                    ref=mcp.ref,
+                )
+            )
+            continue
+
+        # Convention fallback: co-deploy a conventionally-named image.
+        image = build_image_tag(name, "latest", registry_prefix)
+        resolved.append(
+            ResolvedMcpServer(
+                name,
+                transport,
+                f"http://localhost:{port}",
+                True,
+                image=image,
+                port=port,
+                ref=mcp.ref,
+            )
+        )
+        logger.info("Resolved MCP '%s' by convention → %s", name, image)
+
+    return resolved
+
+
+def build_sidecar_env_map(resolved: list[ResolvedMcpServer]) -> dict[str, dict[str, str]]:
+    """Build the ``{name:{transport,url}}`` map for the Go sidecar.
+
+    The Go sidecar can only forward HTTP/SSE. Co-deployed servers always speak
+    HTTP on their localhost port (we set ``MCP_TRANSPORT`` on the container), so a
+    co-deployed ``stdio`` transport is normalised to ``http``. A *remote* ``stdio``
+    server cannot be forwarded and is skipped with a warning.
+    """
+    out: dict[str, dict[str, str]] = {}
+    for r in resolved:
+        transport = r.transport
+        if transport == "stdio":
+            if r.co_deploy:
+                transport = "http"
+            else:
+                logger.warning(
+                    "MCP '%s' uses remote stdio transport — the sidecar cannot "
+                    "forward it; skipping. Use http/sse or co-deploy an image.",
+                    r.name,
+                )
+                continue
+        out[r.name] = {"transport": transport, "url": r.url}
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Container co-deploy injection — one helper per multi-container deployer.
+# All are idempotent (skip a server whose container already exists) and never
+# mutate their input.
+# --------------------------------------------------------------------------- #
+
+
+def _codeploy(resolved: list[ResolvedMcpServer]) -> list[ResolvedMcpServer]:
+    return [r for r in resolved if r.co_deploy and r.image]
+
+
+def inject_mcp_containers_ecs(
+    task_definition: dict[str, Any], resolved: list[ResolvedMcpServer]
+) -> dict[str, Any]:
+    """Append co-deployed MCP server containers to an ECS task definition."""
+    result = copy.deepcopy(task_definition)
+    containers: list[dict[str, Any]] = result.setdefault("containerDefinitions", [])
+    existing = {c.get("name") for c in containers}
+    for r in _codeploy(resolved):
+        cname = f"mcp-{r.name}"
+        if cname in existing:
+            continue
+        containers.append(
+            {
+                "name": cname,
+                "image": r.image,
+                "essential": False,
+                "portMappings": [{"containerPort": r.port, "protocol": "tcp"}],
+                "environment": [
+                    {"name": "MCP_TRANSPORT", "value": "http"},
+                    {"name": "PORT", "value": str(r.port)},
+                ],
+            }
+        )
+    return result
+
+
+def inject_mcp_containers_cloudrun(
+    service_spec: dict[str, Any], resolved: list[ResolvedMcpServer]
+) -> dict[str, Any]:
+    """Append co-deployed MCP server containers to a Cloud Run v2 service spec."""
+    result = copy.deepcopy(service_spec)
+    spec = result.setdefault("spec", {})
+    template = spec.setdefault("template", {})
+    tmpl_spec = template.setdefault("spec", {})
+    containers: list[dict[str, Any]] = tmpl_spec.setdefault("containers", [])
+    existing = {c.get("name") for c in containers}
+    for r in _codeploy(resolved):
+        cname = f"mcp-{r.name}"
+        if cname in existing:
+            continue
+        containers.append(
+            {
+                "name": cname,
+                "image": r.image,
+                "env": [
+                    {"name": "MCP_TRANSPORT", "value": "http"},
+                    {"name": "PORT", "value": str(r.port)},
+                ],
+                "ports": [{"containerPort": r.port}],
+            }
+        )
+    return result
+
+
+def inject_mcp_containers_azure(
+    containers: list[dict[str, Any]], resolved: list[ResolvedMcpServer]
+) -> list[dict[str, Any]]:
+    """Append co-deployed MCP containers to an Azure Container Apps container list."""
+    result = copy.deepcopy(containers)
+    existing = {c.get("name") for c in result}
+    for r in _codeploy(resolved):
+        cname = f"mcp-{r.name}"
+        if cname in existing:
+            continue
+        result.append(
+            {
+                "name": cname,
+                "image": r.image,
+                "env": [
+                    {"name": "MCP_TRANSPORT", "value": "http"},
+                    {"name": "PORT", "value": str(r.port)},
+                ],
+            }
+        )
+    return result
+
+
+def inject_mcp_containers_compose(
+    services: dict[str, Any], resolved: list[ResolvedMcpServer]
+) -> dict[str, Any]:
+    """Append co-deployed MCP server services to a docker-compose services dict."""
+    result = copy.deepcopy(services)
+    for r in _codeploy(resolved):
+        sname = f"mcp-{r.name}"
+        if sname in result:
+            continue
+        result[sname] = {
+            "image": r.image,
+            "environment": {"MCP_TRANSPORT": "http", "PORT": str(r.port)},
+            "restart": "unless-stopped",
+        }
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Back-compat shims — keep the original McpSidecarDeployer surface so existing
+# tests (tests/unit/test_mcp_packager.py) and any callers keep working.
+# --------------------------------------------------------------------------- #
+
 
 class McpSidecarDeployer:
-    """Deploy MCP servers as sidecar containers alongside an agent."""
+    """Legacy helper retained for compose generation + tests."""
 
     def generate_sidecars(
         self,
@@ -25,24 +274,10 @@ class McpSidecarDeployer:
         agent_name: str,
         registry_prefix: str = "agentbreeder",
     ) -> list[dict[str, Any]]:
-        """Generate sidecar configurations for all MCP server refs.
-
-        Args:
-            mcp_servers: List of MCP server references from agent.yaml.
-            agent_name: Name of the parent agent (for labeling).
-            registry_prefix: Docker registry prefix for image URIs.
-
-        Returns:
-            List of sidecar container configurations.
-        """
         sidecars: list[dict[str, Any]] = []
-
         for i, mcp in enumerate(mcp_servers):
-            # Extract server name from ref (e.g., "mcp/zendesk" -> "zendesk")
             server_name = mcp.ref.split("/")[-1]
-            version = "latest"
-            image_uri = build_image_tag(server_name, version, registry_prefix)
-
+            image_uri = build_image_tag(server_name, "latest", registry_prefix)
             sidecar = generate_sidecar_config(
                 name=server_name,
                 image_uri=image_uri,
@@ -54,30 +289,18 @@ class McpSidecarDeployer:
                 "agentbreeder.mcp-ref": mcp.ref,
             }
             sidecars.append(sidecar)
-            logger.info(
-                "Generated sidecar for MCP server '%s' (agent: %s)",
-                server_name,
-                agent_name,
-            )
-
         return sidecars
 
     def inject_into_compose(
-        self,
-        compose_config: dict[str, Any],
-        sidecars: list[dict[str, Any]],
+        self, compose_config: dict[str, Any], sidecars: list[dict[str, Any]]
     ) -> dict[str, Any]:
-        """Inject sidecar services into a docker-compose configuration."""
         services = compose_config.setdefault("services", {})
-
         for sidecar in sidecars:
-            service_name = sidecar["name"]
-            services[service_name] = {
+            services[sidecar["name"]] = {
                 "image": sidecar["image"],
                 "environment": sidecar.get("environment", {}),
                 "ports": [f"{sidecar['port']}:{sidecar['port']}"],
                 "labels": sidecar.get("labels", {}),
                 "restart": "unless-stopped",
             }
-
         return compose_config

--- a/engine/schema/agent.schema.json
+++ b/engine/schema/agent.schema.json
@@ -556,6 +556,20 @@
             ],
             "default": "stdio",
             "description": "Transport protocol"
+          },
+          "url": {
+            "type": "string",
+            "description": "Remote HTTP/SSE MCP server URL. When set, the sidecar forwards to it directly."
+          },
+          "image": {
+            "type": "string",
+            "description": "Container image to co-deploy as an MCP sidecar (reachable over localhost)."
+          },
+          "port": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535,
+            "description": "Localhost port for a co-deployed MCP sidecar container. Auto-assigned from 3100 if omitted."
           }
         }
       },

--- a/engine/sidecar/config.py
+++ b/engine/sidecar/config.py
@@ -52,6 +52,8 @@ class SidecarConfig:
     agent_port: int = 8081
     auth_token_env: str = "AGENT_AUTH_TOKEN"
     api_url_env: str = "AGENTBREEDER_API_URL"
+    # MCP server forwarding map for the Go sidecar: {name: {transport, url}}.
+    mcp_servers: dict[str, dict[str, str]] = field(default_factory=dict)
 
     @classmethod
     def from_deploy_config(cls, deploy_sidecar: dict[str, Any] | None) -> SidecarConfig:
@@ -77,13 +79,22 @@ class SidecarConfig:
     def from_agent_config(cls, agent_config: Any) -> SidecarConfig:
         """Build a SidecarConfig from a parsed AgentConfig.
 
-        Reads guardrails declared at the top level of agent.yaml and any
-        deploy.env_vars hint. Used by deployers that auto-inject the sidecar.
+        Reads top-level guardrails and resolves any ``mcp_servers`` into the
+        forwarding map the Go sidecar consumes. MCP resolution here is offline
+        (inline url/image + convention) — registry enrichment happens earlier
+        in the deploy pipeline when a session is available.
         """
         guardrails = _normalise_guardrails(getattr(agent_config, "guardrails", []) or [])
+        mcp_refs = getattr(agent_config, "mcp_servers", None) or []
+        mcp_map: dict[str, dict[str, str]] = {}
+        if mcp_refs:
+            from engine.deployers.mcp_sidecar import build_sidecar_env_map, resolve_mcp_servers
+
+            mcp_map = build_sidecar_env_map(resolve_mcp_servers(mcp_refs))
         return cls(
             enabled=True,
             guardrails=guardrails,
+            mcp_servers=mcp_map,
         )
 
 

--- a/engine/sidecar/injector.py
+++ b/engine/sidecar/injector.py
@@ -20,6 +20,7 @@ Auto-injection helper:
 from __future__ import annotations
 
 import copy
+import json
 import logging
 import os
 from typing import Any
@@ -90,6 +91,14 @@ def inject_sidecar(task_definition: dict[str, Any], config: SidecarConfig) -> di
         },
     }
 
+    if config.mcp_servers:
+        sidecar_container["environment"].append(
+            {
+                "name": "AGENTBREEDER_SIDECAR_MCP_SERVERS",
+                "value": json.dumps(config.mcp_servers),
+            }
+        )
+
     containers.append(sidecar_container)
     logger.info("Injected observability sidecar into ECS task definition")
     return result
@@ -141,6 +150,14 @@ def inject_cloudrun_sidecar(service_spec: dict[str, Any], config: SidecarConfig)
         "ports": [{"containerPort": config.health_port}],
     }
 
+    if config.mcp_servers:
+        sidecar["env"].append(
+            {
+                "name": "AGENTBREEDER_SIDECAR_MCP_SERVERS",
+                "value": json.dumps(config.mcp_servers),
+            }
+        )
+
     containers.append(sidecar)
     logger.info("Injected observability sidecar into Cloud Run service spec")
     return result
@@ -186,6 +203,10 @@ def inject_compose_sidecar(
         "ports": [f"{config.health_port}:{config.health_port}"],
         "depends_on": [agent_service],
     }
+    if config.mcp_servers:
+        result[SIDECAR_NAME]["environment"]["AGENTBREEDER_SIDECAR_MCP_SERVERS"] = json.dumps(
+            config.mcp_servers
+        )
     logger.info("Injected sidecar into docker-compose services")
     return result
 

--- a/sidecar/internal/config/config.go
+++ b/sidecar/internal/config/config.go
@@ -7,6 +7,7 @@
 package config
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -183,6 +184,23 @@ func (c *Config) overlayEnv() {
 			parts := strings.SplitN(kv, "=", 2)
 			if len(parts) == 2 {
 				c.OTLPHeaders[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+			}
+		}
+	}
+
+	// MCP server map as JSON: {"name":{"transport":"http","url":"..."}}.
+	// Env entries override file entries key-by-key so a deployer can wire MCP
+	// upstreams without shipping a YAML file.
+	if raw := os.Getenv("AGENTBREEDER_SIDECAR_MCP_SERVERS"); raw != "" {
+		parsed := map[string]MCPServerSpec{}
+		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+			fmt.Fprintf(os.Stderr, "sidecar: ignoring malformed AGENTBREEDER_SIDECAR_MCP_SERVERS: %v\n", err)
+		} else {
+			if c.MCPServers == nil {
+				c.MCPServers = map[string]MCPServerSpec{}
+			}
+			for name, spec := range parsed {
+				c.MCPServers[name] = spec
 			}
 		}
 	}

--- a/sidecar/internal/config/config_test.go
+++ b/sidecar/internal/config/config_test.go
@@ -214,3 +214,47 @@ func TestIsDisabled(t *testing.T) {
 		}
 	}
 }
+
+func TestOverlayEnvMCPServers(t *testing.T) {
+	t.Setenv("AGENT_NAME", "a")
+	t.Setenv("AGENTBREEDER_SIDECAR_ALLOW_NO_AUTH", "1")
+	t.Setenv("AGENTBREEDER_SIDECAR_MCP_SERVERS",
+		`{"zendesk":{"transport":"http","url":"http://localhost:3100"}}`)
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	spec, ok := cfg.MCPServers["zendesk"]
+	if !ok {
+		t.Fatalf("zendesk not parsed: %+v", cfg.MCPServers)
+	}
+	if spec.Transport != "http" || spec.URL != "http://localhost:3100" {
+		t.Fatalf("bad spec: %+v", spec)
+	}
+}
+
+func TestOverlayEnvMCPServersWinsOverFile(t *testing.T) {
+	t.Setenv("AGENTBREEDER_SIDECAR_MCP_SERVERS",
+		`{"z":{"transport":"sse","url":"http://env"}}`)
+	c := &Config{MCPServers: map[string]MCPServerSpec{
+		"z": {Transport: "http", URL: "http://file"},
+	}}
+	c.overlayEnv()
+	if c.MCPServers["z"].URL != "http://env" {
+		t.Fatalf("env should win: %+v", c.MCPServers["z"])
+	}
+}
+
+func TestOverlayEnvMCPServersMalformedIgnored(t *testing.T) {
+	t.Setenv("AGENT_NAME", "a")
+	t.Setenv("AGENTBREEDER_SIDECAR_ALLOW_NO_AUTH", "1")
+	t.Setenv("AGENTBREEDER_SIDECAR_MCP_SERVERS", `{not json`)
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load should not fail on malformed MCP env: %v", err)
+	}
+	if len(cfg.MCPServers) != 0 {
+		t.Fatalf("expected no MCP servers, got: %+v", cfg.MCPServers)
+	}
+}

--- a/tests/unit/test_helm_chart.py
+++ b/tests/unit/test_helm_chart.py
@@ -1,0 +1,117 @@
+"""Helm chart renders cleanly (P5). Skips render if helm is unavailable."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+CHART = Path(__file__).resolve().parents[2] / "deploy" / "helm" / "agentbreeder"
+
+
+def _chart_without_deps(tmp_path: Path) -> Path:
+    """Copy the chart, stripping the ``dependencies:`` block.
+
+    helm checks dependency *presence* at load time even for condition-disabled
+    deps, so ``helm template`` would otherwise require the Bitnami charts to be
+    fetched (network). Stripping the block lets us validate *our* templates
+    offline and deterministically.
+    """
+    dst = tmp_path / "agentbreeder"
+    shutil.copytree(CHART, dst)
+    chart_yaml = dst / "Chart.yaml"
+    lines = chart_yaml.read_text().splitlines()
+    kept: list[str] = []
+    for line in lines:
+        if line.startswith("dependencies:"):
+            break
+        kept.append(line)
+    chart_yaml.write_text("\n".join(kept) + "\n")
+    return dst
+
+
+@pytest.fixture(scope="module")
+def helm():
+    exe = shutil.which("helm")
+    if not exe:
+        pytest.skip("helm not installed")
+    return exe
+
+
+def test_chart_lint_structure():
+    # Chart.yaml + key templates exist regardless of helm availability.
+    assert (CHART / "Chart.yaml").exists()
+    assert (CHART / "values.yaml").exists()
+    for t in [
+        "api-deployment.yaml",
+        "dashboard-deployment.yaml",
+        "ingress.yaml",
+        "secret.yaml",
+        "configmap.yaml",
+        "migrate-job.yaml",
+        "_helpers.tpl",
+    ]:
+        assert (CHART / "templates" / t).exists(), t
+
+
+def _render(helm: str, tmp_path: Path, *extra: str) -> subprocess.CompletedProcess:
+    chart = _chart_without_deps(tmp_path)
+    return subprocess.run(
+        [helm, "template", "ab", str(chart), *extra],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_helm_template_renders_external(helm, tmp_path):
+    # External DB/Redis path: no bundled passwords required.
+    out = _render(
+        helm,
+        tmp_path,
+        "--set",
+        "postgresql.enabled=false",
+        "--set",
+        "redis.enabled=false",
+        "--set",
+        "externalDatabaseUrl=postgresql+asyncpg://u:p@db:5432/d",
+        "--set",
+        "externalRedisUrl=redis://r:6379",
+        "--set",
+        "host=example.com",
+    )
+    assert out.returncode == 0, out.stderr
+    assert "kind: Deployment" in out.stdout
+    assert "kind: Ingress" in out.stdout
+    assert "DATABASE_URL" in out.stdout
+    assert "rajits/agentbreeder-api:2.6.0" in out.stdout
+    # No shipped/default secrets or mutable tags.
+    assert "change-me" not in out.stdout
+    assert ":latest" not in out.stdout
+
+
+def test_helm_bundled_requires_db_password(helm, tmp_path):
+    # Bundled Postgres with no password must abort the render.
+    out = _render(helm, tmp_path, "--set", "host=x.com")
+    assert out.returncode != 0
+    assert "postgresql.auth.password must be set" in out.stderr
+
+
+def test_helm_tls_restricts_cors_to_https(helm, tmp_path):
+    out = _render(
+        helm,
+        tmp_path,
+        "--set",
+        "postgresql.auth.password=pw",
+        "--set",
+        "redis.auth.password=pw",
+        "--set",
+        "ingress.tls.enabled=true",
+        "--set",
+        "host=secure.example.com",
+    )
+    assert out.returncode == 0, out.stderr
+    assert 'CORS_ORIGINS: "[\\"https://secure.example.com\\"]"' in out.stdout
+    assert "force-ssl-redirect" in out.stdout
+    assert "redis://:pw@" in out.stdout

--- a/tests/unit/test_mcp_deploy_wiring.py
+++ b/tests/unit/test_mcp_deploy_wiring.py
@@ -1,0 +1,65 @@
+"""MCP co-deploy container injection is wired into the deployers (P4)."""
+
+from __future__ import annotations
+
+
+def test_ecs_injects_codeploy_container():
+    from engine.config_parser import McpServerRef
+    from engine.deployers.mcp_sidecar import inject_mcp_containers_ecs, resolve_mcp_servers
+
+    resolved = resolve_mcp_servers(
+        [McpServerRef(ref="mcp/a", transport="sse", image="img:1", port=3100)]
+    )
+    td = inject_mcp_containers_ecs({"containerDefinitions": [{"name": "app"}]}, resolved)
+    names = {c["name"] for c in td["containerDefinitions"]}
+    assert "mcp-a" in names and "app" in names
+    mcp = [c for c in td["containerDefinitions"] if c["name"] == "mcp-a"][0]
+    assert mcp["image"] == "img:1"
+    assert mcp["essential"] is False
+    assert mcp["portMappings"][0]["containerPort"] == 3100
+
+
+def test_ecs_skips_remote_only():
+    from engine.config_parser import McpServerRef
+    from engine.deployers.mcp_sidecar import inject_mcp_containers_ecs, resolve_mcp_servers
+
+    resolved = resolve_mcp_servers([McpServerRef(ref="mcp/a", transport="sse", url="https://x/sse")])
+    td = inject_mcp_containers_ecs({"containerDefinitions": []}, resolved)
+    assert td["containerDefinitions"] == []  # remote → no container
+
+
+def test_ecs_idempotent():
+    from engine.config_parser import McpServerRef
+    from engine.deployers.mcp_sidecar import inject_mcp_containers_ecs, resolve_mcp_servers
+
+    resolved = resolve_mcp_servers([McpServerRef(ref="mcp/a", transport="sse", image="img:1")])
+    td = inject_mcp_containers_ecs({"containerDefinitions": []}, resolved)
+    td2 = inject_mcp_containers_ecs(td, resolved)
+    assert len([c for c in td2["containerDefinitions"] if c["name"] == "mcp-a"]) == 1
+
+
+def test_cloudrun_injects_codeploy_container():
+    from engine.config_parser import McpServerRef
+    from engine.deployers.mcp_sidecar import inject_mcp_containers_cloudrun, resolve_mcp_servers
+
+    resolved = resolve_mcp_servers([McpServerRef(ref="mcp/a", transport="sse", image="img:1")])
+    containers = inject_mcp_containers_cloudrun([{"name": "app"}], resolved)
+    assert any(c["name"] == "mcp-a" and c["image"] == "img:1" for c in containers)
+
+
+def test_azure_injects_codeploy_container():
+    from engine.config_parser import McpServerRef
+    from engine.deployers.mcp_sidecar import inject_mcp_containers_azure, resolve_mcp_servers
+
+    resolved = resolve_mcp_servers([McpServerRef(ref="mcp/a", transport="sse", image="img:1")])
+    containers = inject_mcp_containers_azure([{"name": "app"}], resolved)
+    assert any(c["name"] == "mcp-a" for c in containers)
+
+
+def test_compose_injects_codeploy_service():
+    from engine.config_parser import McpServerRef
+    from engine.deployers.mcp_sidecar import inject_mcp_containers_compose, resolve_mcp_servers
+
+    resolved = resolve_mcp_servers([McpServerRef(ref="mcp/a", transport="sse", image="img:1")])
+    services = inject_mcp_containers_compose({"app": {}}, resolved)
+    assert "mcp-a" in services and services["mcp-a"]["image"] == "img:1"

--- a/tests/unit/test_mcp_deploy_wiring.py
+++ b/tests/unit/test_mcp_deploy_wiring.py
@@ -12,7 +12,8 @@ def test_ecs_injects_codeploy_container():
     )
     td = inject_mcp_containers_ecs({"containerDefinitions": [{"name": "app"}]}, resolved)
     names = {c["name"] for c in td["containerDefinitions"]}
-    assert "mcp-a" in names and "app" in names
+    assert "mcp-a" in names
+    assert "app" in names
     mcp = [c for c in td["containerDefinitions"] if c["name"] == "mcp-a"][0]
     assert mcp["image"] == "img:1"
     assert mcp["essential"] is False
@@ -23,7 +24,9 @@ def test_ecs_skips_remote_only():
     from engine.config_parser import McpServerRef
     from engine.deployers.mcp_sidecar import inject_mcp_containers_ecs, resolve_mcp_servers
 
-    resolved = resolve_mcp_servers([McpServerRef(ref="mcp/a", transport="sse", url="https://x/sse")])
+    resolved = resolve_mcp_servers(
+        [McpServerRef(ref="mcp/a", transport="sse", url="https://x/sse")]
+    )
     td = inject_mcp_containers_ecs({"containerDefinitions": []}, resolved)
     assert td["containerDefinitions"] == []  # remote → no container
 
@@ -62,4 +65,5 @@ def test_compose_injects_codeploy_service():
 
     resolved = resolve_mcp_servers([McpServerRef(ref="mcp/a", transport="sse", image="img:1")])
     services = inject_mcp_containers_compose({"app": {}}, resolved)
-    assert "mcp-a" in services and services["mcp-a"]["image"] == "img:1"
+    assert "mcp-a" in services
+    assert services["mcp-a"]["image"] == "img:1"

--- a/tests/unit/test_mcp_resolve.py
+++ b/tests/unit/test_mcp_resolve.py
@@ -26,3 +26,63 @@ class TestMcpServerRefFields:
         ref = McpServerRef(ref="mcp/slack", transport="sse", image="acme/mcp-slack:1.2.3", port=3100)
         assert ref.image == "acme/mcp-slack:1.2.3"
         assert ref.port == 3100
+
+
+class TestResolveMcpServers:
+    def test_remote_url(self):
+        from engine.config_parser import McpServerRef
+        from engine.deployers.mcp_sidecar import resolve_mcp_servers
+
+        out = resolve_mcp_servers([McpServerRef(ref="mcp/z", transport="sse", url="https://x/sse")])
+        assert len(out) == 1
+        r = out[0]
+        assert r.name == "z" and r.co_deploy is False
+        assert r.url == "https://x/sse" and r.image is None
+
+    def test_inline_image_autoport(self):
+        from engine.config_parser import McpServerRef
+        from engine.deployers.mcp_sidecar import resolve_mcp_servers
+
+        out = resolve_mcp_servers(
+            [McpServerRef(ref="mcp/a", transport="sse", image="img:1")],
+            base_port=3100,
+        )
+        r = out[0]
+        assert r.co_deploy is True and r.image == "img:1"
+        assert r.port == 3100 and r.url == "http://localhost:3100"
+
+    def test_convention_fallback(self):
+        from engine.config_parser import McpServerRef
+        from engine.deployers.mcp_sidecar import resolve_mcp_servers
+
+        out = resolve_mcp_servers([McpServerRef(ref="mcp/slack", transport="sse")])
+        r = out[0]
+        assert r.co_deploy is True
+        assert r.image == "agentbreeder/mcp-slack:latest"
+        assert r.url == "http://localhost:3100"
+
+    def test_registry_lookup_endpoint(self):
+        from engine.config_parser import McpServerRef
+        from engine.deployers.mcp_sidecar import McpServerInfo, resolve_mcp_servers
+
+        def lookup(name):
+            return McpServerInfo(name=name, transport="sse", endpoint="https://reg/sse")
+
+        out = resolve_mcp_servers([McpServerRef(ref="mcp/z")], registry_lookup=lookup)
+        assert out[0].url == "https://reg/sse" and out[0].co_deploy is False
+
+    def test_env_map_skips_remote_stdio(self):
+        from engine.config_parser import McpServerRef
+        from engine.deployers.mcp_sidecar import build_sidecar_env_map, resolve_mcp_servers
+
+        out = resolve_mcp_servers([McpServerRef(ref="mcp/z", transport="stdio", url="http://x")])
+        env = build_sidecar_env_map(out)
+        assert env == {}  # remote stdio can't be forwarded
+
+    def test_env_map_normalises_codeploy_stdio_to_http(self):
+        from engine.config_parser import McpServerRef
+        from engine.deployers.mcp_sidecar import build_sidecar_env_map, resolve_mcp_servers
+
+        out = resolve_mcp_servers([McpServerRef(ref="mcp/a", transport="stdio", image="img:1")])
+        env = build_sidecar_env_map(out)
+        assert env == {"a": {"transport": "http", "url": "http://localhost:3100"}}

--- a/tests/unit/test_mcp_resolve.py
+++ b/tests/unit/test_mcp_resolve.py
@@ -1,0 +1,28 @@
+"""Tests for MCP server ref parsing + resolution (P4)."""
+
+from __future__ import annotations
+
+
+class TestMcpServerRefFields:
+    def test_ref_only_defaults(self):
+        from engine.config_parser import McpServerRef
+
+        ref = McpServerRef(ref="mcp/zendesk")
+        assert ref.ref == "mcp/zendesk"
+        assert ref.transport == "stdio"
+        assert ref.url is None
+        assert ref.image is None
+        assert ref.port is None
+
+    def test_inline_remote(self):
+        from engine.config_parser import McpServerRef
+
+        ref = McpServerRef(ref="mcp/zendesk", transport="sse", url="https://mcp.acme.com/sse")
+        assert ref.url == "https://mcp.acme.com/sse"
+
+    def test_inline_image(self):
+        from engine.config_parser import McpServerRef
+
+        ref = McpServerRef(ref="mcp/slack", transport="sse", image="acme/mcp-slack:1.2.3", port=3100)
+        assert ref.image == "acme/mcp-slack:1.2.3"
+        assert ref.port == 3100

--- a/tests/unit/test_mcp_resolve.py
+++ b/tests/unit/test_mcp_resolve.py
@@ -23,7 +23,9 @@ class TestMcpServerRefFields:
     def test_inline_image(self):
         from engine.config_parser import McpServerRef
 
-        ref = McpServerRef(ref="mcp/slack", transport="sse", image="acme/mcp-slack:1.2.3", port=3100)
+        ref = McpServerRef(
+            ref="mcp/slack", transport="sse", image="acme/mcp-slack:1.2.3", port=3100
+        )
         assert ref.image == "acme/mcp-slack:1.2.3"
         assert ref.port == 3100
 
@@ -33,11 +35,15 @@ class TestResolveMcpServers:
         from engine.config_parser import McpServerRef
         from engine.deployers.mcp_sidecar import resolve_mcp_servers
 
-        out = resolve_mcp_servers([McpServerRef(ref="mcp/z", transport="sse", url="https://x/sse")])
+        out = resolve_mcp_servers(
+            [McpServerRef(ref="mcp/z", transport="sse", url="https://x/sse")]
+        )
         assert len(out) == 1
         r = out[0]
-        assert r.name == "z" and r.co_deploy is False
-        assert r.url == "https://x/sse" and r.image is None
+        assert r.name == "z"
+        assert r.co_deploy is False
+        assert r.url == "https://x/sse"
+        assert r.image is None
 
     def test_inline_image_autoport(self):
         from engine.config_parser import McpServerRef
@@ -48,8 +54,10 @@ class TestResolveMcpServers:
             base_port=3100,
         )
         r = out[0]
-        assert r.co_deploy is True and r.image == "img:1"
-        assert r.port == 3100 and r.url == "http://localhost:3100"
+        assert r.co_deploy is True
+        assert r.image == "img:1"
+        assert r.port == 3100
+        assert r.url == "http://localhost:3100"
 
     def test_convention_fallback(self):
         from engine.config_parser import McpServerRef
@@ -69,7 +77,8 @@ class TestResolveMcpServers:
             return McpServerInfo(name=name, transport="sse", endpoint="https://reg/sse")
 
         out = resolve_mcp_servers([McpServerRef(ref="mcp/z")], registry_lookup=lookup)
-        assert out[0].url == "https://reg/sse" and out[0].co_deploy is False
+        assert out[0].url == "https://reg/sse"
+        assert out[0].co_deploy is False
 
     def test_env_map_skips_remote_stdio(self):
         from engine.config_parser import McpServerRef

--- a/tests/unit/test_nginx_template.py
+++ b/tests/unit/test_nginx_template.py
@@ -1,0 +1,54 @@
+"""The dashboard nginx template renders API_UPSTREAM from env (P5)."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+TEMPLATE = REPO / "dashboard" / "nginx.conf.template"
+ENTRYPOINT = REPO / "dashboard" / "docker-entrypoint.sh"
+
+
+def _render(env: dict[str, str]) -> str:
+    # Mirror the container entrypoint: envsubst with an explicit var allow-list.
+    envsubst = shutil.which("envsubst")
+    if not envsubst:
+        pytest.skip("envsubst not installed")
+    full = {**os.environ, **env}
+    out = subprocess.run(
+        [envsubst, "${API_UPSTREAM} ${LISTEN_PORT}"],
+        input=TEMPLATE.read_text(),
+        capture_output=True,
+        text=True,
+        env=full,
+        check=True,
+    )
+    return out.stdout
+
+
+def test_template_has_placeholders():
+    text = TEMPLATE.read_text()
+    assert "${API_UPSTREAM}" in text
+    assert "${LISTEN_PORT}" in text
+    # nginx runtime vars must NOT be in the substitution list (they stay literal).
+    assert "$host" in text
+
+
+def test_entrypoint_uses_explicit_var_list():
+    text = ENTRYPOINT.read_text()
+    # Only our two vars are substituted, so nginx's own $host/$uri survive.
+    assert "envsubst '${API_UPSTREAM} ${LISTEN_PORT}'" in text
+    assert 'exec "$@"' in text
+
+
+def test_renders_custom_upstream():
+    rendered = _render({"API_UPSTREAM": "http://my-api:9000", "LISTEN_PORT": "3001"})
+    assert "proxy_pass http://my-api:9000" in rendered
+    assert "listen 3001;" in rendered
+    assert "$host" in rendered  # nginx runtime var preserved
+    assert "${" not in rendered  # all our placeholders substituted

--- a/tests/unit/test_sidecar_injector.py
+++ b/tests/unit/test_sidecar_injector.py
@@ -187,3 +187,28 @@ def test_sidecar_config_from_dict() -> None:
     assert cfg.guardrails == ["pii_detection"]
     assert cfg.otel_endpoint == "http://custom:4317"
     assert cfg.cost_tracking is False
+
+
+class TestSidecarConfigMcp:
+    def _agent(self, mcp):
+        from engine.config_parser import McpServerRef
+
+        class _A:
+            guardrails = []
+            mcp_servers = [McpServerRef(**m) for m in mcp]
+
+        return _A()
+
+    def test_mcp_servers_populated_from_image(self):
+        from engine.sidecar.config import SidecarConfig
+
+        sc = SidecarConfig.from_agent_config(
+            self._agent([{"ref": "mcp/a", "transport": "sse", "image": "img:1", "port": 3100}])
+        )
+        assert sc.mcp_servers == {"a": {"transport": "sse", "url": "http://localhost:3100"}}
+
+    def test_no_mcp_means_empty(self):
+        from engine.sidecar.config import SidecarConfig
+
+        sc = SidecarConfig.from_agent_config(self._agent([]))
+        assert sc.mcp_servers == {}

--- a/tests/unit/test_sidecar_injector.py
+++ b/tests/unit/test_sidecar_injector.py
@@ -212,3 +212,57 @@ class TestSidecarConfigMcp:
 
         sc = SidecarConfig.from_agent_config(self._agent([]))
         assert sc.mcp_servers == {}
+
+
+class TestInjectorMcpEnv:
+    def _cfg(self):
+        from engine.sidecar.config import SidecarConfig
+
+        return SidecarConfig(
+            mcp_servers={"a": {"transport": "http", "url": "http://localhost:3100"}}
+        )
+
+    def _env_value(self, env_list):
+        for e in env_list:
+            if e["name"] == "AGENTBREEDER_SIDECAR_MCP_SERVERS":
+                return e["value"]
+        return None
+
+    def test_ecs_emits_mcp_env(self):
+        import json
+
+        from engine.sidecar.injector import inject_sidecar
+
+        td = inject_sidecar({}, self._cfg())
+        sidecar = [c for c in td["containerDefinitions"] if c["name"] == "agentbreeder-sidecar"][0]
+        val = self._env_value(sidecar["environment"])
+        assert json.loads(val) == {"a": {"transport": "http", "url": "http://localhost:3100"}}
+
+    def test_cloudrun_emits_mcp_env(self):
+        from engine.sidecar.injector import inject_cloudrun_sidecar
+
+        spec = inject_cloudrun_sidecar({}, self._cfg())
+        containers = spec["spec"]["template"]["spec"]["containers"]
+        sidecar = [c for c in containers if c["name"] == "agentbreeder-sidecar"][0]
+        assert self._env_value(sidecar["env"]) is not None
+
+    def test_compose_emits_mcp_env(self):
+        import json
+
+        from engine.sidecar.injector import inject_compose_sidecar
+
+        services = inject_compose_sidecar({}, self._cfg())
+        env = services["agentbreeder-sidecar"]["environment"]
+        assert json.loads(env["AGENTBREEDER_SIDECAR_MCP_SERVERS"]) == {
+            "a": {"transport": "http", "url": "http://localhost:3100"}
+        }
+
+    def test_no_mcp_no_env(self):
+        from engine.sidecar.config import SidecarConfig
+        from engine.sidecar.injector import inject_compose_sidecar
+
+        services = inject_compose_sidecar({}, SidecarConfig())
+        assert (
+            "AGENTBREEDER_SIDECAR_MCP_SERVERS"
+            not in services["agentbreeder-sidecar"]["environment"]
+        )

--- a/website/content/docs/agent-yaml.mdx
+++ b/website/content/docs/agent-yaml.mdx
@@ -446,20 +446,36 @@ subagents:
 
 ### `mcp_servers`
 
-List of MCP server references to deploy as sidecars alongside the agent.
+List of MCP server references the agent can call. At deploy time each entry is
+either **forwarded** to a remote URL or **co-deployed** as a sidecar container,
+and the AgentBreeder sidecar exposes it to the agent at
+`http://localhost:9091/mcp/<name>`.
 
 ```yaml
 mcp_servers:
-  - ref: mcp/zendesk
+  - ref: mcp/zendesk          # registry reference
     transport: sse
+    url: https://mcp.acme.com/sse   # remote server — sidecar forwards here
   - ref: mcp/slack
-    transport: stdio
+    transport: sse
+    image: acme/mcp-slack:1.2.3     # co-deployed as a sidecar container
+    port: 3100                       # localhost port (auto from 3100 if omitted)
 ```
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `ref` | string | **Yes** | — | Registry reference path to the MCP server. |
 | `transport` | string | No | `stdio` | MCP transport type: `stdio`, `sse`, `streamable_http`. |
+| `url` | string | No | — | Remote HTTP/SSE MCP server URL. When set, the sidecar forwards directly to it (no container is co-deployed). |
+| `image` | string | No | — | Container image to co-deploy as an MCP sidecar (reachable over localhost). |
+| `port` | integer | No | `3100+` | Localhost port for a co-deployed MCP container. Auto-assigned from 3100 when omitted. |
+
+When neither `url` nor `image` is given, the deployer co-deploys a
+conventionally-named image (`agentbreeder/mcp-<name>:latest`). Co-deploy works on
+multi-container targets (AWS ECS, GCP Cloud Run, Azure Container Apps,
+docker-compose); single-container targets (App Runner) can only use remote `url`
+servers. A **remote** `stdio` server cannot be forwarded — use `sse`/`http`, or
+co-deploy an `image`.
 
 ---
 

--- a/website/content/docs/mcp-servers.mdx
+++ b/website/content/docs/mcp-servers.mdx
@@ -375,6 +375,35 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
 ```
 
+### Deploying with an agent — forward vs co-deploy
+
+At deploy time every `mcp_servers` entry in `agent.yaml` resolves to one of two
+shapes, and the AgentBreeder sidecar exposes it to the agent at
+`http://localhost:9091/mcp/<name>`:
+
+- **Forward (remote)** — set `url:` to a remote HTTP/SSE MCP server. The sidecar
+  forwards JSON-RPC straight to it; nothing is co-deployed. Works on every
+  deploy target.
+- **Co-deploy (container)** — set `image:` (or omit both and rely on the
+  `agentbreeder/mcp-<name>:latest` convention). The image runs as a sibling
+  container on multi-container targets (AWS ECS, GCP Cloud Run, Azure Container
+  Apps, docker-compose), reachable over `localhost:<port>`.
+
+```yaml
+mcp_servers:
+  - ref: mcp/docs
+    transport: sse
+    url: https://docs.example.com/mcp     # forwarded
+  - ref: mcp/zendesk
+    transport: sse
+    image: agentbreeder/mcp-zendesk:1.0.0  # co-deployed
+    port: 3100
+```
+
+Forwarding is HTTP/SSE-only: a co-deployed server speaks HTTP on its port, and a
+*remote* `stdio` server cannot be forwarded (use `sse`/`http`, or co-deploy an
+image). Single-container targets (App Runner) support remote `url` servers only.
+
 ---
 
 ## API Reference

--- a/website/content/docs/meta.json
+++ b/website/content/docs/meta.json
@@ -33,6 +33,7 @@
     "a2a-protocol",
     "---Deploy & Run---",
     "deployment",
+    "self-hosting",
     "providers",
     "gateways",
     "connectors",

--- a/website/content/docs/self-hosting.mdx
+++ b/website/content/docs/self-hosting.mdx
@@ -1,0 +1,157 @@
+---
+title: Self-Hosting
+description: Run the full AgentBreeder platform (Studio + API + Postgres + Redis) on your own Kubernetes cluster with Helm.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Tabs, Tab } from 'fumadocs-ui/components/tabs';
+
+AgentBreeder ships a Helm chart that runs the whole platform — **AgentBreeder
+Studio**, the **API**, and database migrations — on your own Kubernetes cluster.
+Postgres and Redis come bundled as toggleable dependencies, so you can start with
+one command and switch to managed datastores when you go to production.
+
+The chart lives at [`deploy/helm/agentbreeder`](https://github.com/agentbreeder/agentbreeder/tree/main/deploy/helm/agentbreeder).
+
+## Prerequisites
+
+- A Kubernetes cluster (1.25+) and `kubectl` pointed at it
+- [Helm 3](https://helm.sh/docs/intro/install/)
+- An ingress controller (the chart defaults to the `nginx` ingress class)
+- A DNS record for your chosen `host` pointing at the ingress
+- For TLS: a TLS Secret, or [cert-manager](https://cert-manager.io/)
+
+## Quick start
+
+```bash
+# Fetch the bundled Postgres/Redis subcharts
+helm dependency update deploy/helm/agentbreeder
+
+# Install. Bundled datastores REQUIRE explicit passwords — no defaults ship.
+helm install agentbreeder deploy/helm/agentbreeder \
+  --namespace agentbreeder --create-namespace \
+  --set host=agents.example.com \
+  --set postgresql.auth.password="$(openssl rand -hex 16)" \
+  --set redis.auth.password="$(openssl rand -hex 16)"
+```
+
+Studio is then served at `https://agents.example.com`, the API at
+`/api/v1`, and the OpenAPI docs at `/api/docs`.
+
+<Callout type="info" title="Signing keys are generated for you">
+  `SECRET_KEY` and `JWT_SECRET_KEY` are auto-generated on first install and
+  preserved across upgrades (no known default is ever shipped). Set
+  `secrets.secretKey` / `secrets.jwtSecretKey`, or point `secrets.existingSecret`
+  at a pre-created Secret, to manage them yourself.
+</Callout>
+
+## Using external managed Postgres / Redis
+
+For production, disable the bundled stores and point at managed datastores. The
+connection strings are stored in the release Secret and injected as
+`DATABASE_URL` / `REDIS_URL`.
+
+```bash
+helm install agentbreeder deploy/helm/agentbreeder \
+  --namespace agentbreeder --create-namespace \
+  --set host=agents.example.com \
+  --set postgresql.enabled=false \
+  --set redis.enabled=false \
+  --set externalDatabaseUrl="postgresql+asyncpg://user:pw@db.example.com:5432/agentbreeder" \
+  --set externalRedisUrl="redis://cache.example.com:6379"
+```
+
+<Callout type="warn">
+  `DATABASE_URL` must use the `postgresql+asyncpg://` driver — the API runs async
+  SQLAlchemy. A bare `postgresql://` URL will fail at startup.
+</Callout>
+
+## TLS
+
+TLS is off by default so you can evaluate the chart with plain HTTP. **Turn it on
+for anything real** — when enabled, the chart also adds an HTTP→HTTPS redirect and
+restricts CORS to the `https://` origin.
+
+<Tabs items={['Pre-created secret', 'cert-manager']}>
+<Tab value="Pre-created secret">
+
+```bash
+kubectl create secret tls agentbreeder-tls \
+  --cert=tls.crt --key=tls.key -n agentbreeder
+
+helm upgrade agentbreeder deploy/helm/agentbreeder \
+  --set ingress.tls.enabled=true \
+  --set ingress.tls.secretName=agentbreeder-tls
+```
+
+</Tab>
+<Tab value="cert-manager">
+
+```bash
+helm upgrade agentbreeder deploy/helm/agentbreeder \
+  --set ingress.tls.enabled=true \
+  --set ingress.tls.secretName=agentbreeder-tls \
+  --set ingress.annotations."cert-manager\.io/cluster-issuer"=letsencrypt-prod
+```
+
+</Tab>
+</Tabs>
+
+## CORS
+
+CORS is derived from `host` automatically: `https://<host>` (and `http://<host>`
+only while TLS is disabled). The API reads it as the `CORS_ORIGINS` env var. To
+allow additional origins, add them under `api.env` (as a JSON array string, since
+pydantic-settings parses the list from JSON):
+
+```yaml
+api:
+  env:
+    CORS_ORIGINS: '["https://agents.example.com","https://studio.internal"]'
+```
+
+## Migrations
+
+A `pre-install,pre-upgrade` Helm hook Job runs `alembic upgrade head` against the
+database before the API rolls out, so the schema is always current. Disable it
+with `--set migrate.enabled=false` if you manage migrations yourself.
+
+## Configuration reference
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `host` | `agentbreeder.local` | Public hostname (Ingress + CORS). |
+| `image.tag` | `2.6.0` | Image tag for api + dashboard (pin per environment). |
+| `secrets.secretKey` / `secrets.jwtSecretKey` | _(auto-generated)_ | App signing keys. |
+| `secrets.existingSecret` | `""` | Use a pre-created Secret instead of generating. |
+| `postgresql.enabled` | `true` | Bundle Postgres (set `false` for external). |
+| `postgresql.auth.password` | _(required)_ | Bundled Postgres password — install aborts if unset. |
+| `redis.enabled` | `true` | Bundle Redis (auth on). |
+| `redis.auth.password` | _(required)_ | Bundled Redis password — install aborts if unset. |
+| `externalDatabaseUrl` / `externalRedisUrl` | `""` | Connection strings when bundling is off. |
+| `ingress.enabled` | `true` | Create an Ingress. |
+| `ingress.tls.enabled` | `false` | Terminate TLS + force HTTPS redirect. |
+| `migrate.enabled` | `true` | Run `alembic upgrade head` as a pre-upgrade hook. |
+
+## Docker Compose alternative
+
+If you don't run Kubernetes, the standalone Compose file brings up the same stack
+from pre-built images:
+
+```bash
+curl -O https://raw.githubusercontent.com/agentbreeder/agentbreeder/main/deploy/docker-compose.standalone.yml
+docker compose -f docker-compose.standalone.yml up -d
+```
+
+Override `SECRET_KEY` / `JWT_SECRET_KEY` and the Postgres password before exposing
+it to any network.
+
+## Troubleshooting
+
+- **Install aborts with `postgresql.auth.password must be set`** — bundled stores
+  require explicit passwords. Pass them with `--set`, or use external datastores.
+- **API `CrashLoopBackOff`** — check `DATABASE_URL` uses `postgresql+asyncpg://`
+  and that the migrate Job completed (`kubectl logs job/agentbreeder-migrate`).
+- **Studio loads but API calls 502** — the dashboard proxies `/api` to the API
+  Service via the `API_UPSTREAM` env (set by the chart); confirm the API pods are
+  `Ready` and the Service name matches.

--- a/website/content/docs/sidecar.mdx
+++ b/website/content/docs/sidecar.mdx
@@ -179,6 +179,17 @@ resp = httpx.post(
   v1 supports HTTP / SSE upstream MCP servers. Stdio transport is deferred to a follow-up — see the TODO in `sidecar/internal/mcp/mcp.go`.
 </Callout>
 
+### How the map gets populated
+
+You rarely write the map above by hand. When an agent declares
+[`mcp_servers`](/docs/agent-yaml#mcp_servers), the deployer resolves each entry
+to a forwarding target and passes the sidecar a JSON map via the
+`AGENTBREEDER_SIDECAR_MCP_SERVERS` env var (env overrides any mounted
+`sidecar.yaml`). A remote `url` is forwarded as-is; an `image` is co-deployed as
+a sibling container and forwarded over `localhost:<port>`. Because forwarding is
+HTTP/SSE-only, a co-deployed server always speaks HTTP on its port and a *remote
+stdio* server is skipped.
+
 ---
 
 ## Cost events


### PR DESCRIPTION
Completes the final two phases of the cloud-agnostic deployment epic (#522/#525/#526/#527 + this), as one combined PR.

## P4 — MCP server deployment
Makes `agent.yaml` `mcp_servers` deploy end-to-end and revives the dead `engine/deployers/mcp_sidecar.py` + `engine/mcp/packager.py`.

- **`McpServerRef`** gains optional `url` / `image` / `port` (+ JSON schema) so a deploy is self-contained — no running registry required.
- **`resolve_mcp_servers()`** turns each ref into a `ResolvedMcpServer`: remote `url` → forwarded; `image` (or convention `agentbreeder/mcp-<name>:latest`) → co-deployed container on a localhost port. Optional best-effort registry enrichment via an injected `registry_lookup`.
- **Co-deploy injectors** for the 4 multi-container deployers (AWS ECS, GCP Cloud Run, Azure Container Apps, docker-compose). Compose attaches MCP siblings to the sidecar's netns (`network=container:<sidecar>`) so the `localhost:<port>` forward contract holds everywhere.
- **Go sidecar** now parses `AGENTBREEDER_SIDECAR_MCP_SERVERS` (JSON `{name:{transport,url}}`) in `overlayEnv()` — env overrides the mounted YAML. `SidecarConfig.mcp_servers` is resolved from the agent config and emitted by every injector + manual sidecar builder, so the agent reaches each server at `http://localhost:9091/mcp/<name>`.
- HTTP/SSE only: co-deployed `stdio` is normalised to `http`; a *remote* `stdio` server is skipped (can't be forwarded). App Runner (single-container) supports remote `url` servers only.

## P5 — Studio self-hosting
- **Env-driven nginx**: the dashboard image renders its config from `API_UPSTREAM`/`LISTEN_PORT` at startup via `envsubst` (custom entrypoint that works under the existing non-root `USER nginx`, since nginx:alpine's `/docker-entrypoint.d` is root-only).
- **Helm chart** at `deploy/helm/agentbreeder`: Studio + API + a pre-upgrade `alembic` migrate Job, with **toggleable** Bitnami Postgres/Redis subcharts (bundled by default, or point at `externalDatabaseUrl`/`externalRedisUrl`), a TLS-capable Ingress, and Secret/ConfigMap.
- **Security-hardened** (per automated review): app signing keys auto-generated + preserved across upgrades (no shipped default); bundled Postgres/Redis passwords are **required** (install aborts if unset) with Redis auth on; image tag pinned to `2.6.0` (no `latest`); CORS restricted to `https://` when TLS is on, with an HTTP→HTTPS redirect.
- `self-hosting.mdx` + docs nav + README.

## Testing
- New: `test_mcp_resolve.py`, `test_mcp_deploy_wiring.py`, `test_nginx_template.py`, `test_helm_chart.py`; extended `test_sidecar_injector.py` + Go `config_test.go`.
- Helm chart validated with `helm template`/`lint` in 3 modes (external, bundled+TLS, missing-password→abort).
- Full unit suite: **5319 passed**, 1 skipped. The single local failure (`test_provisioners.py::test_provision_destroy_raise_not_implemented_for_now`) is a pre-existing boto3-creds flake that passes in CI. Repo-wide ruff clean. (Go tests run in CI — Go isn't installed locally.)

## Cross-repo
Grepped `agentbreeder-cloud` for `mcp_servers`/`McpServerRef`/helm/nginx surfaces — no hits; the new `agent.yaml` fields are additive/optional, so no companion change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
