### PR TITLE
docs(deployment): correct AWS greenfield vs existing-account deploy story

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -2841,9 +2841,9 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -7076,9 +7076,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -7173,9 +7173,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.1.tgz",
-      "integrity": "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -7195,12 +7195,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.1.tgz",
-      "integrity": "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.14.1"
+        "react-router": "7.17.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -8325,9 +8325,9 @@
       }
     },
     "node_modules/typescript-eslint/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/website/content/docs/cli-reference.mdx
+++ b/website/content/docs/cli-reference.mdx
@@ -129,7 +129,7 @@ agentbreeder quickstart [--cloud TARGET] [--no-browser] [--skip-seed] [--dev] [-
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--cloud` | — | Also deploy to cloud after local setup. `aws` (ECS Fargate), `gcp` (Cloud Run), and `azure` (Container Apps) all ship with full governance parity and greenfield `--provision`. Secret auto-mirror ships for GCP + Azure; on AWS, pre-create secrets in Secrets Manager. See the [deploy-target status table](#agentbreeder-deploy). |
+| `--cloud` | — | Also deploy to cloud after local setup. `aws` (ECS Fargate), `gcp` (Cloud Run), and `azure` (Container Apps) all ship with full governance parity. This CLI path deploys into **existing** infra (plus auto-provisioned RDS/Redis data backends); greenfield provisioning ships via the [Studio deploy wizard](deployment#deploying-from-studio). Secret auto-mirror ships for GCP + Azure; on AWS, pre-create secrets in Secrets Manager. See the [deploy-target status table](#agentbreeder-deploy). |
 | `--no-browser` | Off | Don't open Studio at `http://localhost:3001` |
 | `--skip-seed` | Off | Skip ChromaDB + Neo4j seeding (fast restart) |
 | `--dev` | Off | Build API and Studio from local source instead of pulling images |
@@ -326,15 +326,30 @@ Mode is picked by these rules, in order:
 
 This is the **canonical deploy-target status table** for AgentBreeder — other docs link here rather than repeating it. As of **v2.6.0**, the same `agent.yaml` deploys with **full governance parity** — the sidecar (guardrails, cost, tracing) plus secret mirroring — to **Local**, **AWS ECS Fargate**, **GCP Cloud Run**, and **Azure Container Apps**. **AWS App Runner** is single-container: it deploys *without* a sidecar and **rejects** `guardrails:` / `secrets:` at `validate-infra`. **Kubernetes** and **Claude-managed** are in flight.
 
+**Greenfield vs. existing account.** The **CLI** (`agentbreeder deploy`) deploys
+into **existing infrastructure** — a VPC, subnets, cluster, and execution role you
+already have (the per-cloud BYO contract). **Greenfield** provisioning (creating that
+footprint from scratch) ships today through the **Studio deploy wizard** (Step 3 →
+*Provision for me*); the CLI `--provision` flag is on the
+[roadmap](https://github.com/agentbreeder/agentbreeder/issues/383). Independently,
+**both surfaces auto-provision the data tier** (RDS pgvector / ElastiCache Redis) when
+an agent declares `memory:` or a knowledge base without a `backend_url`.
+
 | Target | Status | Greenfield provisioning | Sidecar (governance) | Secret auto-mirror |
 |--------|--------|--------------------------|----------------------|--------------------|
-| `local` (Docker Compose) | ✅ Shipped | ✅ | ✅ | n/a (local `.env`) |
-| `ecs-fargate` (AWS) | ✅ Shipped | ✅ `--provision` | ✅ | 🟡 Roadmap — pre-create in Secrets Manager |
-| `cloud-run` (GCP) | ✅ Shipped | ✅ `--provision` | ✅ | ✅ |
-| `container-apps` (Azure) | ✅ Shipped | ✅ `--provision` | ✅ | ✅ |
-| `app-runner` (AWS) | ✅ Shipped (single-container) | ✅ `--provision` | ❌ — rejects `guardrails:`/`secrets:` | ❌ — not supported |
+| `local` (Docker Compose) | ✅ Shipped | ✅ (nothing to provision) | ✅ | n/a (local `.env`) |
+| `ecs-fargate` (AWS) | ✅ Shipped | ✅ Studio wizard¹ · CLI BYO + auto data tier | ✅ | 🟡 Roadmap — pre-create in Secrets Manager |
+| `cloud-run` (GCP) | ✅ Shipped | ✅ Studio wizard¹ · CLI BYO + auto data tier | ✅ | ✅ |
+| `container-apps` (Azure) | ✅ Shipped | ✅ Studio wizard¹ · CLI BYO + auto data tier | ✅ | ✅ |
+| `app-runner` (AWS) | ✅ Shipped (single-container) | CLI BYO only — wizard provisions ECS Fargate, not App Runner | ❌ — rejects `guardrails:`/`secrets:` | ❌ — not supported |
 | `kubernetes` (EKS/GKE/AKS/self-hosted) | 🟡 In flight | ❌ — needs existing cluster + kubeconfig | ✅ (when usable) | 🟡 Roadmap |
 | `claude-managed` (Anthropic) | 🟡 In flight | n/a — runtime is Anthropic-managed | n/a | n/a |
+
+¹ Greenfield provisioning runs through **Studio → Deploys → New deploy** (the
+`/deploy-wizard` flow) and the deployments job API (`POST /api/v1/deployments` with
+`infra_mode: "provision"`). See [Deployment → Deploying from Studio](deployment#deploying-from-studio).
+The equivalent CLI flag (`agentbreeder deploy --provision`) is not yet shipped — from
+the terminal, deploy into existing infra (BYO) or pre-create the footprint first.
 
 Each `--target` value maps to one cloud + runtime combination:
 

--- a/website/content/docs/deployment.mdx
+++ b/website/content/docs/deployment.mdx
@@ -24,11 +24,26 @@ Container Apps with the per-cloud user-input contract below.
   this page was generated from that deploy.
 </Callout>
 
-<Callout type="info" title="Which targets ship greenfield?">
-  For the canonical, up-to-date matrix of which `--target` values provision
-  infrastructure from scratch versus which require pre-existing infra, see the
-  [deploy-target status table in the CLI reference](cli-reference#agentbreeder-deploy).
-  This page focuses on the **actionable prerequisites** for each target — see
+<Callout type="info" title="Greenfield vs. existing account — which surface does what">
+  AgentBreeder supports **two starting points** for every cloud:
+
+  - **Existing account / BYO infra** — you already have a VPC, subnets, an ECS
+    cluster, and an execution role. Both the **CLI** (`agentbreeder deploy`) and
+    **Studio** deploy into them. This is the path the two verified walkthroughs
+    on this page use.
+  - **Greenfield** — a fresh account with no networking. AgentBreeder provisions
+    the whole footprint (VPC, subnets, NAT, security groups, cluster, IAM, and —
+    when declared — RDS/ALB) for you. Today this ships through the **Studio
+    deploy wizard** (Step 3 → *Provision for me*) and the deployments job API;
+    CLI parity (`deploy --provision`) is on the
+    [roadmap](https://github.com/agentbreeder/agentbreeder/issues/383).
+
+  Independently of which path you pick, the CLI and Studio both **auto-provision
+  the data tier** (RDS pgvector / ElastiCache Redis) when an agent declares
+  `memory:` or a knowledge base without a `backend_url`. For the at-a-glance
+  matrix, see the
+  [deploy-target status table in the CLI reference](cli-reference#agentbreeder-deploy);
+  for actionable per-target prerequisites, see
   [Prerequisites per target](#prerequisites-per-target-as-of-2026-05-18) below.
 </Callout>
 
@@ -73,7 +88,10 @@ Both modes are served by two API endpoints:
 
 In simple mode AgentBreeder uses ECS cluster `agentbreeder-default`, IAM role
 `agentbreeder-ecs-execution-role`, the default VPC, and the default security group.
-These are auto-created on first deploy in greenfield mode (coming with [#383](https://github.com/agentbreeder/agentbreeder/issues/383)).
+Those defaults must already exist for a **CLI** deploy. To have AgentBreeder
+create them for you on a fresh account, use **Greenfield mode** (below) via the
+Studio wizard; the equivalent CLI auto-create is on the
+[roadmap](https://github.com/agentbreeder/agentbreeder/issues/383).
 
 **Full mode adds:**
 
@@ -94,10 +112,24 @@ These are auto-created on first deploy in greenfield mode (coming with [#383](ht
 `ec2:DescribeSecurityGroups`, `ecs:DescribeClusters`, `iam:GetRole`,
 `ecr:DescribeRepositories`.
 
-**Greenfield mode (`agentbreeder deploy --target aws --provision`):**
+**Greenfield mode (Studio → "Provision for me"):**
 
-For fresh AWS accounts, AgentBreeder creates the minimum-viable ECS Fargate
-footprint end-to-end. Only `AWS_REGION` and a credential chain are required.
+For a fresh AWS account with no networking, AgentBreeder creates the
+minimum-viable ECS Fargate footprint end-to-end. Today this runs through the
+**Studio deploy wizard** (Step 3 → *Provision for me*) and the deployments job
+API (`POST /api/v1/deployments` with `infra_mode: "provision"`), which drives the
+`AWSProvisioner.provision()` greenfield path with live SSE progress and
+partial-rollback on failure. Only `AWS_REGION` and a credential chain are
+required — no pre-existing cluster, subnets, or roles. See [Deploying from
+Studio](#deploying-from-studio) for the walkthrough.
+
+<Callout type="info" title="CLI greenfield is on the roadmap">
+  `agentbreeder deploy --target aws --provision` ([#383](https://github.com/agentbreeder/agentbreeder/issues/383))
+  will run this same provisioner from the terminal. Until it ships, the **CLI
+  deploys into existing infra** (the BYO fields above are required) — but it
+  still **auto-provisions the data tier** (RDS pgvector / ElastiCache Redis) when
+  you declare `memory:` or a knowledge base without a `backend_url`.
+</Callout>
 
 | Resource | Notes |
 |---|---|
@@ -145,11 +177,15 @@ You still need the four IAM roles documented in [One-time IAM grants](#one-time-
 `resourcemanager:GetProject`, `artifactregistry:GetRepository`,
 `iam:GetServiceAccount`.
 
-**Greenfield mode (`agentbreeder deploy --target gcp --provision`):**
+**Greenfield mode (Studio → "Provision for me"):**
 
 For fresh GCP projects, AgentBreeder can create infrastructure on your behalf
-in place of the "Full mode" inputs above. Only `GOOGLE_CLOUD_PROJECT` and
-`GCP_REGION` are required; everything else is opt-in via environment flags.
+in place of the "Full mode" inputs above. Like AWS, this runs through the
+**Studio deploy wizard** and the deployments job API today; CLI parity
+(`deploy --target gcp --provision`) is on the
+[roadmap](https://github.com/agentbreeder/agentbreeder/issues/383). Only
+`GOOGLE_CLOUD_PROJECT` and `GCP_REGION` are required; everything else is opt-in
+via environment flags.
 
 | Flag | Effect |
 |---|---|
@@ -220,11 +256,15 @@ In simple mode AgentBreeder uses Resource Group `agentbreeder-rg`, auto-creates 
 `ContainerRegistryManagementClient.registries.get`,
 `ContainerAppsAPIClient.managed_environments.get`.
 
-**Greenfield mode (`agentbreeder deploy --target azure --provision`):**
+**Greenfield mode (Studio → "Provision for me"):**
 
 For fresh Azure subscriptions, AgentBreeder creates the minimum-viable
-Container Apps footprint end-to-end. Only `AZURE_SUBSCRIPTION_ID` and a
-credential chain (service-principal env vars or `az login`) are required.
+Container Apps footprint end-to-end. Like AWS and GCP, this runs through the
+**Studio deploy wizard** and the deployments job API today; CLI parity
+(`deploy --target azure --provision`) is on the
+[roadmap](https://github.com/agentbreeder/agentbreeder/issues/383). Only
+`AZURE_SUBSCRIPTION_ID` and a credential chain (service-principal env vars or
+`az login`) are required.
 
 | Resource | Notes |
 |---|---|
@@ -490,6 +530,15 @@ against live AWS: a feature-rich agent — NVIDIA Llama-3.1-8B, a pgvector
 knowledge base, Redis-backed memory, and a web-search tool — deploys, serves,
 answers a multi-turn chat, and tears down with **zero orphaned resources**.
 
+<Callout type="info" title="This is the existing-account (BYO) path">
+  This walkthrough uses the **CLI** deploying into an **existing** VPC, subnets,
+  cluster, and execution role (named in `deploy.env_vars` below) — the data tier
+  (RDS + ElastiCache) is the only thing auto-provisioned. If you're starting from
+  a **fresh AWS account** with no networking, use the greenfield
+  [Studio wizard](#deploying-from-studio) instead, which creates the VPC, NAT,
+  cluster, and IAM for you.
+</Callout>
+
 <Callout type="info" title="What makes ECS Fargate special">
   Declare a knowledge base or `memory:` **without** a `backend_url` and the
   deployer **auto-provisions** the managed data stores (RDS pgvector,
@@ -715,18 +764,22 @@ for the full flow.
 ## Prerequisites per target (as of 2026-05-18)
 
 > **Status reminder (v2.6.0):** Local, AWS ECS Fargate, GCP Cloud Run, and Azure
-> Container Apps deploy with **full governance parity** (sidecar + secret mirroring)
-> and support greenfield `--provision`. **AWS App Runner** is single-container — it
-> deploys without a sidecar and rejects `guardrails:` / `secrets:` at validation.
-> **Kubernetes** and **Claude-managed** are in flight (Kubernetes needs an existing
-> cluster). This page is the canonical home of the **per-target prerequisites**; for
-> the at-a-glance feature matrix see the
-> [deploy-target status table](cli-reference#agentbreeder-deploy).
+> Container Apps deploy with **full governance parity** (sidecar + secret mirroring).
+> Greenfield provisioning (creating the VPC/cluster/IAM from scratch) ships through
+> the **Studio deploy wizard** today; the CLI `--provision` flag is on the
+> [roadmap](https://github.com/agentbreeder/agentbreeder/issues/383), so **CLI
+> deploys currently require existing infra** (plus auto-provisioned data backends).
+> **AWS App Runner** is single-container — it deploys without a sidecar and rejects
+> `guardrails:` / `secrets:` at validation. **Kubernetes** and **Claude-managed**
+> are in flight (Kubernetes needs an existing cluster). This page is the canonical
+> home of the **per-target prerequisites**; for the at-a-glance feature matrix see
+> the [deploy-target status table](cli-reference#agentbreeder-deploy).
 
 ### AWS ECS Fargate (`--target ecs-fargate`)
 
-Full governance (sidecar + cost/tracing). Greenfield `--provision` creates the
-ECS footprint from scratch (see the [Greenfield mode](#user-input-contract-per-cloud-byo-existing-infra) AWS tab above). To deploy into existing infra:
+Full governance (sidecar + cost/tracing). For a fresh account, greenfield
+provisioning creates the ECS footprint from scratch via the
+[Studio wizard](#deploying-from-studio) (see the [Greenfield mode](#user-input-contract-per-cloud-byo-existing-infra) AWS tab above; CLI `--provision` is on the [roadmap](https://github.com/agentbreeder/agentbreeder/issues/383)). To deploy into existing infra from the CLI:
 
 - AWS account ID and access credentials (Secrets Manager–backed `AWS_ACCESS_KEY_ID` /
   `AWS_SECRET_ACCESS_KEY` or an instance profile).
@@ -756,8 +809,9 @@ ECS footprint from scratch (see the [Greenfield mode](#user-input-contract-per-c
 ### Azure Container Apps (`--target container-apps`)
 
 Full governance (sidecar + cost/tracing) and **secret auto-mirror to Azure Key
-Vault**. Greenfield `--provision` creates the Container Apps footprint from scratch
-(see the [Greenfield mode](#user-input-contract-per-cloud-byo-existing-infra) Azure tab above). To deploy into existing infra:
+Vault**. For a fresh subscription, greenfield provisioning creates the Container
+Apps footprint from scratch via the [Studio wizard](#deploying-from-studio) (see
+the [Greenfield mode](#user-input-contract-per-cloud-byo-existing-infra) Azure tab above; CLI `--provision` is on the [roadmap](https://github.com/agentbreeder/agentbreeder/issues/383)). To deploy into existing infra from the CLI:
 
 - Azure subscription ID and service-principal credentials
   (`AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`).
@@ -786,15 +840,62 @@ Vault**. Greenfield `--provision` creates the Container Apps footprint from scra
 
 ## Deploying from Studio
 
-From v2.4, Studio provides a 5-step wizard at `/deploy-wizard`:
+Studio's deploy wizard (`Studio → Deploys → New deploy`, route `/deploy-wizard`)
+is the **graphical home of greenfield provisioning** — and it handles existing
+accounts too. It is a 5-step flow:
 
-1. **Agent** — pick a registered agent. The wizard auto-detects whether the agent requires approval.
-2. **Target** — choose cloud + region. Per-region cost estimate is shown inline (static client-side table, ±10%).
-3. **Infra** — BYO existing infra (validated read-only via `POST /api/v1/deployments/validate-infra`) or "Provision for me" (greenfield).
-4. **Config** — env vars, secrets, scaling, DB tier (only shown when the agent declares `memory:`).
-5. **Live deploy** — real-time SSE progress stream with 6 phase indicators (provisioning → building → pushing → deploying → health_checking → registering).
+1. **Agent** — pick a registered agent. The wizard auto-detects whether the agent
+   requires approval (`access.require_approval: true`).
+2. **Target** — choose cloud (**AWS** · ECS Fargate, **GCP** · Cloud Run, **Azure**
+   · Container Apps) and region. A per-region cost estimate is shown inline (static
+   client-side table, ±10%).
+3. **Infra** — this is where you choose your starting point:
+   - **Bring your own infrastructure** — enter your existing account fields
+     (`mode=simple` or `full` from the [contract above](#user-input-contract-per-cloud-byo-existing-infra))
+     and click **Validate infrastructure**. The wizard calls
+     `POST /api/v1/deployments/validate-infra` (read-only) and shows a per-resource
+     ✅/❌ checklist. You can't advance until validation passes.
+   - **Provision for me** *(greenfield, BETA)* — a `ResourcePreviewTree` lists every
+     resource AgentBreeder will create with a per-line and total monthly cost
+     estimate. You must tick **"I understand this creates cloud resources billable
+     to my account"** before advancing.
+4. **Config** — env vars, secret references, scaling (min / max / target CPU %), and
+   DB tier (shown only when the agent declares `memory:`).
+5. **Live deploy** — submits `POST /api/v1/deployments` (with `infra_mode` set to
+   `byo` or `provision`) and opens an SSE stream
+   (`GET /api/v1/deployments/{job_id}/stream`) with six phase indicators:
+   **provisioning → building → pushing → deploying → health_checking →
+   registering**. On a greenfield run the `provisioning` phase streams each
+   resource (VPC → subnets → NAT → cluster → IAM → RDS/ALB) as it is created.
 
-Drafts auto-save to localStorage every 250ms; refresh-safe. Agents with `access.require_approval: true` are routed through the existing `/approvals` queue and the wizard polls until an admin approves, then switches to the SSE stream.
+<Callout type="warn" title="Provision-for-me is BETA">
+  The greenfield path reliably **provisions the infrastructure** (VPC, subnets,
+  NAT, cluster, IAM, and — when declared — RDS/ALB) and records it for rollback.
+  The hand-off that then **builds and serves the agent into that fresh footprint**
+  is still being finalized. For a guaranteed end-to-end deploy today, provision
+  with the wizard (or pre-create infra yourself) and run the verified BYO
+  [CLI walkthrough](#aws-ecs-fargate--end-to-end-verified) against it.
+</Callout>
+
+**What greenfield provisioning creates** is exactly the per-cloud footprint in the
+[Greenfield mode](#user-input-contract-per-cloud-byo-existing-infra) tables above —
+all tagged `AgentBreeder=true` so teardown can safely target only what it made.
+
+**If a greenfield deploy fails mid-provision**, the wizard exposes a **Roll back**
+action that calls `POST /api/v1/deployments/{job_id}/destroy-partial`, which runs
+the provisioner's `destroy()` against whatever was recorded in the job's
+`InfraState` — no orphaned VPC, NAT, or RDS left billing.
+
+Drafts auto-save to localStorage every 250ms (refresh-safe). Agents with
+`access.require_approval: true` route through the `/approvals` queue; the wizard
+polls until an admin approves, then switches to the SSE stream.
+
+<Callout type="info" title="Tearing down a Studio greenfield deploy">
+  Greenfield resources are recorded in the job's `InfraState`. Remove them with
+  the wizard's **Roll back** action, or from the terminal with
+  `agentbreeder teardown <agent> --cloud aws --region <region>` — both refuse to
+  touch any resource missing the `AgentBreeder=true` tag.
+</Callout>
 
 ---
 

--- a/website/content/docs/examples.mdx
+++ b/website/content/docs/examples.mdx
@@ -86,7 +86,7 @@ Use these to see how the same agent deploys to a specific cloud.
 
 Deploys to AWS App Runner — serverless containers with no VPC, no ALB, and no load balancer configuration required. Ideal for simple HTTP-accessible agents.
 
-*Prereq:* AWS ECS Fargate ships full governance and greenfield `--provision`; on AWS pre-create secrets in Secrets Manager (auto-mirror is on the roadmap). See the [deploy-target status table](cli-reference#agentbreeder-deploy).
+*Prereq:* AWS ECS Fargate ships full governance; greenfield provisioning is available via the [Studio deploy wizard](deployment#deploying-from-studio) (CLI `--provision` is on the roadmap), so CLI deploys use existing infra plus auto-provisioned data backends. On AWS, pre-create secrets in Secrets Manager (auto-mirror is on the roadmap). See the [deploy-target status table](cli-reference#agentbreeder-deploy).
 
 ```yaml
 # agent.yaml


### PR DESCRIPTION
## What

Corrects the AWS deployment docs, which claimed `agentbreeder deploy --target aws --provision` ships greenfield **from the CLI**. That flag did not exist — the CLI deploy path requires BYO infra (`aws_ecs.py` errors without `AWS_ECS_CLUSTER`/`AWS_VPC_SUBNETS`) and only auto-provisions the data tier (RDS/Redis). Full greenfield provisioning shipped through the **Studio deploy wizard** ("Provision for me", BETA), not the CLI.

## Changes

- **`deployment.mdx`** — reframe the top callout around greenfield-vs-existing × CLI-vs-Studio; rewrite all three "Greenfield mode" blocks to point at the Studio wizard with CLI `--provision` noted as roadmap (#383); label the verified ECS walkthrough as the BYO/existing-account path; expand "Deploying from Studio" into a real greenfield walkthrough (BYO-validate vs Provision-for-me, cost preview, ack gate, partial-rollback) + a BETA caveat noting the provision→serve hand-off is still being finalized.
- **`cli-reference.mdx`** — fix the canonical deploy-target status table (drop the false `--provision`), add a greenfield-vs-existing explainer + footnote, fix the `--cloud` flag note.
- **`examples.mdx`** — fix the stale "ships greenfield `--provision`" prereq line.

## Notes

- Docs-only; website `next build` green (63 pages).
- The follow-up feature PR (`feat/cli-greenfield-provision-aws`, #537) makes AWS CLI greenfield real and flips these notes from roadmap → shipped — it is **stacked on this branch**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
