### PR TITLE
feat(deploy): CLI greenfield provisioning for AWS (deploy --provision)

### DIFF
--- a/cli/commands/deploy.py
+++ b/cli/commands/deploy.py
@@ -103,30 +103,53 @@ def deploy(
         "--local",
         help="Run the deploy engine in-process (no RBAC, dev/offline use only).",
     ),
+    provision: bool = typer.Option(
+        False,
+        "--provision",
+        "-p",
+        help=(
+            "Greenfield-provision the cloud footprint (VPC, subnets, cluster, IAM) "
+            "for a fresh account before deploying. AWS only; local mode only."
+        ),
+    ),
 ) -> None:
     """Deploy an agent from an agent.yaml configuration file."""
     use_remote = _resolve_mode(remote, local)
+    if use_remote and provision:
+        console.print(
+            "[red]--provision is local-only for now[/red] — greenfield provisioning "
+            "from the API/Studio path is tracked separately (#537). Re-run with "
+            "[bold]--local --provision[/bold], or use the Studio deploy wizard."
+        )
+        raise typer.Exit(code=2)
     if use_remote:
         _deploy_remote(config_path, target, json_output)
     else:
-        _deploy_local(config_path, target, json_output)
+        _deploy_local(config_path, target, json_output, provision)
 
 
 # ── Local mode (preserved verbatim from the pre-#416 implementation) ────────
 
 
-def _deploy_local(config_path: Path, target: str, json_output: bool) -> None:
+def _deploy_local(
+    config_path: Path, target: str, json_output: bool, provision: bool = False
+) -> None:
     """Run the deploy engine in-process — same flow as before #416.
 
     Kept for dev/offline use; explicitly bypasses every server-side gate
     (RBAC, audit log, team-scoped credentials). Production deploys should
     always go through ``--remote``.
+
+    When ``provision`` is set, the engine greenfield-provisions the cloud
+    footprint before deploying (AWS only; #537).
     """
     if not json_output:
+        provision_note = " [yellow](+ greenfield provisioning)[/yellow]" if provision else ""
         console.print()
         console.print(
             Panel(
-                f"[bold]Deploying[/bold] {config_path.name} → [cyan]{target}[/cyan] "
+                f"[bold]Deploying[/bold] {config_path.name} → [cyan]{target}[/cyan]"
+                f"{provision_note} "
                 "[dim](local mode — RBAC/audit bypassed)[/dim]",
                 title="AgentBreeder",
                 border_style="blue",
@@ -150,7 +173,9 @@ def _deploy_local(config_path: Path, target: str, json_output: bool) -> None:
     engine = DeployEngine(on_step=on_step)
 
     try:
-        result = asyncio.run(engine.deploy(config_path=config_path, target=target))
+        result = asyncio.run(
+            engine.deploy(config_path=config_path, target=target, provision=provision)
+        )
 
         if json_output:
             console.print(json_lib.dumps(result.model_dump(), indent=2))

--- a/cli/commands/teardown.py
+++ b/cli/commands/teardown.py
@@ -894,14 +894,25 @@ def _teardown_infra_state(json_output: bool) -> bool:
             console.print(f"  [yellow]Warning:[/yellow] Could not read infra state: {e}")
         return False
 
+    # A greenfield footprint (created by `deploy --provision`) records the whole
+    # stack — VPC, subnets, cluster, IAM — so it needs the full destroy(). A
+    # data-only footprint (auto-provisioned RDS/Redis into BYO infra) uses the
+    # focused destroy_data_backend() so it never touches the user's own network.
+    greenfield_keys = {"vpc", "network", "ecs_cluster", "iam_execution_role"}
+    is_greenfield = bool(greenfield_keys & set(infra.resources))
+    backend_label = "infrastructure" if is_greenfield else "data backend"
+
     try:
         provisioner = provisioner_for(infra.cloud)
-        asyncio.run(provisioner.destroy_data_backend(infra))
+        if is_greenfield:
+            asyncio.run(provisioner.destroy(infra))
+        else:
+            asyncio.run(provisioner.destroy_data_backend(infra))
     except Exception as e:  # noqa: BLE001 — surface but continue agent teardown
         if not json_output:
             console.print(
                 f"  [yellow]Warning:[/yellow] Could not destroy provisioned "
-                f"{infra.cloud} backend: {e}"
+                f"{infra.cloud} {backend_label}: {e}"
             )
         return False
 
@@ -910,7 +921,9 @@ def _teardown_infra_state(json_output: bool) -> bool:
     except OSError:
         pass
     if not json_output:
-        console.print(f"  [green]✓[/green] Destroyed auto-provisioned {infra.cloud} data backend")
+        console.print(
+            f"  [green]✓[/green] Destroyed auto-provisioned {infra.cloud} {backend_label}"
+        )
     return True
 
 

--- a/docs/superpowers/specs/2026-06-04-cli-greenfield-provision-aws.md
+++ b/docs/superpowers/specs/2026-06-04-cli-greenfield-provision-aws.md
@@ -1,0 +1,110 @@
+# Spec: CLI greenfield provisioning for AWS (`agentbreeder deploy --provision`)
+
+> Issue: #537 · Refs #383 · Scope: **AWS only** (GCP/Azure follow the same shape later)
+> Status: approved-to-implement (user pre-authorized in the c→a→b→implement flow)
+
+## Summary
+
+Let a user with a **fresh AWS account** (no VPC, subnets, ECS cluster, or IAM role)
+run one command and get a fully-provisioned, serving agent:
+
+```bash
+agentbreeder deploy agent.yaml --target ecs-fargate --provision
+```
+
+The greenfield provisioner (`AWSProvisioner.provision()`) already creates the full
+footprint and returns an `InfraState`. The missing glue is: a CLI flag, a branch in
+the deploy pipeline that calls `provision()` **before** the deployer, a **mapper** that
+turns `InfraState.resources` into the `deploy.env_vars` the ECS deployer already reads,
+state persistence, and full-footprint teardown. After the mapper injects the IDs, the
+existing BYO deploy path runs unchanged.
+
+## Inputs
+
+- **CLI flag** `--provision` / `-p` on `agentbreeder deploy` — `bool`, default `False`.
+  Local mode only for this scope (remote/Studio tracked separately).
+- **`agent.yaml`** — unchanged. Greenfield reads `deploy.region`, `deploy.env_vars`
+  (creds + optional `AWS_MULTI_AZ_NAT`, `AWS_ACM_CERTIFICATE_ARN`), and derives:
+  - `AWS_AGENT_NAME` ← `config.name`, `AWS_AGENT_VERSION` ← `config.version`
+  - `AWS_HAS_MEMORY` ← agent declares `memory:`/KB (so RDS is provisioned)
+  - `AWS_ACCESS_VISIBILITY` ← `access.visibility` (so ALB is provisioned when `public`)
+- **Credentials** — standard boto3 chain (env / `~/.aws/credentials` / instance profile).
+
+## Outputs / side effects
+
+- Calls `provisioner_for("aws").provision(InfraValidationInput(cloud="aws", region, mode="simple", fields=...), progress=<console>)`.
+- Injects mapped IDs into `config.deploy.env_vars` (see Mapper below).
+- Auto-provisions the data tier (RDS/Redis) into the **new** VPC (existing behavior, now fed greenfield network).
+- Persists the merged footprint to `.agentbreeder/infra-state.json` (mode `provisioned`).
+- Deploys + health-checks + registers via the existing pipeline; returns the endpoint URL.
+- `agentbreeder teardown <agent>` removes the **entire** greenfield footprint (tag-gated).
+
+## The mapper (the only genuinely new logic)
+
+New module `engine/deployers/_greenfield.py`:
+
+```python
+def infra_state_to_env(cloud: str, state: InfraState) -> dict[str, str]:
+    """Map a greenfield InfraState into the deploy.env_vars the deployer reads."""
+```
+
+AWS mapping (verified against `aws_ecs.py::_extract_ecs_config` and `aws.py::provision`):
+
+| env var (deployer reads) | source in `state.resources` |
+|---|---|
+| `AWS_ECS_CLUSTER` | `["ecs_cluster"]["name"]` |
+| `AWS_EXECUTION_ROLE_ARN` | `["iam_execution_role"]["arn"]` |
+| `AWS_VPC_SUBNETS` | `,`.join(`["network"]["public_subnet_ids"]`) — agent task ENI gets a public IP |
+| `AWS_SECURITY_GROUPS` | `["security_groups"]["agent_sg_id"]` |
+| `AWS_VPC_ID` | `["vpc"]["vpc_id"]` — so data-backend auto-provision lands in the new VPC |
+| `AWS_REGION` | `state.region` |
+| `AWS_DB_SUBNETS` (new, optional) | `,`.join(`["network"]["private_subnet_ids"]`) — RDS/Redis prefer private |
+
+Only set keys the user didn't already supply (`env.setdefault(...)`), so an explicit
+BYO field always wins.
+
+## Pipeline ordering (engine/builder.py Step 5)
+
+```
+if provision and cloud in {aws} and BYO infra absent:
+    state = await provisioner_for(cloud).provision(payload, progress)   # NEW
+    env.update(infra_state_to_env(cloud, state) minus user-set keys)    # NEW (mapper)
+    merge state into .agentbreeder/infra-state.json                     # NEW
+await deployer.provision(config)              # existing — now finds populated env_vars
+await self._auto_provision_data_backends(...) # existing — lands in the new VPC
+```
+
+`DeployEngine.deploy(...)` gains `provision: bool = False`; `cli/commands/deploy.py`
+threads the flag through `_deploy_local`.
+
+## Acceptance criteria
+
+- [ ] `deploy --target ecs-fargate --provision` on an account with **no** VPC/cluster provisions the footprint, deploys, health-checks green, registers — **no BYO env_vars** required.
+- [ ] `infra_state_to_env("aws", state)` returns the exact 6–7 keys above (unit-tested against a representative `InfraState`).
+- [ ] Step 5 ordering verified with a fake provisioner: greenfield → mapper → data-backend → deploy; `.agentbreeder/infra-state.json` holds the greenfield + data footprint.
+- [ ] Explicit BYO `env_vars` are never overwritten by the mapper (`setdefault` semantics).
+- [ ] `--provision` against a cloud whose `provision()` is still `NotImplementedError` (gcp/azure) fails fast with a clear "use Studio wizard / not yet on CLI" message — never a raw traceback.
+- [ ] `agentbreeder teardown <agent>` calls `provisioner.destroy(state)` for the greenfield footprint and leaves **zero** orphans (tag-gated; refuses untagged).
+- [ ] Re-running `deploy --provision` with an existing `infra-state.json` **reuses** infra (no duplicate VPC).
+- [ ] Provisioner `progress` messages stream to the Rich console during Step 5.
+- [ ] Gates green; docs flipped roadmap→shipped.
+
+## Edge cases & error handling
+
+- **Partial provision then deploy fails** → infra is already persisted; print the exact `agentbreeder teardown <agent>` command to clean up. (Auto-rollback is a nice-to-have, not required for v1.)
+- **`--provision` + BYO env_vars both present** → BYO wins; skip greenfield provisioning, log that existing infra was detected.
+- **Missing AWS creds** → fail in Step 5 with the boto3 credential error surfaced clearly (no silent fallback).
+- **Cloud != aws with `--provision`** → fast, friendly error (AWS-only this release).
+- **`provision()` idempotency** → the provisioner is create-if-not-exists (tag-filtered), but we still short-circuit on an existing state file to avoid slow re-describes.
+
+## Out of scope
+
+- GCP / Azure CLI greenfield (same mapper shape; follow-up).
+- Remote (`--remote`) / Studio orchestrator greenfield serve hand-off (the `deployer_for()` gap — separate, larger work noted in #537).
+- App Runner greenfield (the provisioner builds ECS Fargate only).
+- Multi-region / failover / custom-domain wiring beyond the existing ALB+ACM path.
+
+## Open questions (resolved with defaults unless overridden)
+
+1. Agent in public vs private subnets? → **Default: public subnets + `assignPublicIp=ENABLED`** (matches the verified BYO path; no NAT dependency for the task). Data tier → private subnets.
+2. Auto-rollback on deploy failure? → **Default: no**; print the teardown command. Revisit if users hit it.

--- a/engine/builder.py
+++ b/engine/builder.py
@@ -32,13 +32,14 @@ from engine.deployers._autoprovision import (
     resolve_pgvector_dsn,
     resolve_redis_url,
 )
+from engine.deployers._greenfield import infra_state_to_env
 from engine.deployers._pgvector_dsn import (
     needs_managed_memory_postgres,
     needs_managed_pgvector,
 )
 from engine.deployers.base import DeployResult
 from engine.governance import check_rbac
-from engine.provisioners import provisioner_for
+from engine.provisioners import InfraValidationInput, provisioner_for
 from engine.resolver import resolve_dependencies
 from engine.runtimes.registry import get_runtime_from_config
 
@@ -121,8 +122,15 @@ class DeployEngine:
         config_path: Path,
         target: str | None = None,
         user: str = "local",
+        provision: bool = False,
     ) -> DeployResult:
-        """Run the full deploy pipeline."""
+        """Run the full deploy pipeline.
+
+        When ``provision`` is set (``agentbreeder deploy --provision``), Step 5
+        greenfield-provisions the cloud footprint (AWS only for now, #537) and
+        injects its IDs into ``deploy.env_vars`` before the deployer runs, so a
+        fresh account needs no pre-existing VPC/cluster/role.
+        """
         # Absolutize early so config_path.parent is always an absolute project root,
         # regardless of whether the CLI, API, or orchestrator passed a relative path.
         config_path = config_path.resolve()
@@ -214,6 +222,9 @@ class DeployEngine:
         step5.start()
         self._notify(step5)
         try:
+            # Greenfield: create the cloud footprint and inject its IDs into
+            # deploy.env_vars BEFORE the deployer validates/uses them (#537).
+            await self._maybe_provision_greenfield(config, config_path.parent, provision)
             deployer = get_deployer(config.deploy.cloud, config.deploy.runtime)
             await deployer.provision(config)
             # Auto-provision managed data backends (pgvector for a KB declared
@@ -270,6 +281,105 @@ class DeployEngine:
 
         logger.info("Deploy complete: %s → %s", config.name, result.endpoint_url)
         return result
+
+    def _persist_infra_resources(
+        self, project_dir: Path, cloud: str, region: str, new_resources: dict[str, Any]
+    ) -> None:
+        """Merge ``new_resources`` into ``.agentbreeder/infra-state.json``.
+
+        Loads any existing footprint first so a greenfield network/cluster and a
+        later auto-provisioned data tier both survive into one state file that
+        ``agentbreeder teardown`` can fully reverse.
+        """
+        from datetime import UTC, datetime
+
+        from engine.provisioners.state import InfraState
+
+        state_path = project_dir / ".agentbreeder" / "infra-state.json"
+        merged: dict[str, Any] = {}
+        existing = InfraState.load_or_none(state_path)
+        if existing is not None:
+            _merge_infra_resources(merged, existing.resources)
+        _merge_infra_resources(merged, new_resources)
+        InfraState(
+            cloud=cloud,
+            region=region,
+            provisioned_by="agentbreeder.DeployEngine",
+            provisioned_at=datetime.now(UTC),
+            mode="provisioned",
+            resources=merged,
+        ).save(state_path)
+
+    async def _maybe_provision_greenfield(
+        self, config: AgentConfig, project_dir: Path, provision: bool
+    ) -> None:
+        """Greenfield-provision the cloud footprint for ``--provision`` and feed
+        its IDs into ``deploy.env_vars`` so the existing deploy path serves the
+        agent into it. AWS only for now (#537); GCP/Azure greenfield ship via the
+        Studio wizard.
+
+        No-op unless ``provision`` is set. Respects BYO infra already supplied in
+        ``env_vars`` and reuses a previously-recorded greenfield footprint rather
+        than provisioning a duplicate.
+        """
+        if not provision:
+            return
+
+        cloud = config.deploy.cloud
+        if cloud in (CloudType.local, CloudType.claude_managed):
+            return  # nothing to provision
+
+        if cloud != CloudType.aws:
+            raise DeployError(
+                f"--provision currently supports AWS only (got {cloud.value!r}). "
+                "Use the Studio deploy wizard for GCP/Azure greenfield (#537)."
+            )
+
+        from engine.provisioners.state import InfraState
+
+        if config.deploy.env_vars is None:
+            config.deploy.env_vars = {}
+        env = config.deploy.env_vars
+
+        # BYO infra already supplied → respect it, skip greenfield.
+        if env.get("AWS_ECS_CLUSTER") and env.get("AWS_VPC_SUBNETS"):
+            logger.info(
+                "Existing AWS infra in env_vars for '%s'; skipping greenfield provisioning",
+                config.name,
+            )
+            return
+
+        state_path = project_dir / ".agentbreeder" / "infra-state.json"
+        existing = InfraState.load_or_none(state_path)
+        if (
+            existing is not None
+            and existing.mode == "provisioned"
+            and "ecs_cluster" in existing.resources
+        ):
+            logger.info("Reusing greenfield infra recorded at %s", state_path)
+            state = existing
+        else:
+            region = config.deploy.region or env.get("AWS_REGION") or "us-east-1"
+            fields = dict(env)  # carries creds + any user overrides
+            fields.setdefault("AWS_AGENT_NAME", config.name)
+            fields.setdefault("AWS_AGENT_VERSION", config.version)
+            fields.setdefault("AWS_DEFAULT_REGION", region)
+            # CLI deploys reach the task at its public IP (assignPublicIp), no ALB.
+            fields.setdefault("AWS_AGENT_PUBLIC_INGRESS", "true")
+
+            async def _emit(msg: str) -> None:
+                logger.info("greenfield(aws): %s", msg)
+
+            logger.info("Greenfield-provisioning AWS footprint for '%s'", config.name)
+            payload = InfraValidationInput(
+                cloud="aws", region=region, mode="simple", fields=fields
+            )
+            state = await provisioner_for("aws").provision(payload, progress=_emit)
+            self._persist_infra_resources(project_dir, "aws", region, state.resources)
+
+        # Inject the provisioned IDs without clobbering anything the user set.
+        for key, value in infra_state_to_env("aws", state).items():
+            env.setdefault(key, value)
 
     async def _auto_provision_data_backends(
         self, config: AgentConfig, project_dir: Path | None = None
@@ -351,19 +461,9 @@ class DeployEngine:
                     )
 
         # Persist the merged footprint so teardown can destroy everything created.
+        # Merges with any greenfield footprint already recorded for this project.
         if project_dir is not None and merged_resources and cloud and region:
-            from datetime import UTC, datetime
-
-            from engine.provisioners.state import InfraState
-
-            InfraState(
-                cloud=cloud,
-                region=region,
-                provisioned_by="agentbreeder.DeployEngine",
-                provisioned_at=datetime.now(UTC),
-                mode="provisioned",
-                resources=merged_resources,
-            ).save(project_dir / ".agentbreeder" / "infra-state.json")
+            self._persist_infra_resources(project_dir, cloud, region, merged_resources)
 
     def _register(self, config: AgentConfig, endpoint_url: str) -> None:
         """Register the agent in the local registry and sync to the AgentBreeder API.

--- a/engine/deployers/_greenfield.py
+++ b/engine/deployers/_greenfield.py
@@ -38,11 +38,15 @@ def _aws_env(state: InfraState) -> dict[str, str]:
 
     public_subnets = network.get("public_subnet_ids", []) or []
     private_subnets = network.get("private_subnet_ids", []) or []
+    role_arn = str(res["iam_execution_role"]["arn"])
+    # arn:aws:iam::<account-id>:role/<name> → the deployer requires the account ID.
+    account_id = role_arn.split(":")[4] if role_arn.count(":") >= 4 else ""
 
     env: dict[str, str] = {
         # Inputs aws_ecs.py::_extract_ecs_config reads.
+        "AWS_ACCOUNT_ID": account_id,
         "AWS_ECS_CLUSTER": str(res["ecs_cluster"]["name"]),
-        "AWS_EXECUTION_ROLE_ARN": str(res["iam_execution_role"]["arn"]),
+        "AWS_EXECUTION_ROLE_ARN": role_arn,
         # The agent task ENI joins the public subnets and gets a public IP.
         "AWS_VPC_SUBNETS": ",".join(public_subnets),
         "AWS_SECURITY_GROUPS": str(sgs["agent_sg_id"]),

--- a/engine/deployers/_greenfield.py
+++ b/engine/deployers/_greenfield.py
@@ -1,0 +1,56 @@
+"""Greenfield → deploy glue.
+
+After a greenfield :meth:`InfraProvisioner.provision` creates a fresh footprint,
+:func:`infra_state_to_env` maps its returned ``InfraState.resources`` into the
+``deploy.env_vars`` the cloud deployer already reads — so the existing
+(bring-your-own-infra) deploy path serves the agent into the new footprint with
+no further changes.
+
+This is the one piece of new logic behind ``agentbreeder deploy --provision``
+(issue #537). Keep it pure and per-cloud: given a provisioned ``InfraState``,
+return a ``dict[str, str]`` of environment variables. Callers apply it with
+``setdefault`` semantics so an explicit BYO field always wins.
+"""
+
+from __future__ import annotations
+
+from engine.provisioners.state import InfraState
+
+
+def infra_state_to_env(cloud: str, state: InfraState) -> dict[str, str]:
+    """Map a greenfield ``InfraState`` into deploy ``env_vars`` for ``cloud``.
+
+    Raises ``NotImplementedError`` for clouds whose CLI greenfield mapping is
+    not implemented yet (GCP/Azure follow in later work; see #537).
+    """
+    if cloud == "aws":
+        return _aws_env(state)
+    raise NotImplementedError(
+        f"CLI greenfield provisioning is implemented for AWS only; got {cloud!r}. "
+        "Use the Studio deploy wizard for GCP/Azure greenfield (issue #537)."
+    )
+
+
+def _aws_env(state: InfraState) -> dict[str, str]:
+    res = state.resources
+    network = res.get("network", {})
+    sgs = res.get("security_groups", {})
+
+    public_subnets = network.get("public_subnet_ids", []) or []
+    private_subnets = network.get("private_subnet_ids", []) or []
+
+    env: dict[str, str] = {
+        # Inputs aws_ecs.py::_extract_ecs_config reads.
+        "AWS_ECS_CLUSTER": str(res["ecs_cluster"]["name"]),
+        "AWS_EXECUTION_ROLE_ARN": str(res["iam_execution_role"]["arn"]),
+        # The agent task ENI joins the public subnets and gets a public IP.
+        "AWS_VPC_SUBNETS": ",".join(public_subnets),
+        "AWS_SECURITY_GROUPS": str(sgs["agent_sg_id"]),
+        "AWS_REGION": str(state.region),
+        # So the data-tier auto-provision (RDS/Redis) lands in the new VPC and
+        # can prefer private subnets.
+        "AWS_VPC_ID": str(res["vpc"]["vpc_id"]),
+    }
+    if private_subnets:
+        env["AWS_DB_SUBNETS"] = ",".join(private_subnets)
+    return env

--- a/engine/provisioners/aws.py
+++ b/engine/provisioners/aws.py
@@ -242,6 +242,11 @@ class AWSProvisioner(InfraProvisioner):
         has_memory = bool(fields.get("AWS_HAS_MEMORY"))
         is_public = str(fields.get("AWS_ACCESS_VISIBILITY", "")).lower() == "public"
         multi_az_nat = str(fields.get("AWS_MULTI_AZ_NAT", "")).strip() in {"1", "true", "yes"}
+        # When the agent is NOT fronted by an ALB (the CLI deployer reaches it at
+        # the task ENI's public IP via assignPublicIp=ENABLED), the agent SG must
+        # accept the agent port directly. The runtime gates /invoke with a bearer
+        # token; /health stays open.
+        direct_public_ingress = bool(fields.get("AWS_AGENT_PUBLIC_INGRESS"))
 
         ec2 = _client("ec2", region, fields)
         ecs = _client("ecs", region, fields)
@@ -283,6 +288,7 @@ class AWSProvisioner(InfraProvisioner):
             agent_name=agent_name,
             agent_version=agent_version,
             include_db_sg=has_memory,
+            direct_public_ingress=direct_public_ingress,
         )
         resources["security_groups"] = sgs
 
@@ -1031,6 +1037,7 @@ class AWSProvisioner(InfraProvisioner):
         agent_name: str,
         agent_version: str,
         include_db_sg: bool,
+        direct_public_ingress: bool = False,
     ) -> dict[str, str | None]:
         alb_sg_id = self._ensure_security_group(
             ec2=ec2,
@@ -1075,6 +1082,17 @@ class AWSProvisioner(InfraProvisioner):
             to_port=AGENT_CONTAINER_PORT,
             source_sg_id=alb_sg_id,
         )
+        # No ALB in front (CLI public-IP deploy): also accept the agent port
+        # directly from the internet so the task ENI's public IP is reachable.
+        if direct_public_ingress:
+            self._authorize_ingress(
+                ec2=ec2,
+                sg_id=agent_sg_id,
+                protocol="tcp",
+                from_port=AGENT_CONTAINER_PORT,
+                to_port=AGENT_CONTAINER_PORT,
+                cidr="0.0.0.0/0",
+            )
 
         db_sg_id: str | None = None
         if include_db_sg:

--- a/engine/provisioners/aws.py
+++ b/engine/provisioners/aws.py
@@ -948,21 +948,27 @@ class AWSProvisioner(InfraProvisioner):
             ]
         )
         if nats := existing.get("NatGateways", []):
-            return nats[0]["NatGatewayId"]
-        eip = ec2.allocate_address(
-            Domain="vpc",
-            TagSpecifications=[
-                {"ResourceType": "elastic-ip", "Tags": _tags(agent_name, agent_version)}
-            ],
-        )
-        nat = ec2.create_nat_gateway(
-            SubnetId=subnet_id,
-            AllocationId=eip["AllocationId"],
-            TagSpecifications=[
-                {"ResourceType": "natgateway", "Tags": _tags(agent_name, agent_version)}
-            ],
-        )
-        return nat["NatGateway"]["NatGatewayId"]
+            nat_id = nats[0]["NatGatewayId"]
+        else:
+            eip = ec2.allocate_address(
+                Domain="vpc",
+                TagSpecifications=[
+                    {"ResourceType": "elastic-ip", "Tags": _tags(agent_name, agent_version)}
+                ],
+            )
+            nat = ec2.create_nat_gateway(
+                SubnetId=subnet_id,
+                AllocationId=eip["AllocationId"],
+                TagSpecifications=[
+                    {"ResourceType": "natgateway", "Tags": _tags(agent_name, agent_version)}
+                ],
+            )
+            nat_id = nat["NatGateway"]["NatGatewayId"]
+        # A NAT gateway starts in "pending" and is not a valid route target until
+        # it reaches "available" (1-2 min). Block here so the caller's CreateRoute
+        # doesn't fail with InvalidNatGatewayID.NotFound.
+        ec2.get_waiter("nat_gateway_available").wait(NatGatewayIds=[nat_id])
+        return nat_id
 
     def _ensure_route_table(
         self,

--- a/tests/unit/test_aws_provisioner.py
+++ b/tests/unit/test_aws_provisioner.py
@@ -368,6 +368,51 @@ async def test_alb_sg_accepts_internet_traffic_on_80_443(
         assert c.kwargs["IpPermissions"][0]["IpRanges"] == [{"CidrIp": "0.0.0.0/0"}]
 
 
+@pytest.mark.asyncio
+async def test_agent_sg_has_no_internet_ingress_by_default(fake_clients_minimal) -> None:
+    """Default greenfield: the agent SG accepts 8080 from the ALB SG only, never
+    from the internet. Preserves the ALB-fronted architecture."""
+    with patch(
+        "engine.provisioners.aws._client", side_effect=_client_factory(fake_clients_minimal)
+    ):
+        await AWSProvisioner().provision(_payload())
+
+    ec2 = fake_clients_minimal["ec2"]
+    agent_calls = [
+        c
+        for c in ec2.authorize_security_group_ingress.call_args_list
+        if c.kwargs.get("GroupId") == "sg-agent"
+    ]
+    # Exactly one rule, sourced from the ALB SG — no CIDR ingress.
+    assert len(agent_calls) == 1
+    perms = agent_calls[0].kwargs["IpPermissions"][0]
+    assert perms["UserIdGroupPairs"][0]["GroupId"] == "sg-alb"
+    assert "IpRanges" not in perms
+
+
+@pytest.mark.asyncio
+async def test_agent_sg_opens_8080_to_internet_when_public_ingress_requested(
+    fake_clients_minimal,
+) -> None:
+    """With AWS_AGENT_PUBLIC_INGRESS set, the agent SG also accepts 8080 from
+    0.0.0.0/0 so the ECS deployer's public-IP task (assignPublicIp=ENABLED) is
+    reachable without an ALB. The runtime gates /invoke with a bearer token."""
+    with patch(
+        "engine.provisioners.aws._client", side_effect=_client_factory(fake_clients_minimal)
+    ):
+        await AWSProvisioner().provision(_payload(AWS_AGENT_PUBLIC_INGRESS="true"))
+
+    ec2 = fake_clients_minimal["ec2"]
+    agent_cidr_calls = [
+        c
+        for c in ec2.authorize_security_group_ingress.call_args_list
+        if c.kwargs.get("GroupId") == "sg-agent"
+        and c.kwargs["IpPermissions"][0].get("IpRanges") == [{"CidrIp": "0.0.0.0/0"}]
+    ]
+    assert len(agent_cidr_calls) == 1
+    assert agent_cidr_calls[0].kwargs["IpPermissions"][0]["FromPort"] == 8080
+
+
 # -- RDS security invariants -----------------------------------------------
 
 

--- a/tests/unit/test_aws_provisioner.py
+++ b/tests/unit/test_aws_provisioner.py
@@ -413,6 +413,25 @@ async def test_agent_sg_opens_8080_to_internet_when_public_ingress_requested(
     assert agent_cidr_calls[0].kwargs["IpPermissions"][0]["FromPort"] == 8080
 
 
+@pytest.mark.asyncio
+async def test_provision_waits_for_nat_available_before_routing(fake_clients_minimal) -> None:
+    """A new NAT gateway starts 'pending' and cannot be a route target until
+    'available'. provision() must wait, else CreateRoute fails with
+    InvalidNatGatewayID.NotFound (caught in #537 live validation)."""
+    ec2 = fake_clients_minimal["ec2"]
+    waiter = MagicMock()
+    ec2.get_waiter.return_value = waiter
+
+    with patch(
+        "engine.provisioners.aws._client", side_effect=_client_factory(fake_clients_minimal)
+    ):
+        await AWSProvisioner().provision(_payload())
+
+    ec2.get_waiter.assert_any_call("nat_gateway_available")
+    waited_ids = [c.kwargs.get("NatGatewayIds") for c in waiter.wait.call_args_list]
+    assert ["nat-1"] in waited_ids
+
+
 # -- RDS security invariants -----------------------------------------------
 
 

--- a/tests/unit/test_builder_greenfield.py
+++ b/tests/unit/test_builder_greenfield.py
@@ -1,0 +1,125 @@
+"""DeployEngine greenfield branch — `agentbreeder deploy --provision` (#537).
+
+Covers ``DeployEngine._maybe_provision_greenfield``: when ``--provision`` is set
+and no BYO infra is supplied, it provisions the cloud footprint, maps the
+returned ``InfraState`` into ``deploy.env_vars`` (so the existing deploy path
+serves the agent into it), and records the footprint for teardown. AWS only.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from engine.builder import DeployEngine, DeployError
+from engine.config_parser import (
+    AgentConfig,
+    CloudType,
+    DeployConfig,
+    ModelConfig,
+)
+from engine.provisioners.state import InfraState
+
+
+def _cfg(
+    *, cloud: CloudType = CloudType.aws, env_vars: dict[str, str] | None = None
+) -> AgentConfig:
+    return AgentConfig(
+        name="demo",
+        version="1.0.0",
+        team="t",
+        owner="a@b.com",
+        framework="langgraph",
+        model=ModelConfig(primary="gpt-4o"),
+        deploy=DeployConfig(cloud=cloud, region="us-east-1", env_vars=env_vars or {}),
+    )
+
+
+def _greenfield_state() -> InfraState:
+    return InfraState(
+        cloud="aws",
+        region="us-east-1",
+        provisioned_by="agentbreeder.AWSProvisioner",
+        provisioned_at=datetime.now(UTC),
+        mode="provisioned",
+        resources={
+            "vpc": {"vpc_id": "vpc-0abc"},
+            "network": {
+                "public_subnet_ids": ["subnet-pub1", "subnet-pub2"],
+                "private_subnet_ids": ["subnet-prv1"],
+            },
+            "security_groups": {"agent_sg_id": "sg-agent", "alb_sg_id": None, "db_sg_id": None},
+            "ecs_cluster": {"name": "agentbreeder-demo", "arn": "arn:x"},
+            "iam_execution_role": {"name": "r", "arn": "arn:aws:iam::1:role/r"},
+        },
+    )
+
+
+def _fake_provisioner(state: InfraState) -> AsyncMock:
+    fake = AsyncMock()
+    fake.provision.return_value = state
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_greenfield_provisions_and_injects_env(tmp_path: Path) -> None:
+    cfg = _cfg(env_vars={"AWS_ACCESS_KEY_ID": "AKIA", "AWS_SECRET_ACCESS_KEY": "x"})
+    fake = _fake_provisioner(_greenfield_state())
+
+    with patch("engine.builder.provisioner_for", return_value=fake):
+        await DeployEngine()._maybe_provision_greenfield(cfg, tmp_path, provision=True)
+
+    fake.provision.assert_awaited_once()
+    env = cfg.deploy.env_vars
+    assert env["AWS_ECS_CLUSTER"] == "agentbreeder-demo"
+    assert env["AWS_VPC_SUBNETS"] == "subnet-pub1,subnet-pub2"
+    assert env["AWS_SECURITY_GROUPS"] == "sg-agent"
+    assert env["AWS_VPC_ID"] == "vpc-0abc"
+    # Footprint recorded for teardown.
+    assert (tmp_path / ".agentbreeder" / "infra-state.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_no_op_when_provision_false(tmp_path: Path) -> None:
+    cfg = _cfg()
+    with patch("engine.builder.provisioner_for") as pf:
+        await DeployEngine()._maybe_provision_greenfield(cfg, tmp_path, provision=False)
+    pf.assert_not_called()
+    assert "AWS_ECS_CLUSTER" not in cfg.deploy.env_vars
+
+
+@pytest.mark.asyncio
+async def test_skips_when_byo_infra_present(tmp_path: Path) -> None:
+    cfg = _cfg(env_vars={"AWS_ECS_CLUSTER": "mine", "AWS_VPC_SUBNETS": "subnet-mine"})
+    with patch("engine.builder.provisioner_for") as pf:
+        await DeployEngine()._maybe_provision_greenfield(cfg, tmp_path, provision=True)
+    pf.assert_not_called()
+    # User's values are untouched.
+    assert cfg.deploy.env_vars["AWS_ECS_CLUSTER"] == "mine"
+
+
+@pytest.mark.asyncio
+async def test_rejects_non_aws_cloud(tmp_path: Path) -> None:
+    cfg = _cfg(cloud=CloudType.gcp)
+    with pytest.raises(DeployError, match="AWS"):
+        await DeployEngine()._maybe_provision_greenfield(cfg, tmp_path, provision=True)
+
+
+@pytest.mark.asyncio
+async def test_reuses_existing_greenfield_state(tmp_path: Path) -> None:
+    # Pre-record a greenfield footprint.
+    state_dir = tmp_path / ".agentbreeder"
+    state_dir.mkdir()
+    _greenfield_state().save(state_dir / "infra-state.json")
+
+    cfg = _cfg()
+    fake = _fake_provisioner(_greenfield_state())
+    with patch("engine.builder.provisioner_for", return_value=fake):
+        await DeployEngine()._maybe_provision_greenfield(cfg, tmp_path, provision=True)
+
+    # Existing infra reused — no re-provision — but env still injected.
+    fake.provision.assert_not_awaited()
+    assert cfg.deploy.env_vars["AWS_ECS_CLUSTER"] == "agentbreeder-demo"

--- a/tests/unit/test_cli_commands_extended.py
+++ b/tests/unit/test_cli_commands_extended.py
@@ -152,6 +152,46 @@ class TestDeployCommand:
             len(call_kwargs[0]) > 1 and call_kwargs[0][1] == "aws"
         )
 
+    def test_deploy_provision_flag_passed_to_engine(self) -> None:
+        f = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
+        f.write(VALID_YAML)
+        f.close()
+
+        mock_result = MagicMock()
+        mock_result.agent_name = "test-agent"
+        mock_result.version = "1.0.0"
+        mock_result.endpoint_url = "http://localhost:8080"
+        mock_result.model_dump.return_value = {}
+
+        with patch("cli.commands.deploy.DeployEngine") as mock_engine_cls:
+            engine_inst = mock_engine_cls.return_value
+            engine_inst.deploy = AsyncMock(return_value=mock_result)
+            result = runner.invoke(
+                app, ["deploy", f.name, "--target", "ecs-fargate", "--provision", "--local"]
+            )
+
+        assert result.exit_code == 0
+        assert engine_inst.deploy.call_args[1]["provision"] is True
+
+    def test_deploy_no_provision_flag_defaults_false(self) -> None:
+        f = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
+        f.write(VALID_YAML)
+        f.close()
+
+        mock_result = MagicMock()
+        mock_result.agent_name = "test-agent"
+        mock_result.version = "1.0.0"
+        mock_result.endpoint_url = "http://localhost:8080"
+        mock_result.model_dump.return_value = {}
+
+        with patch("cli.commands.deploy.DeployEngine") as mock_engine_cls:
+            engine_inst = mock_engine_cls.return_value
+            engine_inst.deploy = AsyncMock(return_value=mock_result)
+            result = runner.invoke(app, ["deploy", f.name, "--local"])
+
+        assert result.exit_code == 0
+        assert engine_inst.deploy.call_args[1]["provision"] is False
+
 
 # ── Secret Subcommands ─────────────────────────────────────────────
 

--- a/tests/unit/test_cli_deploy_remote.py
+++ b/tests/unit/test_cli_deploy_remote.py
@@ -282,7 +282,9 @@ class TestLocalPathPreserved:
             def __init__(self, *, on_step: Any) -> None:
                 self.on_step = on_step
 
-            async def deploy(self, *, config_path: Any, target: str) -> Any:
+            async def deploy(
+                self, *, config_path: Any, target: str, provision: bool = False
+            ) -> Any:
                 called["engine"] = True
                 from types import SimpleNamespace
 
@@ -322,7 +324,9 @@ class TestLocalPathPreserved:
             def __init__(self, *, on_step: Any) -> None:
                 self.on_step = on_step
 
-            async def deploy(self, *, config_path: Any, target: str) -> Any:
+            async def deploy(
+                self, *, config_path: Any, target: str, provision: bool = False
+            ) -> Any:
                 called["engine"] = True
                 from types import SimpleNamespace
 

--- a/tests/unit/test_greenfield_mapper.py
+++ b/tests/unit/test_greenfield_mapper.py
@@ -57,6 +57,8 @@ def test_aws_mapper_emits_the_env_the_ecs_deployer_reads() -> None:
     assert env["AWS_VPC_SUBNETS"] == "subnet-pub1,subnet-pub2"
     assert env["AWS_SECURITY_GROUPS"] == "sg-agent"
     assert env["AWS_REGION"] == "us-east-1"
+    # Required by the ECS deployer — derived from the execution-role ARN.
+    assert env["AWS_ACCOUNT_ID"] == "123456789012"
 
 
 def test_aws_mapper_exposes_vpc_and_private_subnets_for_the_data_tier() -> None:

--- a/tests/unit/test_greenfield_mapper.py
+++ b/tests/unit/test_greenfield_mapper.py
@@ -1,0 +1,79 @@
+"""Greenfield mapper — turn a provisioned ``InfraState`` into the deploy.env_vars
+the cloud deployer reads, so the existing BYO deploy path serves an agent into a
+freshly-provisioned footprint.
+
+Covers ``engine.deployers._greenfield.infra_state_to_env`` (issue #537).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from engine.deployers._greenfield import infra_state_to_env
+from engine.provisioners.state import InfraState
+
+
+def _aws_state() -> InfraState:
+    """A representative greenfield InfraState as AWSProvisioner.provision() returns it."""
+    return InfraState(
+        cloud="aws",
+        region="us-east-1",
+        provisioned_by="agentbreeder.AWSProvisioner",
+        provisioned_at=datetime.now(UTC),
+        mode="provisioned",
+        resources={
+            "vpc": {"vpc_id": "vpc-0abc", "cidr": "10.0.0.0/16"},
+            "network": {
+                "public_subnet_ids": ["subnet-pub1", "subnet-pub2"],
+                "private_subnet_ids": ["subnet-prv1", "subnet-prv2"],
+                "internet_gateway_id": "igw-0a",
+                "nat_gateway_ids": ["nat-0a"],
+            },
+            "security_groups": {
+                "alb_sg_id": "sg-alb",
+                "agent_sg_id": "sg-agent",
+                "db_sg_id": "sg-db",
+            },
+            "ecs_cluster": {"name": "agentbreeder-my-agent", "arn": "arn:aws:ecs:...:cluster/x"},
+            "iam_execution_role": {
+                "name": "agentbreeder-execution-my-agent",
+                "arn": "arn:aws:iam::123456789012:role/agentbreeder-execution-my-agent",
+            },
+        },
+    )
+
+
+def test_aws_mapper_emits_the_env_the_ecs_deployer_reads() -> None:
+    env = infra_state_to_env("aws", _aws_state())
+
+    # These are exactly the keys aws_ecs.py::_extract_ecs_config reads.
+    assert env["AWS_ECS_CLUSTER"] == "agentbreeder-my-agent"
+    assert (
+        env["AWS_EXECUTION_ROLE_ARN"]
+        == "arn:aws:iam::123456789012:role/agentbreeder-execution-my-agent"
+    )
+    assert env["AWS_VPC_SUBNETS"] == "subnet-pub1,subnet-pub2"
+    assert env["AWS_SECURITY_GROUPS"] == "sg-agent"
+    assert env["AWS_REGION"] == "us-east-1"
+
+
+def test_aws_mapper_exposes_vpc_and_private_subnets_for_the_data_tier() -> None:
+    # The data-backend auto-provision step places RDS/Redis into this VPC and
+    # prefers private subnets.
+    env = infra_state_to_env("aws", _aws_state())
+    assert env["AWS_VPC_ID"] == "vpc-0abc"
+    assert env["AWS_DB_SUBNETS"] == "subnet-prv1,subnet-prv2"
+
+
+def test_aws_mapper_returns_only_strings() -> None:
+    env = infra_state_to_env("aws", _aws_state())
+    assert all(isinstance(k, str) and isinstance(v, str) for k, v in env.items())
+
+
+def test_unsupported_cloud_raises() -> None:
+    state = _aws_state()
+    state.cloud = "gcp"
+    with pytest.raises(NotImplementedError):
+        infra_state_to_env("gcp", state)

--- a/tests/unit/test_teardown_cmd.py
+++ b/tests/unit/test_teardown_cmd.py
@@ -178,6 +178,53 @@ class TestTeardownCommand:
             # State file removed so a re-run doesn't double-destroy.
             assert not infra_file.exists()
 
+    def test_teardown_destroys_full_greenfield_footprint(self) -> None:
+        """A greenfield footprint (vpc + ecs_cluster) gets a full destroy(), not
+        just the data backend, so no VPC/cluster/IAM is left orphaned (#537)."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_file = Path(tmpdir) / "state.json"
+            state_file.write_text(json.dumps(_sample_state()))
+            registry_dir = Path(tmpdir) / "registry"
+            registry_dir.mkdir()
+            (registry_dir / "agents.json").write_text(json.dumps(_sample_registry()))
+
+            infra_file = Path(tmpdir) / "infra-state.json"
+            infra_file.write_text(
+                json.dumps(
+                    {
+                        "cloud": "aws",
+                        "region": "us-east-1",
+                        "provisioned_by": "agentbreeder.DeployEngine",
+                        "provisioned_at": "2026-06-04T00:00:00+00:00",
+                        "mode": "provisioned",
+                        "resources": {
+                            "vpc": {"vpc_id": "vpc-1"},
+                            "ecs_cluster": {"name": "agentbreeder-demo"},
+                            "rds": {"db_instance_identifier": "agentbreeder-demo"},
+                        },
+                    }
+                )
+            )
+
+            provisioner = MagicMock()
+            provisioner.destroy = AsyncMock()
+            provisioner.destroy_data_backend = AsyncMock()
+            with (
+                patch("cli.commands.teardown.STATE_FILE", state_file),
+                patch("cli.commands.teardown.REGISTRY_DIR", registry_dir),
+                patch("cli.commands.teardown.INFRA_STATE_FILE", infra_file),
+                patch("cli.commands.teardown._teardown_container", return_value=True),
+                patch("engine.provisioners.provisioner_for", return_value=provisioner),
+            ):
+                result = runner.invoke(app, ["teardown", "my-agent", "--force"])
+
+            assert result.exit_code == 0
+            provisioner.destroy.assert_awaited_once()
+            provisioner.destroy_data_backend.assert_not_awaited()
+            assert not infra_file.exists()
+
     def test_teardown_no_infra_state_is_noop(self) -> None:
         """No infra-state.json → no provisioner call, teardown still succeeds."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/website/content/docs/cli-reference.mdx
+++ b/website/content/docs/cli-reference.mdx
@@ -307,6 +307,7 @@ agentbreeder deploy CONFIG_PATH [--target TARGET] [--json] [--remote | --local]
 | `--target`, `-t` | No | `local` | Deploy target. See supported values below. |
 | `--remote` | No | Auto | POST to the API server (RBAC + audit enforced). Auto-enabled when `$AGENTBREEDER_URL` is set. |
 | `--local` | No | Auto | Run the deploy engine in-process. Use for dev / offline work; bypasses RBAC + audit. |
+| `--provision`, `-p` | No | Off | Greenfield-provision the cloud footprint (VPC, subnets, NAT, cluster, IAM) for a fresh account before deploying, then inject the IDs into the deploy. **AWS only; local mode only** for now (`--local --provision`). The footprint is recorded in `.agentbreeder/infra-state.json` and removed by `agentbreeder teardown`. |
 | `--json` | No | Off | Emit JSON to stdout (for CI/scripting). |
 
 **Remote vs. local mode**
@@ -328,9 +329,10 @@ This is the **canonical deploy-target status table** for AgentBreeder — other 
 
 **Greenfield vs. existing account.** The **CLI** (`agentbreeder deploy`) deploys
 into **existing infrastructure** — a VPC, subnets, cluster, and execution role you
-already have (the per-cloud BYO contract). **Greenfield** provisioning (creating that
-footprint from scratch) ships today through the **Studio deploy wizard** (Step 3 →
-*Provision for me*); the CLI `--provision` flag is on the
+already have (the per-cloud BYO contract) — **or**, on **AWS**, greenfield-provisions
+that footprint from scratch with `--provision`. For **GCP/Azure**, greenfield ships
+through the **Studio deploy wizard** (Step 3 → *Provision for me*); CLI `--provision`
+for those clouds is on the
 [roadmap](https://github.com/agentbreeder/agentbreeder/issues/383). Independently,
 **both surfaces auto-provision the data tier** (RDS pgvector / ElastiCache Redis) when
 an agent declares `memory:` or a knowledge base without a `backend_url`.
@@ -338,18 +340,20 @@ an agent declares `memory:` or a knowledge base without a `backend_url`.
 | Target | Status | Greenfield provisioning | Sidecar (governance) | Secret auto-mirror |
 |--------|--------|--------------------------|----------------------|--------------------|
 | `local` (Docker Compose) | ✅ Shipped | ✅ (nothing to provision) | ✅ | n/a (local `.env`) |
-| `ecs-fargate` (AWS) | ✅ Shipped | ✅ Studio wizard¹ · CLI BYO + auto data tier | ✅ | 🟡 Roadmap — pre-create in Secrets Manager |
+| `ecs-fargate` (AWS) | ✅ Shipped | ✅ **CLI `--provision`** + Studio wizard¹ | ✅ | 🟡 Roadmap — pre-create in Secrets Manager |
 | `cloud-run` (GCP) | ✅ Shipped | ✅ Studio wizard¹ · CLI BYO + auto data tier | ✅ | ✅ |
 | `container-apps` (Azure) | ✅ Shipped | ✅ Studio wizard¹ · CLI BYO + auto data tier | ✅ | ✅ |
-| `app-runner` (AWS) | ✅ Shipped (single-container) | CLI BYO only — wizard provisions ECS Fargate, not App Runner | ❌ — rejects `guardrails:`/`secrets:` | ❌ — not supported |
+| `app-runner` (AWS) | ✅ Shipped (single-container) | CLI BYO only — `--provision`/wizard provision ECS Fargate, not App Runner | ❌ — rejects `guardrails:`/`secrets:` | ❌ — not supported |
 | `kubernetes` (EKS/GKE/AKS/self-hosted) | 🟡 In flight | ❌ — needs existing cluster + kubeconfig | ✅ (when usable) | 🟡 Roadmap |
 | `claude-managed` (Anthropic) | 🟡 In flight | n/a — runtime is Anthropic-managed | n/a | n/a |
 
-¹ Greenfield provisioning runs through **Studio → Deploys → New deploy** (the
-`/deploy-wizard` flow) and the deployments job API (`POST /api/v1/deployments` with
-`infra_mode: "provision"`). See [Deployment → Deploying from Studio](deployment#deploying-from-studio).
-The equivalent CLI flag (`agentbreeder deploy --provision`) is not yet shipped — from
-the terminal, deploy into existing infra (BYO) or pre-create the footprint first.
+¹ **AWS** greenfield ships from the CLI today (`agentbreeder deploy --target
+ecs-fargate --provision --local`) and from **Studio → Deploys → New deploy** (the
+`/deploy-wizard` flow) + the deployments job API (`POST /api/v1/deployments` with
+`infra_mode: "provision"`). See [Deployment → Greenfield mode](deployment#user-input-contract-per-cloud-byo-existing-infra)
+and [Deploying from Studio](deployment#deploying-from-studio). For **GCP/Azure**, CLI
+`--provision` is not yet shipped — use the Studio wizard, deploy into existing infra
+(BYO), or pre-create the footprint first.
 
 Each `--target` value maps to one cloud + runtime combination:
 

--- a/website/content/docs/deployment.mdx
+++ b/website/content/docs/deployment.mdx
@@ -33,9 +33,10 @@ Container Apps with the per-cloud user-input contract below.
     on this page use.
   - **Greenfield** — a fresh account with no networking. AgentBreeder provisions
     the whole footprint (VPC, subnets, NAT, security groups, cluster, IAM, and —
-    when declared — RDS/ALB) for you. Today this ships through the **Studio
-    deploy wizard** (Step 3 → *Provision for me*) and the deployments job API;
-    CLI parity (`deploy --provision`) is on the
+    when declared — RDS) for you. On **AWS** this ships from the **CLI**
+    (`agentbreeder deploy --target ecs-fargate --provision`) **and** the Studio
+    deploy wizard (Step 3 → *Provision for me*). For **GCP/Azure**, greenfield
+    ships through the Studio wizard today; CLI parity is on the
     [roadmap](https://github.com/agentbreeder/agentbreeder/issues/383).
 
   Independently of which path you pick, the CLI and Studio both **auto-provision
@@ -112,23 +113,37 @@ Studio wizard; the equivalent CLI auto-create is on the
 `ec2:DescribeSecurityGroups`, `ecs:DescribeClusters`, `iam:GetRole`,
 `ecr:DescribeRepositories`.
 
-**Greenfield mode (Studio → "Provision for me"):**
+**Greenfield mode — `agentbreeder deploy --target ecs-fargate --provision`:**
 
 For a fresh AWS account with no networking, AgentBreeder creates the
-minimum-viable ECS Fargate footprint end-to-end. Today this runs through the
-**Studio deploy wizard** (Step 3 → *Provision for me*) and the deployments job
-API (`POST /api/v1/deployments` with `infra_mode: "provision"`), which drives the
-`AWSProvisioner.provision()` greenfield path with live SSE progress and
-partial-rollback on failure. Only `AWS_REGION` and a credential chain are
-required — no pre-existing cluster, subnets, or roles. See [Deploying from
-Studio](#deploying-from-studio) for the walkthrough.
+minimum-viable ECS Fargate footprint end-to-end, then deploys the agent into it.
+This ships from **both** the **CLI** and the **Studio** wizard:
 
-<Callout type="info" title="CLI greenfield is on the roadmap">
-  `agentbreeder deploy --target aws --provision` ([#383](https://github.com/agentbreeder/agentbreeder/issues/383))
-  will run this same provisioner from the terminal. Until it ships, the **CLI
-  deploys into existing infra** (the BYO fields above are required) — but it
-  still **auto-provisions the data tier** (RDS pgvector / ElastiCache Redis) when
-  you declare `memory:` or a knowledge base without a `backend_url`.
+```bash
+# Fresh AWS account: just creds + region in agent.yaml — no BYO env_vars.
+agentbreeder deploy agent.yaml --target ecs-fargate --provision --local
+```
+
+The CLI provisions the VPC, subnets, NAT, security groups, ECS cluster, and IAM
+execution role (opening the agent's port for the task's public IP since there's
+no ALB in front), maps the resulting IDs into the deploy, and then runs the
+normal build → deploy → health-check → register pipeline. Declaring `memory:`
+or a knowledge base also auto-provisions the data tier (RDS pgvector /
+ElastiCache Redis) **into the new VPC**. Everything is tagged `AgentBreeder=true`
+and recorded in `.agentbreeder/infra-state.json`, so `agentbreeder teardown
+<agent>` removes the whole footprint with no orphans. Re-running `--provision`
+reuses the recorded footprint instead of creating a duplicate.
+
+Only `AWS_REGION` (or `deploy.region`) and a credential chain are required — no
+pre-existing cluster, subnets, or roles.
+
+<Callout type="info" title="Studio equivalent + GCP/Azure">
+  The Studio deploy wizard (Step 3 → *Provision for me*) runs the same
+  `AWSProvisioner.provision()` path with live SSE progress and partial-rollback;
+  see [Deploying from Studio](#deploying-from-studio). On **GCP/Azure**,
+  greenfield ships via the Studio wizard today — CLI `--provision` for those
+  clouds is on the [roadmap](https://github.com/agentbreeder/agentbreeder/issues/383).
+  `--provision` is **local mode** only for now (use `--local`).
 </Callout>
 
 | Resource | Notes |


### PR DESCRIPTION
## What

Implements **CLI greenfield provisioning for AWS** (issue #537, refs #383). A fresh AWS account with no VPC/subnets/cluster/role can now deploy with one command:

```bash
agentbreeder deploy agent.yaml --target ecs-fargate --provision --local
```

> **Stacked on** `docs/aws-greenfield-deploy-accuracy` — review/merge that PR first. This branch also flips the AWS CLI-greenfield docs from roadmap → shipped.

## How it works (the missing glue)

`AWSProvisioner.provision()` already creates the full footprint and returns an `InfraState`. The gap was the wiring:

- **`engine/deployers/_greenfield.py::infra_state_to_env`** — maps a provisioned `InfraState` into the `deploy.env_vars` the ECS deployer already reads (`AWS_ECS_CLUSTER` / `AWS_EXECUTION_ROLE_ARN` / `AWS_VPC_SUBNETS` / `AWS_SECURITY_GROUPS` / `AWS_VPC_ID`), so the existing BYO deploy path serves the agent unchanged. (100% covered.)
- **`DeployEngine.deploy(provision=True)`** — Step 5 greenfield-provisions network + cluster + IAM (no `AWS_HAS_MEMORY` → no double-provisioned RDS), injects the IDs with `setdefault` (explicit BYO always wins), records the footprint. The existing data-tier auto-provision (RDS pgvector / ElastiCache Redis) then lands in the new VPC. Reuses a recorded footprint instead of duplicating; non-AWS clouds fail fast pointing at the Studio wizard.
- **`AWSProvisioner`** — gated `AWS_AGENT_PUBLIC_INGRESS` opens the agent SG :8080 to the internet when there's no ALB (matches the deployer's `assignPublicIp` public-IP model; `/invoke` stays bearer-gated). Default off → existing behavior unchanged; **DB SG stays agent-only, never `0.0.0.0/0`**.
- **`_persist_infra_resources`** — merges greenfield + data-tier footprints into one `infra-state.json`; **teardown** runs the full `provisioner.destroy()` for a greenfield footprint (vs `destroy_data_backend()` for data-only) → no orphans.
- **CLI** — `--provision/-p` flag (local mode only for now; remote errors clearly).

## Testing

- New: mapper (4 tests, 100%), engine greenfield branch (5), agent-SG reachability rule (2), CLI flag threading (2), full-footprint teardown (1).
- **Full unit suite green: 5366 passed, 0 failures.** Ruff clean. Website build green.
- ⚠️ Live AWS validation: see checklist below.

## Out of scope (tracked)

- GCP/Azure CLI greenfield (same mapper shape; follow-up).
- Studio/API greenfield serve hand-off — the orchestrator's build/deploy phases call `engine.deployers.deployer_for()` which doesn't exist; unifying it onto `DeployEngine` is the shared fix (noted in #537).

## Reviewer checklist

- [ ] Live `--provision` deploy to a fresh footprint → serves → `teardown` leaves zero orphans
- [ ] Confirm DB SG never exposed to `0.0.0.0/0`

Spec: `docs/superpowers/specs/2026-06-04-cli-greenfield-provision-aws.md`. Closes #537.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
