### PR TITLE
feat(deployers): GCP + Azure deploy parity with AWS (epic #505)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [2.7.0] — 2026-06-16
 
+### Added
+- **GCP + Azure deploy parity with AWS** (multi-cloud parity epic #505). The same
+  `agent.yaml` now reaches feature parity across all three managed clouds:
+  - **MCP discovery on every cloud** — the GCP Cloud Run and Azure Container Apps
+    deployers now inject the agent-facing `AGENTBREEDER_MCP_SERVERS` env so
+    `agenthub.mcp.load_mcp_tools()` discovers co-deployed MCP servers (was AWS-only;
+    closes #533).
+  - **CLI greenfield `--provision` for GCP and Azure** — `agentbreeder deploy
+    --target cloud-run --provision --local` and `--target container-apps --provision
+    --local` now stand up a fresh footprint, mapping the provisioned IDs into the
+    deploy (was AWS-only; #537). GCP greenfield additionally builds a dedicated VPC +
+    subnet + Cloud NAT + a Private Service Access range (for Cloud SQL private IP),
+    matching the AWS VPC story; the footprint is torn down by `agentbreeder teardown`.
+
+### Fixed
+- **GCP sidecar boot-auth** — the Cloud Run sidecar now emits `AGENT_AUTH_TOKEN`
+  (or `AGENTBREEDER_SIDECAR_ALLOW_NO_AUTH=1`) so it starts, matching the AWS injector.
+- **GCP/Azure resource normalization** — `resources.cpu`/`memory` accept the
+  documented `agent.yaml` notation (vCPU + `Gi`/`Mi`/`G`/`M`/raw) and render
+  Cloud Run (Mi/Gi, whole vCPU/millicpu) and Container Apps (fractional cores,
+  canonical `<x>Gi`) valid values.
+
 ### Security
 - **Bumped `vitest` to `^4.1.8` in `sdk/typescript`** (was `^1.6.0`), clearing a critical advisory
   (GHSA — Vitest UI server arbitrary file read/execute, fixed in 4.1.0). Dev/test-only dependency;

--- a/cli/commands/deploy.py
+++ b/cli/commands/deploy.py
@@ -108,8 +108,9 @@ def deploy(
         "--provision",
         "-p",
         help=(
-            "Greenfield-provision the cloud footprint (VPC, subnets, cluster, IAM) "
-            "for a fresh account before deploying. AWS only; local mode only."
+            "Greenfield-provision the cloud footprint (network, registry, cluster/"
+            "environment, IAM) for a fresh account before deploying. Supports AWS, "
+            "GCP, and Azure; local mode only."
         ),
     ),
 ) -> None:
@@ -141,7 +142,7 @@ def _deploy_local(
     always go through ``--remote``.
 
     When ``provision`` is set, the engine greenfield-provisions the cloud
-    footprint before deploying (AWS only; #537).
+    footprint before deploying (AWS, GCP, or Azure; #537, parity #505).
     """
     if not json_output:
         provision_note = " [yellow](+ greenfield provisioning)[/yellow]" if provision else ""

--- a/engine/builder.py
+++ b/engine/builder.py
@@ -102,6 +102,66 @@ class PipelineStep:
         )
 
 
+def _aws_greenfield_fields(fields: dict[str, Any], config: AgentConfig, region: str) -> None:
+    fields.setdefault("AWS_AGENT_NAME", config.name)
+    fields.setdefault("AWS_AGENT_VERSION", config.version)
+    fields.setdefault("AWS_DEFAULT_REGION", region)
+    # CLI deploys reach the task at its public IP (assignPublicIp), no ALB.
+    fields.setdefault("AWS_AGENT_PUBLIC_INGRESS", "true")
+
+
+def _gcp_greenfield_fields(fields: dict[str, Any], config: AgentConfig, region: str) -> None:
+    fields.setdefault("GCP_AGENT_NAME", config.name)
+    fields.setdefault("GCP_AGENT_VERSION", config.version)
+    fields.setdefault("GCP_REGION", region)
+    # provision(gcp) requires GOOGLE_CLOUD_PROJECT; recover it from GCP_PROJECT_ID.
+    if not fields.get("GOOGLE_CLOUD_PROJECT") and fields.get("GCP_PROJECT_ID"):
+        fields["GOOGLE_CLOUD_PROJECT"] = fields["GCP_PROJECT_ID"]
+    # Create a dedicated VPC + Serverless connector so the agent and data tier
+    # share a private network (matches the AWS VPC story).
+    fields.setdefault("GCP_PROVISION_VPC", "true")
+    fields.setdefault("GCP_PROVISION_VPC_CONNECTOR", "true")
+
+
+def _azure_greenfield_fields(fields: dict[str, Any], config: AgentConfig, region: str) -> None:
+    fields.setdefault("AZURE_AGENT_NAME", config.name)
+    fields.setdefault("AZURE_AGENT_VERSION", config.version)
+    fields.setdefault("AZURE_LOCATION", region)
+
+
+# Per-cloud greenfield descriptors for ``agentbreeder deploy --provision``
+# (#537, multi-cloud parity #505). Each maps a cloud to the provisioner provider
+# string, the env keys that mean "BYO infra already supplied" (skip greenfield),
+# the InfraState.resources key that confirms a prior greenfield footprint, the
+# default region + region env key, and the field setter applied before provision.
+_GREENFIELD_SPECS: dict[CloudType, dict[str, Any]] = {
+    CloudType.aws: {
+        "provider": "aws",
+        "byo_keys": ("AWS_ECS_CLUSTER", "AWS_VPC_SUBNETS"),
+        "reuse_key": "ecs_cluster",
+        "default_region": "us-east-1",
+        "region_env": "AWS_REGION",
+        "set_fields": _aws_greenfield_fields,
+    },
+    CloudType.gcp: {
+        "provider": "gcp",
+        "byo_keys": ("GCP_ARTIFACT_REGISTRY_REPO", "GCP_SERVICE_ACCOUNT"),
+        "reuse_key": "service_account",
+        "default_region": "us-central1",
+        "region_env": "GCP_REGION",
+        "set_fields": _gcp_greenfield_fields,
+    },
+    CloudType.azure: {
+        "provider": "azure",
+        "byo_keys": ("AZURE_RESOURCE_GROUP", "AZURE_CONTAINER_APPS_ENV", "AZURE_REGISTRY_SERVER"),
+        "reuse_key": "container_apps_environment",
+        "default_region": "eastus",
+        "region_env": "AZURE_LOCATION",
+        "set_fields": _azure_greenfield_fields,
+    },
+}
+
+
 class DeployEngine:
     """Orchestrates the full deploy pipeline."""
 
@@ -329,11 +389,10 @@ class DeployEngine:
         if cloud in (CloudType.local, CloudType.claude_managed):
             return  # nothing to provision
 
-        if cloud != CloudType.aws:
-            raise DeployError(
-                f"--provision currently supports AWS only (got {cloud.value!r}). "
-                "Use the Studio deploy wizard for GCP/Azure greenfield (#537)."
-            )
+        spec = _GREENFIELD_SPECS.get(cloud)
+        if spec is None:
+            raise DeployError(f"--provision does not support cloud {cloud.value!r}.")
+        provider = spec["provider"]
 
         from engine.provisioners.state import InfraState
 
@@ -342,9 +401,10 @@ class DeployEngine:
         env = config.deploy.env_vars
 
         # BYO infra already supplied → respect it, skip greenfield.
-        if env.get("AWS_ECS_CLUSTER") and env.get("AWS_VPC_SUBNETS"):
+        if all(env.get(k) for k in spec["byo_keys"]):
             logger.info(
-                "Existing AWS infra in env_vars for '%s'; skipping greenfield provisioning",
+                "Existing %s infra in env_vars for '%s'; skipping greenfield provisioning",
+                provider,
                 config.name,
             )
             return
@@ -354,31 +414,28 @@ class DeployEngine:
         if (
             existing is not None
             and existing.mode == "provisioned"
-            and "ecs_cluster" in existing.resources
+            and existing.cloud == provider
+            and spec["reuse_key"] in existing.resources
         ):
             logger.info("Reusing greenfield infra recorded at %s", state_path)
             state = existing
         else:
-            region = config.deploy.region or env.get("AWS_REGION") or "us-east-1"
+            region = config.deploy.region or env.get(spec["region_env"]) or spec["default_region"]
             fields = dict(env)  # carries creds + any user overrides
-            fields.setdefault("AWS_AGENT_NAME", config.name)
-            fields.setdefault("AWS_AGENT_VERSION", config.version)
-            fields.setdefault("AWS_DEFAULT_REGION", region)
-            # CLI deploys reach the task at its public IP (assignPublicIp), no ALB.
-            fields.setdefault("AWS_AGENT_PUBLIC_INGRESS", "true")
+            spec["set_fields"](fields, config, region)
 
             async def _emit(msg: str) -> None:
-                logger.info("greenfield(aws): %s", msg)
+                logger.info("greenfield(%s): %s", provider, msg)
 
-            logger.info("Greenfield-provisioning AWS footprint for '%s'", config.name)
+            logger.info("Greenfield-provisioning %s footprint for '%s'", provider, config.name)
             payload = InfraValidationInput(
-                cloud="aws", region=region, mode="simple", fields=fields
+                cloud=provider, region=region, mode="simple", fields=fields
             )
-            state = await provisioner_for("aws").provision(payload, progress=_emit)
-            self._persist_infra_resources(project_dir, "aws", region, state.resources)
+            state = await provisioner_for(provider).provision(payload, progress=_emit)
+            self._persist_infra_resources(project_dir, provider, region, state.resources)
 
         # Inject the provisioned IDs without clobbering anything the user set.
-        for key, value in infra_state_to_env("aws", state).items():
+        for key, value in infra_state_to_env(provider, state).items():
             env.setdefault(key, value)
 
     async def _auto_provision_data_backends(

--- a/engine/builder.py
+++ b/engine/builder.py
@@ -117,10 +117,18 @@ def _gcp_greenfield_fields(fields: dict[str, Any], config: AgentConfig, region: 
     # provision(gcp) requires GOOGLE_CLOUD_PROJECT; recover it from GCP_PROJECT_ID.
     if not fields.get("GOOGLE_CLOUD_PROJECT") and fields.get("GCP_PROJECT_ID"):
         fields["GOOGLE_CLOUD_PROJECT"] = fields["GCP_PROJECT_ID"]
-    # Create a dedicated VPC + Serverless connector so the agent and data tier
-    # share a private network (matches the AWS VPC story).
-    fields.setdefault("GCP_PROVISION_VPC", "true")
-    fields.setdefault("GCP_PROVISION_VPC_CONNECTOR", "true")
+    # Cloud Run is serverless and reaches the public internet without a VPC, so a
+    # greenfield VPC + Serverless connector is only worth building when the agent
+    # has a private managed data tier to reach (Cloud SQL private IP / Memorystore).
+    # For a stateless agent, greenfield stays minimal (Artifact Registry + SA).
+    needs_private_net = (
+        needs_managed_pgvector(config)
+        or needs_managed_memory_postgres(config)
+        or needs_managed_memory_redis(config)
+    )
+    if needs_private_net:
+        fields.setdefault("GCP_PROVISION_VPC", "true")
+        fields.setdefault("GCP_PROVISION_VPC_CONNECTOR", "true")
 
 
 def _azure_greenfield_fields(fields: dict[str, Any], config: AgentConfig, region: str) -> None:

--- a/engine/deployers/_docker.py
+++ b/engine/deployers/_docker.py
@@ -1,0 +1,38 @@
+"""Shared Docker client factory for the cloud deployers.
+
+All three managed-cloud deployers (AWS ECS, GCP Cloud Run, Azure Container Apps)
+build + push images with the Docker SDK. On multi-user machines and macOS Docker
+Desktop, ``docker.from_env()`` defaults to ``/var/run/docker.sock`` — which may
+symlink to a root-owned socket and fail with ``PermissionError(13)`` even though
+the ``docker`` CLI (which uses the Desktop context) works fine. This factory
+prefers the current user's Desktop socket so every deployer behaves identically.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def docker_client() -> Any:
+    """Return a Docker SDK client that works on multi-user machines / Docker Desktop.
+
+    Honors ``DOCKER_HOST``; otherwise prefers the current user's Docker Desktop
+    socket (``~/.docker/run/docker.sock``) over ``/var/run/docker.sock``.
+
+    Raises ``ImportError`` (with a pip hint) if the Docker SDK is not installed.
+    """
+    import os
+    from pathlib import Path
+
+    try:
+        import docker
+    except ImportError as e:  # pragma: no cover - exercised via deployer tests
+        msg = "Docker SDK not installed. Run: pip install docker"
+        raise ImportError(msg) from e
+
+    if os.environ.get("DOCKER_HOST"):
+        return docker.from_env()
+    user_socket = Path.home() / ".docker" / "run" / "docker.sock"
+    if user_socket.exists():
+        return docker.DockerClient(base_url=f"unix://{user_socket}")
+    return docker.from_env()

--- a/engine/deployers/_greenfield.py
+++ b/engine/deployers/_greenfield.py
@@ -20,15 +20,13 @@ from engine.provisioners.state import InfraState
 def infra_state_to_env(cloud: str, state: InfraState) -> dict[str, str]:
     """Map a greenfield ``InfraState`` into deploy ``env_vars`` for ``cloud``.
 
-    Raises ``NotImplementedError`` for clouds whose CLI greenfield mapping is
-    not implemented yet (GCP/Azure follow in later work; see #537).
+    Implemented for AWS, GCP, and Azure (multi-cloud parity, #505/#537).
+    Raises ``NotImplementedError`` for any other cloud.
     """
-    if cloud == "aws":
-        return _aws_env(state)
-    raise NotImplementedError(
-        f"CLI greenfield provisioning is implemented for AWS only; got {cloud!r}. "
-        "Use the Studio deploy wizard for GCP/Azure greenfield (issue #537)."
-    )
+    mapper = {"aws": _aws_env, "gcp": _gcp_env, "azure": _azure_env}.get(cloud)
+    if mapper is None:
+        raise NotImplementedError(f"CLI greenfield provisioning is not implemented for {cloud!r}.")
+    return mapper(state)
 
 
 def _aws_env(state: InfraState) -> dict[str, str]:
@@ -57,4 +55,69 @@ def _aws_env(state: InfraState) -> dict[str, str]:
     }
     if private_subnets:
         env["AWS_DB_SUBNETS"] = ",".join(private_subnets)
+    return env
+
+
+def _gcp_env(state: InfraState) -> dict[str, str]:
+    """Map a GCP greenfield ``InfraState`` into the env keys the Cloud Run
+    deployer (``gcp_cloudrun._extract_cloudrun_config``) and the data-tier
+    auto-provisioner read."""
+    res = state.resources
+    sa = res.get("service_account", {})
+    ar = res.get("artifact_registry", {})
+    connector = res.get("vpc_connector", {})
+    network = res.get("network", {})
+
+    project = str(sa.get("project") or "")
+    env: dict[str, str] = {"GCP_REGION": str(state.region)}
+    if project:
+        # The deployer reads GCP_PROJECT_ID/GOOGLE_CLOUD_PROJECT; the user
+        # normally supplies it, but stamp it for completeness.
+        env["GCP_PROJECT_ID"] = project
+    if sa.get("email"):
+        env["GCP_SERVICE_ACCOUNT"] = str(sa["email"])
+    if ar.get("repo"):
+        env["GCP_ARTIFACT_REGISTRY_REPO"] = str(ar["repo"])
+    if connector.get("name"):
+        env["GCP_VPC_CONNECTOR"] = str(connector["name"])
+    # A greenfield VPC (created by the provisioner) so the data tier
+    # (Cloud SQL / Memorystore) lands in it rather than the default network.
+    if network.get("name"):
+        env["GCP_VPC_NAME"] = str(network["name"])
+    if network.get("subnet"):
+        env["GCP_SUBNET_NAME"] = str(network["subnet"])
+    return env
+
+
+def _azure_env(state: InfraState) -> dict[str, str]:
+    """Map an Azure greenfield ``InfraState`` into the env keys the Container
+    Apps deployer (``azure_container_apps._extract_azure_config``) and the
+    data-tier auto-provisioner read."""
+    res = state.resources
+    rg = res.get("resource_group", {})
+    aca_env = res.get("container_apps_environment", {})
+    acr = res.get("acr", {})
+    vnet = res.get("vnet", {})
+    key_vault = res.get("key_vault", {})
+
+    env: dict[str, str] = {"AZURE_LOCATION": str(state.region)}
+    # Subscription id is supplied by the user, but recover it from the RG ARM id
+    # (/subscriptions/<id>/resourceGroups/<name>) so the mapping is self-contained.
+    rg_id = str(rg.get("id") or "")
+    parts = rg_id.split("/")
+    if "subscriptions" in parts:
+        env["AZURE_SUBSCRIPTION_ID"] = parts[parts.index("subscriptions") + 1]
+    if rg.get("name"):
+        env["AZURE_RESOURCE_GROUP"] = str(rg["name"])
+    if aca_env.get("name"):
+        env["AZURE_CONTAINER_APPS_ENV"] = str(aca_env["name"])
+    if acr.get("login_server"):
+        env["AZURE_REGISTRY_SERVER"] = str(acr["login_server"])
+    # Data tier: land managed Postgres in the greenfield VNet's delegated subnet.
+    if vnet.get("name"):
+        env["AZURE_VNET_NAME"] = str(vnet["name"])
+    if vnet.get("db_subnet_id"):
+        env["AZURE_DB_SUBNET_ID"] = str(vnet["db_subnet_id"])
+    if key_vault.get("uri"):
+        env["AZURE_KEYVAULT_URL"] = str(key_vault["uri"])
     return env

--- a/engine/deployers/aws_ecs.py
+++ b/engine/deployers/aws_ecs.py
@@ -103,25 +103,14 @@ AGENT_PUBLIC_PORT = 8080
 
 
 def _docker_client() -> Any:
-    """Return a Docker client that works on multi-user machines.
+    """Return a Docker client that works on multi-user machines / Docker Desktop.
 
-    Honors ``DOCKER_HOST``; otherwise prefers the current user's Docker Desktop
-    socket (``~/.docker/run/docker.sock``) over ``/var/run/docker.sock`` — on a
-    shared host the latter can symlink to another user's root-owned socket,
-    which makes the Python SDK fail with ``PermissionError(13)`` even though the
-    ``docker`` CLI (which uses the Desktop context) works fine.
+    Thin wrapper over the shared :func:`engine.deployers._docker.docker_client`
+    so all three cloud deployers resolve the Docker socket identically.
     """
-    import os
-    from pathlib import Path
+    from engine.deployers._docker import docker_client
 
-    import docker
-
-    if os.environ.get("DOCKER_HOST"):
-        return docker.from_env()
-    user_socket = Path.home() / ".docker" / "run" / "docker.sock"
-    if user_socket.exists():
-        return docker.DockerClient(base_url=f"unix://{user_socket}")
-    return docker.from_env()
+    return docker_client()
 
 
 class AWSECSConfig(BaseModel):

--- a/engine/deployers/azure_container_apps.py
+++ b/engine/deployers/azure_container_apps.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from datetime import datetime
 from typing import Any
 
@@ -43,6 +44,49 @@ DEFAULT_MEMORY = "1.0Gi"
 DEFAULT_TARGET_PORT = 8080
 HEALTH_CHECK_TIMEOUT = 120
 HEALTH_CHECK_INTERVAL = 5
+
+
+def _normalize_aca_cpu(value: str | None) -> float:
+    """Convert a CPU spec to Azure Container Apps fractional cores.
+
+    ACA wants a numeric core count (``0.5``, ``1.0``, ``2.0``). Accepts vCPU
+    notation (``"1"``, ``"0.5"``) and millicpu (``"500m"`` → ``0.5``).
+    """
+    raw = (value or "").strip().lower().removesuffix("vcpu").strip()
+    if raw.endswith("m"):
+        try:
+            return float(raw[:-1].strip()) / 1000
+        except ValueError:
+            return DEFAULT_CPU
+    match = re.match(r"^([0-9]*\.?[0-9]+)$", raw)
+    if not match:
+        return DEFAULT_CPU
+    num = float(match.group(1))
+    return num if num > 0 else DEFAULT_CPU
+
+
+def _normalize_aca_memory(value: str | None) -> str:
+    """Convert a memory spec to the ACA canonical form ``"<x.x>Gi"``.
+
+    Accepts Kubernetes-style quantities (``"2Gi"``, ``"512Mi"``), plain GB/MB
+    suffixes (``"2G"``, ``"512M"``) and raw MiB integers (``"2048"`` →
+    ``"2.0Gi"``). ACA only accepts Gi-denominated memory.
+    """
+    raw = (value or "").strip()
+    match = re.match(r"^([0-9]*\.?[0-9]+)\s*([a-zA-Z]*)$", raw)
+    if not match:
+        return DEFAULT_MEMORY
+    num = float(match.group(1))
+    unit = match.group(2).lower()
+    if num <= 0:
+        return DEFAULT_MEMORY
+    if unit in ("gi", "g", "gb"):
+        gi = num
+    else:  # "", "mi", "m", "mb" — MiB-scale → Gi
+        gi = num / 1024
+    # Canonical ACA form: drop trailing zeros ("2.0Gi" → "2Gi", keep "0.5Gi").
+    text = f"{gi:.2f}".rstrip("0").rstrip(".")
+    return f"{text}Gi"
 
 
 class AzureConfig(BaseModel):
@@ -442,13 +486,11 @@ class AzureContainerAppsDeployer(BaseDeployer):
         Constructs the template for the Container App resource including
         ingress, registry credentials, container spec, and scaling rules.
         """
-        # Parse resource config — Azure Container Apps uses numeric CPU
-        cpu_str = config.deploy.resources.cpu or str(DEFAULT_CPU)
-        try:
-            cpu = float(cpu_str)
-        except ValueError:
-            cpu = DEFAULT_CPU
-        memory = config.deploy.resources.memory or DEFAULT_MEMORY
+        # Parse resource config — Azure Container Apps uses numeric (fractional
+        # core) CPU and Gi-denominated memory. Normalize the documented
+        # agent.yaml notation (vCPU + Gi/Mi/G/M/raw) into those forms.
+        cpu = _normalize_aca_cpu(config.deploy.resources.cpu)
+        memory = _normalize_aca_memory(config.deploy.resources.memory)
 
         # Environment variables for the container
         env_vars = [
@@ -465,6 +507,26 @@ class AzureContainerAppsDeployer(BaseDeployer):
         for key, value in config.deploy.env_vars.items():
             if not key.startswith("AZURE_"):
                 env_vars.append({"name": key, "value": value})
+
+        # Expose the resolved MCP forwarding map to the agent so it can load the
+        # co-deployed servers' tools via agenthub.mcp.load_mcp_tools() (#533 —
+        # parity with aws_ecs.py).
+        if config.mcp_servers:
+            import json as _mcp_json
+
+            from engine.deployers.mcp_sidecar import (
+                build_sidecar_env_map,
+                resolve_mcp_servers,
+            )
+
+            mcp_map = build_sidecar_env_map(resolve_mcp_servers(config.mcp_servers))
+            if mcp_map:
+                env_vars.append(
+                    {
+                        "name": "AGENTBREEDER_MCP_SERVERS",
+                        "value": _mcp_json.dumps(mcp_map),
+                    }
+                )
 
         # Scaling
         min_replicas = max(0, config.deploy.scaling.min)

--- a/engine/deployers/azure_container_apps.py
+++ b/engine/deployers/azure_container_apps.py
@@ -328,13 +328,9 @@ class AzureContainerAppsDeployer(BaseDeployer):
         Requires `az acr login --name <registry>` or AZURE_REGISTRY_USERNAME/PASSWORD
         to be set for authentication.
         """
-        try:
-            import docker
-        except ImportError as e:
-            msg = "Docker SDK not installed. Run: pip install docker"
-            raise ImportError(msg) from e
+        from engine.deployers._docker import docker_client
 
-        client = docker.from_env()
+        client = docker_client()
 
         # Build the image locally first
         logger.info("Building Docker image: %s", image.tag)

--- a/engine/deployers/gcp_cloudrun.py
+++ b/engine/deployers/gcp_cloudrun.py
@@ -595,13 +595,9 @@ class GCPCloudRunDeployer(BaseDeployer):
         Requires `gcloud auth configure-docker` to have been run for the
         Artifact Registry region.
         """
-        try:
-            import docker
-        except ImportError as e:
-            msg = "Docker SDK not installed. Run: pip install docker"
-            raise ImportError(msg) from e
+        from engine.deployers._docker import docker_client
 
-        client = docker.from_env()
+        client = docker_client()
 
         # Build the image locally first
         logger.info("Building Docker image: %s", image.tag)

--- a/engine/deployers/gcp_cloudrun.py
+++ b/engine/deployers/gcp_cloudrun.py
@@ -422,8 +422,11 @@ def _build_cloudrun_sidecar_container(config: AgentConfig) -> dict[str, Any]:
         "image": sc.image,
         "env": env,
         "resources": {"limits": {"cpu": "500m", "memory": "256Mi"}},
-        # #500: run the sidecar as the distroless non-root user.
-        "security_context": {"run_as_user": 65532},
+        # #500: the sidecar runs as a non-root user (uid 65532). Cloud Run v2's
+        # Container has no security_context field — it derives the run-as user
+        # from the image's Dockerfile USER, which the distroless sidecar image
+        # already sets to nonroot. Setting it here makes the Admin API reject
+        # the revision with "Unknown field for Container: security_context".
         "ports": [{"container_port": INGRESS_PORT}],
         "startup_probe": {
             "http_get": {"path": "/health", "port": INGRESS_PORT},
@@ -783,21 +786,20 @@ class GCPCloudRunDeployer(BaseDeployer):
         }
         ingress = ingress_map.get(gcp.ingress, IngressTraffic.INGRESS_TRAFFIC_ALL)
 
-        # Try to get existing service first
-        try:
+        from google.api_core.exceptions import AlreadyExists, NotFound
+
+        async def _update_existing() -> Any:
             existing = await run_client.get_service(request=GetServiceRequest(name=service_name))
             logger.info("Updating existing Cloud Run service: %s", config.name)
-
             existing.template = RevisionTemplate(template_dict)
             existing.ingress = ingress
-
             operation = await run_client.update_service(
                 request=UpdateServiceRequest(service=existing)
             )
-            service = await operation.result()
-        except Exception:
-            logger.info("Creating new Cloud Run service: %s", config.name)
+            return await operation.result()
 
+        async def _create_new() -> Any:
+            logger.info("Creating new Cloud Run service: %s", config.name)
             service_obj = Service(
                 template=RevisionTemplate(template_dict),
                 ingress=ingress,
@@ -808,7 +810,6 @@ class GCPCloudRunDeployer(BaseDeployer):
                     "team": config.team,
                 },
             )
-
             operation = await run_client.create_service(
                 request=CreateServiceRequest(
                     parent=parent,
@@ -816,7 +817,21 @@ class GCPCloudRunDeployer(BaseDeployer):
                     service_id=config.name,
                 )
             )
-            service = await operation.result()
+            return await operation.result()
+
+        # Idempotent upsert. Update the service when it already exists, create it
+        # otherwise. The W4-35 stale-cleanup path may leave a delete in flight, so
+        # each direction falls back to its inverse on the opposite error: a service
+        # that vanishes mid-update (NotFound) is created, and one that reappears
+        # mid-create (AlreadyExists) is patched. Without this, retrying a deploy
+        # that partially created a service fails with HTTP 400 "already exists".
+        try:
+            service = await _update_existing()
+        except NotFound:
+            try:
+                service = await _create_new()
+            except AlreadyExists:
+                service = await _update_existing()
 
         # Extract the service URL
         service_url = service.uri

--- a/engine/deployers/gcp_cloudrun.py
+++ b/engine/deployers/gcp_cloudrun.py
@@ -12,6 +12,7 @@ Cloud-specific logic stays in this module — never leak GCP details elsewhere.
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime
 from typing import Any
 
@@ -53,6 +54,61 @@ HEALTH_CHECK_INTERVAL = 5
 # ingress container on 8080.
 INGRESS_PORT = 8080
 AGENT_INTERNAL_PORT = 8081
+
+# Cloud Run caps CPU at 8 vCPU. Values at/below this are read as a vCPU count.
+_MAX_VCPU = 8
+
+
+def _normalize_cloudrun_cpu(value: str | None) -> str:
+    """Convert a CPU spec to a Cloud Run-valid limit.
+
+    Cloud Run expects whole vCPU (``"1"``, ``"2"``) or millicpu (``"500m"``).
+    Accepts vCPU notation (``"1"``, ``"0.5"``) and millicpu (``"500m"``); raw
+    CPU-unit notation (``"1024"``, AWS-style) is interpreted as vCPU/1024.
+    Cloud Run requires >= 1 vCPU when concurrency > 1, so sub-1.0 values are
+    clamped to ``"1000m"`` (matches the prior #119 behaviour).
+    """
+    raw = (value or "").strip().lower().removesuffix("vcpu").strip()
+    if raw.endswith("m"):
+        digits = raw[:-1].strip()
+        try:
+            milli = float(digits)
+        except ValueError:
+            return DEFAULT_CPU
+        return "1000m" if milli < 1000 else str(int(round(milli / 1000)))
+    match = re.match(r"^([0-9]*\.?[0-9]+)$", raw)
+    if not match:
+        return DEFAULT_CPU
+    num = float(match.group(1))
+    if num <= 0:
+        return DEFAULT_CPU
+    # Large integers are AWS-style CPU units (1024 = 1 vCPU); convert.
+    if num > _MAX_VCPU:
+        num = num / 1024
+    if num < 1.0:
+        return "1000m"  # Cloud Run minimum for concurrency > 1
+    return str(int(round(num)))
+
+
+def _normalize_cloudrun_memory(value: str | None) -> str:
+    """Convert a memory spec to a Cloud Run-valid limit (``"<n>Mi"``/``"<n>Gi"``).
+
+    Cloud Run only accepts ``Mi``/``Gi`` suffixes. Accepts Kubernetes-style
+    quantities (``"2Gi"``, ``"512Mi"``), plain GB/MB suffixes (``"2G"``,
+    ``"512M"``) and raw MiB integers (``"1024"`` → ``"1024Mi"``).
+    """
+    raw = (value or "").strip()
+    match = re.match(r"^([0-9]*\.?[0-9]+)\s*([a-zA-Z]*)$", raw)
+    if not match:
+        return DEFAULT_MEMORY
+    num = float(match.group(1))
+    unit = match.group(2).lower()
+    if num <= 0:
+        return DEFAULT_MEMORY
+    if unit in ("gi", "g", "gb"):
+        return f"{int(round(num))}Gi"
+    # "", "mi", "m", "mb" — already MiB-scale.
+    return f"{int(round(num))}Mi"
 
 
 class CloudRunConfig(BaseModel):
@@ -148,14 +204,12 @@ def _build_service_template(
     This produces the template dict used by the Cloud Run v2 API
     to define the service's container spec, scaling, and resource limits.
     """
-    # Parse resource config
-    # Fix #119: Cloud Run requires >= 1 vCPU when concurrency > 1.
-    # Normalise the value first, then clamp to 1000m if below 1.0 vCPU.
-    cpu_str = str(config.deploy.resources.cpu or DEFAULT_CPU)
-    cpu_val = float(cpu_str.replace("m", "")) / (1000 if cpu_str.endswith("m") else 1)
-    if cpu_val < 1.0:
-        cpu_str = "1000m"  # Cloud Run minimum for concurrency > 1
-    memory = config.deploy.resources.memory or DEFAULT_MEMORY
+    # Parse resource config. Cloud Run accepts only whole-vCPU/millicpu CPU and
+    # Mi/Gi memory; normalize the documented agent.yaml notation (vCPU + Gi/Mi/
+    # G/M/raw) into those forms. Fix #119: clamp CPU to >= 1 vCPU for
+    # concurrency > 1 (handled inside the normalizer).
+    cpu_str = _normalize_cloudrun_cpu(config.deploy.resources.cpu)
+    memory = _normalize_cloudrun_memory(config.deploy.resources.memory)
 
     # Environment variables for the container
     # Fix #120: env vars whose value starts with "secret://" are wired as
@@ -180,6 +234,21 @@ def _build_service_template(
     for key, value in config.deploy.env_vars.items():
         if not key.startswith("GCP_") and not key.startswith("GOOGLE_"):
             plain_env_vars[key] = value
+
+    # Expose the resolved MCP forwarding map to the agent so it can load the
+    # co-deployed servers' tools via agenthub.mcp.load_mcp_tools() (#533 —
+    # parity with aws_ecs.py).
+    if config.mcp_servers:
+        import json as _mcp_json
+
+        from engine.deployers.mcp_sidecar import (
+            build_sidecar_env_map,
+            resolve_mcp_servers,
+        )
+
+        mcp_map = build_sidecar_env_map(resolve_mcp_servers(config.mcp_servers))
+        if mcp_map:
+            plain_env_vars["AGENTBREEDER_MCP_SERVERS"] = _mcp_json.dumps(mcp_map)
 
     # Build the env list, resolving secret:// references into SecretKeyRef entries.
     env_list: list[dict[str, Any]] = []
@@ -326,6 +395,13 @@ def _build_cloudrun_sidecar_container(config: AgentConfig) -> dict[str, Any]:
         {"name": "AB_GUARDRAILS", "value": ",".join(sc.guardrails)},
         {"name": "AB_COST_TRACKING", "value": str(sc.cost_tracking).lower()},
     ]
+    # Auth: forward a configured token, else explicitly allow no-auth so the
+    # sidecar boots (it refuses to start without one of these). Parity with
+    # engine.sidecar.injector.inject_sidecar.
+    if sc.auth_token:
+        env.append({"name": "AGENT_AUTH_TOKEN", "value": sc.auth_token})
+    else:
+        env.append({"name": "AGENTBREEDER_SIDECAR_ALLOW_NO_AUTH", "value": "1"})
     otel = _os.getenv("OPENTELEMETRY_ENDPOINT") or sc.otel_endpoint
     if otel:
         env.append({"name": "OTEL_EXPORTER_OTLP_ENDPOINT", "value": otel})

--- a/engine/provisioners/gcp.py
+++ b/engine/provisioners/gcp.py
@@ -218,6 +218,28 @@ class GCPProvisioner(InfraProvisioner):
             "project": project,
         }
 
+        # ---- 2.5 Greenfield VPC network + subnet + Cloud NAT + PSA -------
+        # When GCP_PROVISION_VPC is set (the CLI `deploy --provision` path), build
+        # a dedicated custom-mode VPC so the agent + data tier share a private
+        # network — parity with the AWS greenfield VPC story (#505). The network
+        # name then drives the VPC connector + Cloud SQL private-IP steps below.
+        if _should_provision_vpc_network(fields):
+            network_name = str(fields.get("GCP_VPC_NAME") or f"{_truncate_network_id(agent_name)}")
+            subnet_name = str(fields.get("GCP_SUBNET_NAME") or f"{network_name}-subnet")
+            await _emit(
+                f"ensuring VPC network '{network_name}' + subnet '{subnet_name}' in {region}"
+            )
+            network_info = await self._ensure_vpc_network(
+                project=project,
+                region=region,
+                network_name=network_name,
+                subnet_name=subnet_name,
+                fields=fields,
+            )
+            resources["network"] = network_info
+            # Downstream steps (connector, Cloud SQL) target the new network.
+            fields["GCP_VPC_NAME"] = network_name
+
         # ---- 3. Serverless VPC Access Connector (optional, #436) -------
         if _should_provision_vpc_connector(fields):
             connector_id = _truncate_connector_id(agent_name)
@@ -313,6 +335,17 @@ class GCPProvisioner(InfraProvisioner):
                 except Exception:  # noqa: BLE001
                     logger.exception(
                         "destroy(gcp): failed to delete VPC connector %s", vpc.get("name")
+                    )
+
+        # Greenfield VPC (network + subnet + firewall + Cloud NAT + PSA). Deleted
+        # after the connector / Cloud SQL that depend on it.
+        if net := resources.get("network"):
+            if net.get("name"):
+                try:
+                    await self._delete_vpc_network(info=net, fields=fields)
+                except Exception:  # noqa: BLE001
+                    logger.exception(
+                        "destroy(gcp): failed to delete VPC network %s", net.get("name")
                     )
 
         if sa := resources.get("service_account"):
@@ -790,6 +823,250 @@ class GCPProvisioner(InfraProvisioner):
             except NotFound:
                 logger.debug("cloud sql secret %s already absent", secret_name)
 
+    async def _ensure_vpc_network(
+        self,
+        *,
+        project: str,
+        region: str,
+        network_name: str,
+        subnet_name: str,
+        fields: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Greenfield-create a custom-mode VPC + regional subnet, with Cloud NAT
+        for egress and a Private Service Access range for Cloud SQL private IP.
+
+        Idempotent throughout — every resource is get-before-create. Returns a
+        resource dict recorded in ``InfraState.resources["network"]`` and reversed
+        by :meth:`_delete_vpc_network` at teardown. Cloud NAT and PSA are gated by
+        ``GCP_PROVISION_NAT`` / ``GCP_PROVISION_PSA`` (both default-on).
+        """
+        import asyncio
+
+        from google.api_core.exceptions import NotFound
+        from google.cloud import compute_v1
+
+        creds = _credentials(fields)
+        subnet_cidr = str(fields.get("GCP_SUBNET_CIDR", "10.20.0.0/20"))
+        network_url = f"projects/{project}/global/networks/{network_name}"
+
+        def _ensure_network() -> None:
+            networks = compute_v1.NetworksClient(credentials=creds)
+            try:
+                networks.get(project=project, network=network_name)
+                return
+            except NotFound:
+                pass
+            net = compute_v1.Network(name=network_name, auto_create_subnetworks=False)
+            networks.insert(project=project, network_resource=net).result()
+
+        def _ensure_subnet() -> None:
+            subnets = compute_v1.SubnetworksClient(credentials=creds)
+            try:
+                subnets.get(project=project, region=region, subnetwork=subnet_name)
+                return
+            except NotFound:
+                pass
+            sn = compute_v1.Subnetwork(
+                name=subnet_name,
+                ip_cidr_range=subnet_cidr,
+                region=region,
+                network=network_url,
+                private_ip_google_access=True,
+            )
+            subnets.insert(project=project, region=region, subnetwork_resource=sn).result()
+
+        def _ensure_firewall() -> None:
+            # Allow internal traffic within the subnet (agent ↔ sidecar ↔ data).
+            fw_name = f"{network_name}-allow-internal"
+            firewalls = compute_v1.FirewallsClient(credentials=creds)
+            try:
+                firewalls.get(project=project, firewall=fw_name)
+                return
+            except NotFound:
+                pass
+            rule = compute_v1.Firewall(
+                name=fw_name,
+                network=network_url,
+                direction="INGRESS",
+                source_ranges=[subnet_cidr],
+                allowed=[
+                    compute_v1.Allowed(I_p_protocol="tcp"),
+                    compute_v1.Allowed(I_p_protocol="udp"),
+                    compute_v1.Allowed(I_p_protocol="icmp"),
+                ],
+            )
+            firewalls.insert(project=project, firewall_resource=rule).result()
+
+        await asyncio.to_thread(_ensure_network)
+        await asyncio.to_thread(_ensure_subnet)
+        await asyncio.to_thread(_ensure_firewall)
+
+        info: dict[str, Any] = {
+            "name": network_name,
+            "network_url": network_url,
+            "subnet": subnet_name,
+            "subnet_cidr": subnet_cidr,
+            "region": region,
+            "project": project,
+        }
+
+        # Cloud Router + NAT so scale-to-zero containers on private IPs can still
+        # pull images / reach external APIs (parity with the AWS NAT gateway).
+        if str(fields.get("GCP_PROVISION_NAT", "true")).lower() not in ("false", "0", ""):
+            router_name = f"{network_name}-router"
+            nat_name = f"{network_name}-nat"
+            await asyncio.to_thread(
+                self._ensure_cloud_nat,
+                project=project,
+                region=region,
+                network_url=network_url,
+                router_name=router_name,
+                nat_name=nat_name,
+                creds=creds,
+            )
+            info["router"] = router_name
+            info["nat"] = nat_name
+
+        # Private Service Access range + peering so Cloud SQL gets a private IP on
+        # this network (Cloud SQL private-IP requires a configured PSA range).
+        if str(fields.get("GCP_PROVISION_PSA", "true")).lower() not in ("false", "0", ""):
+            psa_range = str(fields.get("GCP_PSA_RANGE_NAME", f"{network_name}-psa"))
+            await asyncio.to_thread(
+                self._ensure_private_service_access,
+                project=project,
+                network_name=network_name,
+                range_name=psa_range,
+                creds=creds,
+                fields=fields,
+            )
+            info["psa_range"] = psa_range
+
+        return info
+
+    def _ensure_cloud_nat(
+        self,
+        *,
+        project: str,
+        region: str,
+        network_url: str,
+        router_name: str,
+        nat_name: str,
+        creds: Any,
+    ) -> None:
+        """Create a Cloud Router + Cloud NAT (auto IP, all subnet ranges)."""
+        from google.api_core.exceptions import NotFound
+        from google.cloud import compute_v1
+
+        routers = compute_v1.RoutersClient(credentials=creds)
+        try:
+            router = routers.get(project=project, region=region, router=router_name)
+        except NotFound:
+            router = compute_v1.Router(name=router_name, network=network_url)
+            routers.insert(project=project, region=region, router_resource=router).result()
+            router = routers.get(project=project, region=region, router=router_name)
+
+        if any(n.name == nat_name for n in router.nats):
+            return
+        nat = compute_v1.RouterNat(
+            name=nat_name,
+            nat_ip_allocate_option="AUTO_ONLY",
+            source_subnetwork_ip_ranges_to_nat="ALL_SUBNETWORKS_ALL_IP_RANGES",
+        )
+        router.nats.append(nat)
+        routers.patch(
+            project=project, region=region, router=router_name, router_resource=router
+        ).result()
+
+    def _ensure_private_service_access(
+        self,
+        *,
+        project: str,
+        network_name: str,
+        range_name: str,
+        creds: Any,
+        fields: dict[str, Any],
+    ) -> None:
+        """Allocate a PSA IP range + create the servicenetworking peering so
+        managed services (Cloud SQL) can be reached on a private IP."""
+        from google.api_core.exceptions import Conflict, NotFound
+        from google.cloud import compute_v1
+
+        addresses = compute_v1.GlobalAddressesClient(credentials=creds)
+        prefix_length = int(fields.get("GCP_PSA_PREFIX_LENGTH", 16))
+        try:
+            addresses.get(project=project, address=range_name)
+        except NotFound:
+            addr = compute_v1.Address(
+                name=range_name,
+                purpose="VPC_PEERING",
+                address_type="INTERNAL",
+                prefix_length=prefix_length,
+                network=f"projects/{project}/global/networks/{network_name}",
+            )
+            try:
+                addresses.insert(project=project, address_resource=addr).result()
+            except Conflict:
+                pass
+
+        # Peering connection via the Service Networking API (discovery client).
+        try:
+            from googleapiclient import discovery
+        except ImportError:
+            logger.warning(
+                "google-api-python-client not installed — skipping PSA peering for %s",
+                network_name,
+            )
+            return
+        svc = discovery.build("servicenetworking", "v1", credentials=creds, cache_discovery=False)
+        network_path = f"projects/{project}/global/networks/{network_name}"
+        body = {"network": network_path, "reservedPeeringRanges": [range_name]}
+        try:
+            svc.services().connections().create(
+                parent="services/servicenetworking.googleapis.com", body=body
+            ).execute()
+        except Exception as exc:  # noqa: BLE001 — peering may already exist
+            # A pre-existing connection returns 400 ALREADY_EXISTS; treat as done.
+            if "ALREADY_EXISTS" not in str(exc) and "already" not in str(exc).lower():
+                raise
+
+    async def _delete_vpc_network(self, *, info: dict[str, Any], fields: dict[str, Any]) -> None:
+        """Reverse :meth:`_ensure_vpc_network` in dependency order: NAT/router →
+        firewall → subnet → network (PSA peering range is left for the operator —
+        deleting it requires the peering be removed first and is rarely needed)."""
+        import asyncio
+
+        from google.api_core.exceptions import NotFound
+        from google.cloud import compute_v1
+
+        creds = _credentials(fields)
+        project = str(info.get("project") or fields.get("GOOGLE_CLOUD_PROJECT", ""))
+        region = str(info.get("region", ""))
+        network_name = str(info["name"])
+
+        def _delete() -> None:
+            if info.get("router"):
+                routers = compute_v1.RoutersClient(credentials=creds)
+                with contextlib.suppress(NotFound):
+                    routers.delete(
+                        project=project, region=region, router=str(info["router"])
+                    ).result()
+            firewalls = compute_v1.FirewallsClient(credentials=creds)
+            with contextlib.suppress(NotFound):
+                firewalls.delete(
+                    project=project, firewall=f"{network_name}-allow-internal"
+                ).result()
+            if info.get("subnet"):
+                subnets = compute_v1.SubnetworksClient(credentials=creds)
+                with contextlib.suppress(NotFound):
+                    subnets.delete(
+                        project=project, region=region, subnetwork=str(info["subnet"])
+                    ).result()
+            networks = compute_v1.NetworksClient(credentials=creds)
+            with contextlib.suppress(NotFound):
+                networks.delete(project=project, network=network_name).result()
+
+        await asyncio.to_thread(_delete)
+
     async def _ensure_vpc_connector(
         self,
         *,
@@ -901,6 +1178,12 @@ class GCPProvisioner(InfraProvisioner):
             crm.projects().setIamPolicy(resource=project, body={"policy": policy}).execute()
 
 
+def _should_provision_vpc_network(fields: dict[str, Any]) -> bool:
+    """Trigger predicate for greenfield VPC creation (CLI ``deploy --provision``)."""
+    flag = fields.get("GCP_PROVISION_VPC")
+    return flag in (True, 1, "1", "true", "True", "yes")
+
+
 def _should_provision_vpc_connector(fields: dict[str, Any]) -> bool:
     """Trigger predicate: explicit opt-in, or implicit when Cloud SQL needs private IP.
 
@@ -927,6 +1210,17 @@ def _truncate_connector_id(agent_name: str) -> str:
     if len(safe) < 2:
         safe = (safe + "-c")[:25]
     return safe[:25]
+
+
+def _truncate_network_id(agent_name: str) -> str:
+    """VPC network names: lowercase letters/digits/hyphens, start with a letter,
+    1-63 chars. Mirrors the per-agent identity of the SA + connector."""
+    raw = f"ab-{agent_name[:55]}-vpc".lower()
+    safe = "".join(ch if ch.isalnum() or ch == "-" else "-" for ch in raw)
+    safe = safe.strip("-")
+    if not safe or not safe[0].isalpha():
+        safe = f"ab-{safe}".strip("-")
+    return safe[:63]
 
 
 def _await_operation(op: Any, timeout: float = 1800.0) -> Any:

--- a/engine/provisioners/gcp.py
+++ b/engine/provisioners/gcp.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
+import time
 from typing import TYPE_CHECKING, Any
 
 from engine.provisioners.base import (
@@ -19,6 +21,13 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     from engine.provisioners.state import InfraState
 
 logger = logging.getLogger(__name__)
+
+# A freshly-created service account is eventually consistent: GCP may take
+# several seconds (occasionally up to ~a minute) before it can be read back or
+# referenced as a member in a project setIamPolicy call. Bound the waits so a
+# genuinely failing provision still surfaces instead of hanging.
+_SA_PROPAGATION_TIMEOUT = 120.0  # seconds
+_IAM_BINDING_TIMEOUT = 120.0  # seconds
 
 
 def _select_private_ip(ip_addresses: Any) -> str | None:
@@ -538,6 +547,32 @@ class GCPProvisioner(InfraProvisioner):
             )
         except AlreadyExists:
             logger.debug("service account %s created concurrently", sa_email)
+
+        # Wait for the new SA to propagate before any caller binds IAM roles to
+        # it — GCP IAM is eventually consistent and a too-early setIamPolicy
+        # fails with "Service account ... does not exist".
+        await self._await_sa_propagation(client=client, sa_resource=sa_resource)
+
+    async def _await_sa_propagation(self, *, client: Any, sa_resource: str) -> None:
+        """Block until a just-created service account is readable, or time out."""
+        from google.api_core.exceptions import NotFound
+
+        deadline = time.monotonic() + _SA_PROPAGATION_TIMEOUT
+        interval = 2.0
+        while True:
+            try:
+                client.get_service_account(name=sa_resource)
+                return
+            except NotFound:
+                if time.monotonic() >= deadline:
+                    logger.warning(
+                        "service account %s not readable after %.0fs; proceeding",
+                        sa_resource,
+                        _SA_PROPAGATION_TIMEOUT,
+                    )
+                    return
+                await asyncio.sleep(min(interval, max(0.0, deadline - time.monotonic())))
+                interval = min(interval * 1.5, 15.0)
 
     async def _delete_service_account(
         self, *, project: str, sa_email: str, fields: dict[str, Any]
@@ -1147,9 +1182,16 @@ class GCPProvisioner(InfraProvisioner):
         roles: list[str],
         fields: dict[str, Any],
     ) -> None:
-        """Idempotently bind each role to the SA on the project IAM policy."""
+        """Idempotently bind each role to the SA on the project IAM policy.
+
+        Retries the read-modify-write with backoff: a freshly-created SA is
+        rejected by setIamPolicy ("does not exist") until it propagates, and a
+        concurrent policy change yields a 409 etag conflict. Both recover by
+        re-fetching the policy and re-applying, so we re-read inside the loop.
+        """
         try:
             from googleapiclient import discovery
+            from googleapiclient.errors import HttpError
         except ImportError:
             logger.warning(
                 "google-api-python-client not installed — skipping IAM binding for %s",
@@ -1158,24 +1200,47 @@ class GCPProvisioner(InfraProvisioner):
             return
 
         crm = discovery.build("cloudresourcemanager", "v1", cache_discovery=False)
-        policy = (
-            crm.projects()
-            .getIamPolicy(resource=project, body={"options": {"requestedPolicyVersion": 1}})
-            .execute()
-        )
         member = f"serviceAccount:{sa_email}"
-        mutated = False
-        for role in roles:
-            binding = next((b for b in policy.get("bindings", []) if b["role"] == role), None)
-            if binding:
-                if member not in binding["members"]:
-                    binding["members"].append(member)
+
+        def _apply_once() -> None:
+            policy = (
+                crm.projects()
+                .getIamPolicy(resource=project, body={"options": {"requestedPolicyVersion": 1}})
+                .execute()
+            )
+            mutated = False
+            for role in roles:
+                binding = next((b for b in policy.get("bindings", []) if b["role"] == role), None)
+                if binding:
+                    if member not in binding["members"]:
+                        binding["members"].append(member)
+                        mutated = True
+                else:
+                    policy.setdefault("bindings", []).append({"role": role, "members": [member]})
                     mutated = True
-            else:
-                policy.setdefault("bindings", []).append({"role": role, "members": [member]})
-                mutated = True
-        if mutated:
-            crm.projects().setIamPolicy(resource=project, body={"policy": policy}).execute()
+            if mutated:
+                crm.projects().setIamPolicy(resource=project, body={"policy": policy}).execute()
+
+        deadline = time.monotonic() + _IAM_BINDING_TIMEOUT
+        interval = 2.0
+        while True:
+            try:
+                _apply_once()
+                return
+            except HttpError as e:
+                status = getattr(getattr(e, "resp", None), "status", None)
+                msg = str(e)
+                transient = status == 409 or (status == 400 and "does not exist" in msg)
+                if not transient or time.monotonic() >= deadline:
+                    raise
+                logger.info(
+                    "IAM binding for %s not ready (HTTP %s); retrying in %.0fs",
+                    sa_email,
+                    status,
+                    interval,
+                )
+                await asyncio.sleep(min(interval, max(0.0, deadline - time.monotonic())))
+                interval = min(interval * 1.5, 15.0)
 
 
 def _should_provision_vpc_network(fields: dict[str, Any]) -> bool:

--- a/engine/runtimes/base.py
+++ b/engine/runtimes/base.py
@@ -79,6 +79,33 @@ def runtime_support_requirement() -> str | None:
         return "agentbreeder"
 
 
+def inject_wheel_copies(template: str, build_dir: Path) -> str:
+    """Insert ``COPY <wheel> ./`` lines into a Dockerfile template for any
+    ``*.whl`` bundled in ``build_dir``.
+
+    When the runtime is bundled as a local wheel (deploying from an unpublished
+    dev checkout via ``AGENTBREEDER_RUNTIME_REQUIREMENT=./*.whl``), the wheel
+    must be ``COPY``ed into the image *before* ``pip install -r requirements.txt``
+    runs — the cache-friendly "COPY requirements.txt first" ordering would
+    otherwise leave the path requirement unresolvable and fail the build with a
+    non-zero pip exit. The wheel COPYs are inserted right after the first
+    ``COPY requirements.txt .`` so layer caching of dependencies is preserved.
+
+    No-op for the common case of published dependencies (no wheels in the
+    context). Shared across every pip-based Python runtime so dev-checkout
+    deploys behave identically regardless of framework.
+    """
+    wheels = sorted(p.name for p in build_dir.glob("*.whl"))
+    if not wheels:
+        return template
+    copy_wheels = "".join(f"COPY {w} ./\n" for w in wheels)
+    return template.replace(
+        "COPY requirements.txt .\n",
+        "COPY requirements.txt .\n" + copy_wheels,
+        1,
+    )
+
+
 def _should_add_litellm_sdk(config: AgentConfig) -> bool:
     """Return True only when the LiteLLM Python SDK should be injected.
 

--- a/engine/runtimes/claude_sdk.py
+++ b/engine/runtimes/claude_sdk.py
@@ -19,6 +19,7 @@ from engine.runtimes.base import (
     RuntimeValidationResult,
     _is_litellm_model,
     build_env_block,
+    inject_wheel_copies,
     runtime_support_requirement,
 )
 
@@ -48,9 +49,12 @@ USER agent
 EXPOSE 8080
 
 HEALTHCHECK --interval=10s --timeout=5s --retries=3 \\
-    CMD python -c "import httpx; httpx.get('http://localhost:8080/health').raise_for_status()"
+    CMD python -c "import os,httpx; httpx.get('http://localhost:'+os.environ.get('PORT','8080')+'/health').raise_for_status()"
 
-CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8080"]
+# Honor $PORT: when the observability sidecar is injected the deployer sets
+# PORT=8081 so the agent listens on an internal port and the sidecar owns 8080.
+# Braces are doubled because this template is rendered with str.format().
+CMD ["sh", "-c", "uvicorn server:app --host 0.0.0.0 --port ${{PORT:-8080}}"]
 """
 
 
@@ -237,7 +241,8 @@ class ClaudeSDKRuntime(RuntimeBuilder):
 
             # Write Dockerfile
             env_block = self._build_env_block(config)
-            dockerfile_content = DOCKERFILE_TEMPLATE.format(env_block=env_block)
+            template = inject_wheel_copies(DOCKERFILE_TEMPLATE, build_dir)
+            dockerfile_content = template.format(env_block=env_block)
             dockerfile = build_dir / "Dockerfile"
             dockerfile.write_text(dockerfile_content)
 

--- a/engine/runtimes/crewai.py
+++ b/engine/runtimes/crewai.py
@@ -18,6 +18,7 @@ from engine.runtimes.base import (
     _get_litellm_requirements,
     _should_add_litellm_sdk,
     build_env_block,
+    inject_wheel_copies,
     runtime_support_requirement,
 )
 
@@ -42,9 +43,11 @@ USER agent
 EXPOSE 8080
 
 HEALTHCHECK --interval=10s --timeout=5s --retries=3 \
-    CMD python -c "import httpx; httpx.get('http://localhost:8080/health').raise_for_status()"
+    CMD python -c "import os,httpx; httpx.get('http://localhost:'+os.environ.get('PORT','8080')+'/health').raise_for_status()"
 
-CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8080"]
+# Honor $PORT: when the observability sidecar is injected the deployer sets
+# PORT=8081 so the agent listens on an internal port and the sidecar owns 8080.
+CMD ["sh", "-c", "uvicorn server:app --host 0.0.0.0 --port ${PORT:-8080}"]
 """
 
 
@@ -142,7 +145,7 @@ class CrewAIRuntime(RuntimeBuilder):
 
             crewai_env_block = ("\n" + "\n".join(crewai_env_lines)) if crewai_env_lines else ""
             dockerfile_content = (
-                DOCKERFILE_TEMPLATE.rstrip()
+                inject_wheel_copies(DOCKERFILE_TEMPLATE, build_dir).rstrip()
                 + "\n\n# Agent configuration\n"
                 + env_block
                 + crewai_env_block

--- a/engine/runtimes/custom.py
+++ b/engine/runtimes/custom.py
@@ -20,6 +20,7 @@ from engine.runtimes.base import (
     _get_litellm_requirements,
     _is_litellm_model,
     build_env_block,
+    inject_wheel_copies,
 )
 
 CUSTOM_SERVER_TEMPLATE = Path(__file__).parent / "templates" / "custom_server.py"
@@ -43,9 +44,11 @@ USER agent
 EXPOSE 8080
 
 HEALTHCHECK --interval=10s --timeout=5s --retries=3 \
-    CMD python -c "import httpx; httpx.get('http://localhost:8080/health').raise_for_status()"
+    CMD python -c "import os,httpx; httpx.get('http://localhost:'+os.environ.get('PORT','8080')+'/health').raise_for_status()"
 
-CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8080"]
+# Honor $PORT: when the observability sidecar is injected the deployer sets
+# PORT=8081 so the agent listens on an internal port and the sidecar owns 8080.
+CMD ["sh", "-c", "uvicorn server:app --host 0.0.0.0 --port ${PORT:-8080}"]
 """
 
 
@@ -157,7 +160,7 @@ class CustomRuntime(RuntimeBuilder):
                 if config.model.primary.startswith("ollama/"):
                     ollama_extra = '\nENV OLLAMA_BASE_URL="http://agentbreeder-ollama:11434"'
                 dockerfile_content = (
-                    FALLBACK_DOCKERFILE.rstrip()
+                    inject_wheel_copies(FALLBACK_DOCKERFILE, build_dir).rstrip()
                     + "\n\n# Agent configuration\n"
                     + env_block
                     + ollama_extra

--- a/engine/runtimes/google_adk.py
+++ b/engine/runtimes/google_adk.py
@@ -23,6 +23,7 @@ from engine.runtimes.base import (
     _get_litellm_requirements,
     _should_add_litellm_sdk,
     build_env_block,
+    inject_wheel_copies,
     runtime_support_requirement,
 )
 
@@ -110,9 +111,12 @@ USER agent
 EXPOSE 8080
 
 HEALTHCHECK --interval=10s --timeout=5s --retries=3 \\
-    CMD python -c "import httpx; httpx.get('http://localhost:8080/health').raise_for_status()"
+    CMD python -c "import os,httpx; httpx.get('http://localhost:'+os.environ.get('PORT','8080')+'/health').raise_for_status()"
 
-CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8080"]
+# Honor $PORT: when the observability sidecar is injected the deployer sets
+# PORT=8081 so the agent listens on an internal port and the sidecar owns 8080.
+# Braces are doubled because this template is rendered with str.format().
+CMD ["sh", "-c", "uvicorn server:app --host 0.0.0.0 --port ${{PORT:-8080}}"]
 """
 
 
@@ -224,7 +228,7 @@ class GoogleADKRuntime(RuntimeBuilder):
             # Build Dockerfile
             env_block = build_env_block(config, "google_adk")
             adk_env_block = _build_adk_env_block(config)
-            dockerfile_content = DOCKERFILE_TEMPLATE.format(
+            dockerfile_content = inject_wheel_copies(DOCKERFILE_TEMPLATE, build_dir).format(
                 env_block=env_block,
                 adk_env_block=adk_env_block,
             )

--- a/engine/runtimes/langgraph.py
+++ b/engine/runtimes/langgraph.py
@@ -18,6 +18,7 @@ from engine.runtimes.base import (
     _get_litellm_requirements,
     _should_add_litellm_sdk,
     build_env_block,
+    inject_wheel_copies,
     runtime_support_requirement,
 )
 
@@ -127,21 +128,7 @@ class LangGraphRuntime(RuntimeBuilder):
             ollama_extra = ""
             if config.model.primary.startswith("ollama/"):
                 ollama_extra = '\nENV OLLAMA_BASE_URL="http://agentbreeder-ollama:11434"'
-            template = DOCKERFILE_TEMPLATE
-            # When the runtime is bundled as a local wheel (e.g. deploying from an
-            # unpublished dev checkout via AGENTBREEDER_RUNTIME_REQUIREMENT=./*.whl),
-            # the wheel must be COPYied into the image BEFORE `pip install -r`, which
-            # the cache-friendly "COPY requirements.txt first" ordering skips. Copy
-            # any bundled wheels just before the install so the path requirement
-            # resolves; no-op for the common (published-dependency) case.
-            wheels = sorted(p.name for p in build_dir.glob("*.whl"))
-            if wheels:
-                copy_wheels = "".join(f"COPY {w} ./\n" for w in wheels)
-                template = template.replace(
-                    "COPY requirements.txt .\n",
-                    "COPY requirements.txt .\n" + copy_wheels,
-                    1,
-                )
+            template = inject_wheel_copies(DOCKERFILE_TEMPLATE, build_dir)
             dockerfile_content = (
                 template.rstrip() + "\n\n# Agent configuration\n" + env_block + ollama_extra + "\n"
             )

--- a/engine/runtimes/openai_agents.py
+++ b/engine/runtimes/openai_agents.py
@@ -18,6 +18,7 @@ from engine.runtimes.base import (
     _get_litellm_requirements,
     _should_add_litellm_sdk,
     build_env_block,
+    inject_wheel_copies,
     runtime_support_requirement,
 )
 
@@ -42,9 +43,11 @@ USER agent
 EXPOSE 8080
 
 HEALTHCHECK --interval=10s --timeout=5s --retries=3 \
-    CMD python -c "import httpx; httpx.get('http://localhost:8080/health').raise_for_status()"
+    CMD python -c "import os,httpx; httpx.get('http://localhost:'+os.environ.get('PORT','8080')+'/health').raise_for_status()"
 
-CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8080"]
+# Honor $PORT: when the observability sidecar is injected the deployer sets
+# PORT=8081 so the agent listens on an internal port and the sidecar owns 8080.
+CMD ["sh", "-c", "uvicorn server:app --host 0.0.0.0 --port ${PORT:-8080}"]
 """
 
 
@@ -127,7 +130,7 @@ class OpenAIAgentsRuntime(RuntimeBuilder):
             if config.model.primary.startswith("ollama/"):
                 ollama_extra = '\nENV OLLAMA_BASE_URL="http://agentbreeder-ollama:11434"'
             dockerfile_content = (
-                DOCKERFILE_TEMPLATE.rstrip()
+                inject_wheel_copies(DOCKERFILE_TEMPLATE, build_dir).rstrip()
                 + "\n\n# Agent configuration\n"
                 + env_block
                 + ollama_extra

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ gcp = [
     "google-cloud-iam>=2.15.0",
     "google-cloud-redis>=2.15.0",
     "google-cloud-resource-manager>=1.12.0",
+    "google-cloud-run>=0.10.0",
     "google-cloud-secret-manager>=2.20.0",
     "google-cloud-sql>=1.6.0",
     "google-cloud-vpc-access>=1.10.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ all-clouds = [
     "google-cloud-iam>=2.15.0",
     "google-cloud-redis>=2.15.0",
     "google-cloud-resource-manager>=1.12.0",
+    "google-cloud-run>=0.10.0",
     "google-cloud-secret-manager>=2.20.0",
     "google-cloud-sql>=1.6.0",
     "google-cloud-vpc-access>=1.10.0",

--- a/tests/unit/test_builder_greenfield.py
+++ b/tests/unit/test_builder_greenfield.py
@@ -3,7 +3,8 @@
 Covers ``DeployEngine._maybe_provision_greenfield``: when ``--provision`` is set
 and no BYO infra is supplied, it provisions the cloud footprint, maps the
 returned ``InfraState`` into ``deploy.env_vars`` (so the existing deploy path
-serves the agent into it), and records the footprint for teardown. AWS only.
+serves the agent into it), and records the footprint for teardown. Covers all
+managed clouds (AWS, GCP, Azure) — multi-cloud parity (#505/#537).
 """
 
 from __future__ import annotations
@@ -101,10 +102,88 @@ async def test_skips_when_byo_infra_present(tmp_path: Path) -> None:
     assert cfg.deploy.env_vars["AWS_ECS_CLUSTER"] == "mine"
 
 
+def _gcp_greenfield_state() -> InfraState:
+    return InfraState(
+        cloud="gcp",
+        region="us-central1",
+        provisioned_by="agentbreeder.GCPProvisioner",
+        provisioned_at=datetime.now(UTC),
+        mode="provisioned",
+        resources={
+            "artifact_registry": {"repo": "agentbreeder", "region": "us-central1"},
+            "service_account": {
+                "email": "ab-demo@p.iam.gserviceaccount.com",
+                "project": "p",
+            },
+        },
+    )
+
+
+def _azure_greenfield_state() -> InfraState:
+    return InfraState(
+        cloud="azure",
+        region="eastus",
+        provisioned_by="agentbreeder.AzureProvisioner",
+        provisioned_at=datetime.now(UTC),
+        mode="provisioned",
+        resources={
+            "resource_group": {
+                "id": "/subscriptions/sub-1/resourceGroups/ab-demo-rg",
+                "name": "ab-demo-rg",
+            },
+            "container_apps_environment": {"name": "ab-demo-env"},
+            "acr": {"login_server": "abdemo.azurecr.io"},
+        },
+    )
+
+
 @pytest.mark.asyncio
-async def test_rejects_non_aws_cloud(tmp_path: Path) -> None:
-    cfg = _cfg(cloud=CloudType.gcp)
-    with pytest.raises(DeployError, match="AWS"):
+async def test_greenfield_provisions_gcp(tmp_path: Path) -> None:
+    cfg = _cfg(cloud=CloudType.gcp, env_vars={"GCP_PROJECT_ID": "p"})
+    fake = _fake_provisioner(_gcp_greenfield_state())
+    with patch("engine.builder.provisioner_for", return_value=fake):
+        await DeployEngine()._maybe_provision_greenfield(cfg, tmp_path, provision=True)
+
+    fake.provision.assert_awaited_once()
+    # The provisioner received the required GOOGLE_CLOUD_PROJECT field.
+    payload = fake.provision.await_args.args[0]
+    assert payload.cloud == "gcp"
+    assert payload.fields["GOOGLE_CLOUD_PROJECT"] == "p"
+    env = cfg.deploy.env_vars
+    assert env["GCP_SERVICE_ACCOUNT"] == "ab-demo@p.iam.gserviceaccount.com"
+    assert env["GCP_ARTIFACT_REGISTRY_REPO"] == "agentbreeder"
+    assert (tmp_path / ".agentbreeder" / "infra-state.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_greenfield_provisions_azure(tmp_path: Path) -> None:
+    cfg = _cfg(cloud=CloudType.azure, env_vars={"AZURE_SUBSCRIPTION_ID": "sub-1"})
+    fake = _fake_provisioner(_azure_greenfield_state())
+    with patch("engine.builder.provisioner_for", return_value=fake):
+        await DeployEngine()._maybe_provision_greenfield(cfg, tmp_path, provision=True)
+
+    fake.provision.assert_awaited_once()
+    env = cfg.deploy.env_vars
+    assert env["AZURE_RESOURCE_GROUP"] == "ab-demo-rg"
+    assert env["AZURE_CONTAINER_APPS_ENV"] == "ab-demo-env"
+    assert env["AZURE_REGISTRY_SERVER"] == "abdemo.azurecr.io"
+
+
+@pytest.mark.asyncio
+async def test_skips_when_byo_infra_present_gcp(tmp_path: Path) -> None:
+    cfg = _cfg(
+        cloud=CloudType.gcp,
+        env_vars={"GCP_ARTIFACT_REGISTRY_REPO": "mine", "GCP_SERVICE_ACCOUNT": "me@p"},
+    )
+    with patch("engine.builder.provisioner_for") as pf:
+        await DeployEngine()._maybe_provision_greenfield(cfg, tmp_path, provision=True)
+    pf.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rejects_unsupported_cloud(tmp_path: Path) -> None:
+    cfg = _cfg(cloud=CloudType.kubernetes)
+    with pytest.raises(DeployError, match="does not support"):
         await DeployEngine()._maybe_provision_greenfield(cfg, tmp_path, provision=True)
 
 

--- a/tests/unit/test_deployers_azure.py
+++ b/tests/unit/test_deployers_azure.py
@@ -501,7 +501,9 @@ class TestDeploy:
         mock_docker_client.images.push.return_value = iter([{"status": "Pushed"}])
 
         mock_docker = MagicMock()
+        # docker_client() may return docker.from_env() or docker.DockerClient(...)
         mock_docker.from_env.return_value = mock_docker_client
+        mock_docker.DockerClient.return_value = mock_docker_client
 
         with patch.dict(sys.modules, {"docker": mock_docker}):
             await deployer._push_image(image, "myregistry.azurecr.io/my-agent:1.0.0")

--- a/tests/unit/test_gcp_azure_deploy_parity.py
+++ b/tests/unit/test_gcp_azure_deploy_parity.py
@@ -1,0 +1,278 @@
+"""GCP + Azure deployer parity with AWS ECS (epic #505, #533).
+
+These tests lock the deployer-level capabilities that AWS ECS gained during its
+end-to-end hardening (#532) onto GCP Cloud Run and Azure Container Apps:
+
+- agent-facing ``AGENTBREEDER_MCP_SERVERS`` env so ``agenthub.mcp.load_mcp_tools``
+  can discover co-deployed MCP servers (#533),
+- sidecar boot-auth env so the sidecar starts (GCP),
+- CPU/memory normalization so the documented ``agent.yaml`` resource notation
+  (vCPU + Gi/Mi/G/M/raw) renders into each platform's accepted form.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from engine.config_parser import (
+    AccessConfig,
+    AgentConfig,
+    CloudType,
+    DeployConfig,
+    FrameworkType,
+    McpServerRef,
+    ModelConfig,
+    ResourceConfig,
+    ScalingConfig,
+)
+
+SIDECAR = "agentbreeder-sidecar"
+
+
+def _config(
+    *,
+    cloud: CloudType,
+    runtime: str,
+    env_vars: dict[str, str],
+    cpu: str = "1",
+    memory: str = "1Gi",
+    guardrails: bool = False,
+    mcp: bool = False,
+) -> AgentConfig:
+    config = AgentConfig(
+        name="my-agent",
+        version="1.0.0",
+        team="engineering",
+        owner="dev@example.com",
+        framework=FrameworkType.langgraph,
+        model=ModelConfig(primary="claude-sonnet-4"),
+        deploy=DeployConfig(
+            cloud=cloud,
+            runtime=runtime,
+            region=env_vars.get("AZURE_LOCATION", "us-central1"),
+            env_vars=env_vars,
+            resources=ResourceConfig(cpu=cpu, memory=memory),
+            scaling=ScalingConfig(min=1, max=3),
+        ),
+        access=AccessConfig(),
+    )
+    if guardrails:
+        config.guardrails = ["pii_detection"]
+    if mcp:
+        config.mcp_servers = [
+            McpServerRef(
+                ref="mcp/example-tools",
+                transport="streamable_http",
+                url="http://remote/mcp",
+            )
+        ]
+    return config
+
+
+# --------------------------------------------------------------------------- #
+# GCP Cloud Run
+# --------------------------------------------------------------------------- #
+
+
+def _gcp_template(config: AgentConfig):
+    from engine.deployers.gcp_cloudrun import (
+        _build_service_template,
+        _extract_cloudrun_config,
+    )
+
+    gcp = _extract_cloudrun_config(config)
+    return _build_service_template(config, gcp, "img:1.0.0")
+
+
+def _agent_env(template) -> dict[str, str]:
+    containers = template["containers"]
+    agent = next(c for c in containers if c.get("name") != SIDECAR)
+    return {e["name"]: e.get("value") for e in agent["env"] if "value" in e}
+
+
+class TestGcpMcpEnvInjection:
+    def test_agent_env_carries_mcp_servers_map(self) -> None:
+        config = _config(
+            cloud=CloudType.gcp,
+            runtime="cloud-run",
+            env_vars={"GCP_PROJECT_ID": "my-project-123"},
+            mcp=True,
+        )
+        env = _agent_env(_gcp_template(config))
+        assert "AGENTBREEDER_MCP_SERVERS" in env
+        parsed = json.loads(env["AGENTBREEDER_MCP_SERVERS"])
+        assert "example-tools" in parsed
+        assert parsed["example-tools"]["url"] == "http://remote/mcp"
+
+    def test_no_mcp_env_when_no_servers(self) -> None:
+        config = _config(
+            cloud=CloudType.gcp,
+            runtime="cloud-run",
+            env_vars={"GCP_PROJECT_ID": "my-project-123"},
+        )
+        env = _agent_env(_gcp_template(config))
+        assert "AGENTBREEDER_MCP_SERVERS" not in env
+
+
+class TestGcpSidecarAuth:
+    def test_allow_no_auth_when_no_token(self) -> None:
+        from engine.deployers.gcp_cloudrun import _build_cloudrun_sidecar_container
+
+        config = _config(
+            cloud=CloudType.gcp,
+            runtime="cloud-run",
+            env_vars={"GCP_PROJECT_ID": "p"},
+            guardrails=True,
+        )
+        env = {e["name"]: e.get("value") for e in _build_cloudrun_sidecar_container(config)["env"]}
+        assert env.get("AGENTBREEDER_SIDECAR_ALLOW_NO_AUTH") == "1"
+        assert "AGENT_AUTH_TOKEN" not in env
+
+    def test_forwards_configured_auth_token(self) -> None:
+        from engine.deployers.gcp_cloudrun import _build_cloudrun_sidecar_container
+
+        config = _config(
+            cloud=CloudType.gcp,
+            runtime="cloud-run",
+            env_vars={"GCP_PROJECT_ID": "p", "AGENT_AUTH_TOKEN": "s3cr3t"},
+            guardrails=True,
+        )
+        env = {e["name"]: e.get("value") for e in _build_cloudrun_sidecar_container(config)["env"]}
+        assert env.get("AGENT_AUTH_TOKEN") == "s3cr3t"
+        assert "AGENTBREEDER_SIDECAR_ALLOW_NO_AUTH" not in env
+
+
+class TestGcpResourceNormalization:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("1", "1"),
+            ("2", "2"),
+            ("0.5", "1000m"),  # clamped to Cloud Run minimum for concurrency
+            ("500m", "1000m"),
+            ("2000m", "2"),
+            ("1024", "1"),  # AWS-style units → vCPU
+        ],
+    )
+    def test_cpu_normalizer(self, raw: str, expected: str) -> None:
+        from engine.deployers.gcp_cloudrun import _normalize_cloudrun_cpu
+
+        assert _normalize_cloudrun_cpu(raw) == expected
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("1Gi", "1Gi"),
+            ("2Gi", "2Gi"),
+            ("2G", "2Gi"),
+            ("512Mi", "512Mi"),
+            ("512M", "512Mi"),
+            ("1024", "1024Mi"),
+        ],
+    )
+    def test_memory_normalizer(self, raw: str, expected: str) -> None:
+        from engine.deployers.gcp_cloudrun import _normalize_cloudrun_memory
+
+        assert _normalize_cloudrun_memory(raw) == expected
+
+    def test_template_applies_normalized_resources(self) -> None:
+        config = _config(
+            cloud=CloudType.gcp,
+            runtime="cloud-run",
+            env_vars={"GCP_PROJECT_ID": "p"},
+            cpu="2",
+            memory="2G",
+        )
+        limits = _gcp_template(config)["containers"][0]["resources"]["limits"]
+        assert limits["cpu"] == "2"
+        assert limits["memory"] == "2Gi"
+
+
+# --------------------------------------------------------------------------- #
+# Azure Container Apps
+# --------------------------------------------------------------------------- #
+
+
+def _azure_body(config: AgentConfig):
+    from engine.deployers.azure_container_apps import (
+        AzureContainerAppsDeployer,
+        _extract_azure_config,
+    )
+
+    azure = _extract_azure_config(config)
+    return AzureContainerAppsDeployer()._build_container_app_body(
+        config, azure, "img:1.0.0", "env-id"
+    )
+
+
+def _azure_env_vars(body: dict) -> dict[str, str]:
+    containers = body["properties"]["template"]["containers"]
+    agent = next(c for c in containers if c.get("name") != SIDECAR)
+    return {e["name"]: e.get("value") for e in agent["env"] if "value" in e}
+
+
+_AZURE_ENV = {
+    "AZURE_SUBSCRIPTION_ID": "sub-1234",
+    "AZURE_RESOURCE_GROUP": "rg-agents",
+    "AZURE_CONTAINER_APPS_ENV": "aca-env-prod",
+    "AZURE_REGISTRY_SERVER": "myregistry.azurecr.io",
+    "AZURE_LOCATION": "eastus",
+}
+
+
+class TestAzureMcpEnvInjection:
+    def test_agent_env_carries_mcp_servers_map(self) -> None:
+        config = _config(
+            cloud=CloudType.azure,
+            runtime="container-apps",
+            env_vars=_AZURE_ENV,
+            mcp=True,
+        )
+        env = _azure_env_vars(_azure_body(config))
+        assert "AGENTBREEDER_MCP_SERVERS" in env
+        parsed = json.loads(env["AGENTBREEDER_MCP_SERVERS"])
+        assert parsed["example-tools"]["url"] == "http://remote/mcp"
+
+    def test_no_mcp_env_when_no_servers(self) -> None:
+        config = _config(
+            cloud=CloudType.azure,
+            runtime="container-apps",
+            env_vars=_AZURE_ENV,
+        )
+        env = _azure_env_vars(_azure_body(config))
+        assert "AGENTBREEDER_MCP_SERVERS" not in env
+
+
+class TestAzureResourceNormalization:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [("1", 1.0), ("0.5", 0.5), ("500m", 0.5), ("2", 2.0)],
+    )
+    def test_cpu_normalizer(self, raw: str, expected: float) -> None:
+        from engine.deployers.azure_container_apps import _normalize_aca_cpu
+
+        assert _normalize_aca_cpu(raw) == pytest.approx(expected)
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [("1Gi", "1Gi"), ("2G", "2Gi"), ("512Mi", "0.5Gi"), ("2048", "2Gi")],
+    )
+    def test_memory_normalizer(self, raw: str, expected: str) -> None:
+        from engine.deployers.azure_container_apps import _normalize_aca_memory
+
+        assert _normalize_aca_memory(raw) == expected
+
+    def test_body_applies_normalized_resources(self) -> None:
+        config = _config(
+            cloud=CloudType.azure,
+            runtime="container-apps",
+            env_vars=_AZURE_ENV,
+            cpu="500m",
+            memory="2G",
+        )
+        containers = _azure_body(config)["properties"]["template"]["containers"]
+        agent = next(c for c in containers if c.get("name") != SIDECAR)
+        assert float(agent["resources"]["cpu"]) == pytest.approx(0.5)
+        assert agent["resources"]["memory"] == "2Gi"

--- a/tests/unit/test_gcp_cloudrun_deployer.py
+++ b/tests/unit/test_gcp_cloudrun_deployer.py
@@ -756,7 +756,9 @@ class TestPushImage:
         mock_client.images.push.return_value = [{"status": "Pushed"}]
 
         mock_docker = MagicMock()
+        # docker_client() may return docker.from_env() or docker.DockerClient(...)
         mock_docker.from_env.return_value = mock_client
+        mock_docker.DockerClient.return_value = mock_client
 
         with patch.dict("sys.modules", {"docker": mock_docker}):
             await deployer._push_image(image, image_uri)
@@ -777,7 +779,9 @@ class TestPushImage:
         mock_client.images.push.return_value = [{"error": "access denied"}]
 
         mock_docker = MagicMock()
+        # docker_client() may return docker.from_env() or docker.DockerClient(...)
         mock_docker.from_env.return_value = mock_client
+        mock_docker.DockerClient.return_value = mock_client
 
         with (
             patch.dict("sys.modules", {"docker": mock_docker}),

--- a/tests/unit/test_gcp_cloudrun_deployer.py
+++ b/tests/unit/test_gcp_cloudrun_deployer.py
@@ -410,6 +410,22 @@ class TestSidecarIngressRouting:
         assert env["AGENTBREEDER_SIDECAR_AGENT_URL"] == "http://localhost:8081"
         assert env["AGENTBREEDER_SIDECAR_INBOUND_ADDR"] == ":8080"
 
+    def test_template_builds_valid_run_v2_revision_template(self) -> None:
+        """The assembled template dict must construct a real Cloud Run v2
+        RevisionTemplate without raising. This guards against emitting any
+        container field the API rejects — e.g. ``security_context``, which is
+        not a Cloud Run v2 Container field (Cloud Run derives the run-as user
+        from the image's Dockerfile USER, not the Admin API)."""
+        from google.cloud import run_v2
+
+        template = self._injected_template()  # agent + sidecar
+        # Must not raise "Unknown field for Container: ...".
+        run_v2.RevisionTemplate(template)
+
+    def test_sidecar_omits_unsupported_security_context(self) -> None:
+        sidecar = self._sidecar_container(self._injected_template())
+        assert "security_context" not in sidecar
+
     def test_no_sidecar_keeps_agent_as_ingress_on_8080(self) -> None:
         config = _make_config()  # no guardrails → no sidecar
         gcp = _extract_cloudrun_config(config)
@@ -788,3 +804,92 @@ class TestPushImage:
             pytest.raises(RuntimeError, match="Image push failed"),
         ):
             await deployer._push_image(image, image_uri)
+
+
+# ---------------------------------------------------------------------------
+# GCPCloudRunDeployer._create_or_update_service — idempotent upsert
+# ---------------------------------------------------------------------------
+
+
+def _fake_run_op(uri: str) -> MagicMock:
+    """Build a fake long-running operation whose result() yields a service."""
+    svc = MagicMock()
+    svc.uri = uri
+    op = MagicMock()
+    op.result = AsyncMock(return_value=svc)
+    return op
+
+
+def _idempotency_deployer_and_config():
+    deployer = GCPCloudRunDeployer()
+    config = _make_config()
+    config.access.visibility = Visibility.public
+    gcp = _extract_cloudrun_config(config)
+    deployer._gcp_config = gcp
+    return deployer, config, gcp
+
+
+class TestCreateOrUpdateServiceIdempotency:
+    """The upsert must survive retries against partially-created services."""
+
+    @pytest.mark.asyncio
+    async def test_updates_when_service_exists(self) -> None:
+        deployer, config, gcp = _idempotency_deployer_and_config()
+        mock_client = MagicMock()
+        from google.cloud.run_v2 import Service
+
+        mock_client.get_service = AsyncMock(return_value=Service())
+        mock_client.update_service = AsyncMock(
+            return_value=_fake_run_op("https://updated.a.run.app")
+        )
+        mock_client.create_service = AsyncMock()
+
+        with patch.object(deployer, "_get_run_client", return_value=mock_client):
+            url = await deployer._create_or_update_service(config, gcp, "img:1")
+
+        assert url == "https://updated.a.run.app"
+        mock_client.update_service.assert_awaited_once()
+        mock_client.create_service.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_creates_when_service_missing(self) -> None:
+        from google.api_core.exceptions import NotFound
+
+        deployer, config, gcp = _idempotency_deployer_and_config()
+        mock_client = MagicMock()
+        mock_client.get_service = AsyncMock(side_effect=NotFound("nope"))
+        mock_client.update_service = AsyncMock()
+        mock_client.create_service = AsyncMock(
+            return_value=_fake_run_op("https://created.a.run.app")
+        )
+
+        with patch.object(deployer, "_get_run_client", return_value=mock_client):
+            url = await deployer._create_or_update_service(config, gcp, "img:1")
+
+        assert url == "https://created.a.run.app"
+        mock_client.create_service.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_create_race_falls_back_to_update(self) -> None:
+        """get_service says NotFound, create races a settling delete and returns
+        AlreadyExists — the deployer must patch the resurfaced service."""
+        from google.api_core.exceptions import AlreadyExists, NotFound
+        from google.cloud.run_v2 import Service
+
+        deployer, config, gcp = _idempotency_deployer_and_config()
+        mock_client = MagicMock()
+        # First get_service (in _update_existing) → NotFound; second (the
+        # fallback _update_existing after AlreadyExists) → found.
+        mock_client.get_service = AsyncMock(side_effect=[NotFound("nope"), Service()])
+        mock_client.create_service = AsyncMock(side_effect=AlreadyExists("exists"))
+        mock_client.update_service = AsyncMock(
+            return_value=_fake_run_op("https://recovered.a.run.app")
+        )
+
+        with patch.object(deployer, "_get_run_client", return_value=mock_client):
+            url = await deployer._create_or_update_service(config, gcp, "img:1")
+
+        assert url == "https://recovered.a.run.app"
+        mock_client.create_service.assert_awaited_once()
+        assert mock_client.get_service.await_count == 2
+        mock_client.update_service.assert_awaited_once()

--- a/tests/unit/test_gcp_cloudrun_deployer.py
+++ b/tests/unit/test_gcp_cloudrun_deployer.py
@@ -416,7 +416,10 @@ class TestSidecarIngressRouting:
         container field the API rejects — e.g. ``security_context``, which is
         not a Cloud Run v2 Container field (Cloud Run derives the run-as user
         from the image's Dockerfile USER, not the Admin API)."""
-        from google.cloud import run_v2
+        run_v2 = pytest.importorskip(
+            "google.cloud.run_v2",
+            reason="google-cloud-run not installed (pip install agentbreeder[gcp])",
+        )
 
         template = self._injected_template()  # agent + sidecar
         # Must not raise "Unknown field for Container: ...".
@@ -834,9 +837,13 @@ class TestCreateOrUpdateServiceIdempotency:
 
     @pytest.mark.asyncio
     async def test_updates_when_service_exists(self) -> None:
+        run_v2 = pytest.importorskip(
+            "google.cloud.run_v2",
+            reason="google-cloud-run not installed (pip install agentbreeder[gcp])",
+        )
+        Service = run_v2.Service
         deployer, config, gcp = _idempotency_deployer_and_config()
         mock_client = MagicMock()
-        from google.cloud.run_v2 import Service
 
         mock_client.get_service = AsyncMock(return_value=Service())
         mock_client.update_service = AsyncMock(
@@ -853,7 +860,11 @@ class TestCreateOrUpdateServiceIdempotency:
 
     @pytest.mark.asyncio
     async def test_creates_when_service_missing(self) -> None:
-        from google.api_core.exceptions import NotFound
+        api_core_exc = pytest.importorskip(
+            "google.api_core.exceptions",
+            reason="google-cloud-run not installed (pip install agentbreeder[gcp])",
+        )
+        NotFound = api_core_exc.NotFound
 
         deployer, config, gcp = _idempotency_deployer_and_config()
         mock_client = MagicMock()
@@ -873,8 +884,17 @@ class TestCreateOrUpdateServiceIdempotency:
     async def test_create_race_falls_back_to_update(self) -> None:
         """get_service says NotFound, create races a settling delete and returns
         AlreadyExists — the deployer must patch the resurfaced service."""
-        from google.api_core.exceptions import AlreadyExists, NotFound
-        from google.cloud.run_v2 import Service
+        api_core_exc = pytest.importorskip(
+            "google.api_core.exceptions",
+            reason="google-cloud-run not installed (pip install agentbreeder[gcp])",
+        )
+        AlreadyExists = api_core_exc.AlreadyExists
+        NotFound = api_core_exc.NotFound
+        run_v2 = pytest.importorskip(
+            "google.cloud.run_v2",
+            reason="google-cloud-run not installed (pip install agentbreeder[gcp])",
+        )
+        Service = run_v2.Service
 
         deployer, config, gcp = _idempotency_deployer_and_config()
         mock_client = MagicMock()

--- a/tests/unit/test_greenfield_mapper.py
+++ b/tests/unit/test_greenfield_mapper.py
@@ -74,8 +74,93 @@ def test_aws_mapper_returns_only_strings() -> None:
     assert all(isinstance(k, str) and isinstance(v, str) for k, v in env.items())
 
 
+def _gcp_state() -> InfraState:
+    """A representative greenfield InfraState as GCPProvisioner.provision() returns it."""
+    return InfraState(
+        cloud="gcp",
+        region="us-central1",
+        provisioned_by="agentbreeder.GCPProvisioner",
+        provisioned_at=datetime.now(UTC),
+        mode="provisioned",
+        resources={
+            "artifact_registry": {
+                "name": "projects/my-proj/locations/us-central1/repositories/agentbreeder",
+                "repo": "agentbreeder",
+                "region": "us-central1",
+            },
+            "service_account": {
+                "email": "ab-my-agent@my-proj.iam.gserviceaccount.com",
+                "sa_id": "ab-my-agent",
+                "project": "my-proj",
+            },
+            "vpc_connector": {
+                "name": "projects/my-proj/locations/us-central1/connectors/ab-my-agent",
+                "network": "ab-my-agent-vpc",
+            },
+            "network": {"name": "ab-my-agent-vpc", "subnet": "ab-my-agent-subnet"},
+        },
+    )
+
+
+def test_gcp_mapper_emits_the_env_the_cloudrun_deployer_reads() -> None:
+    env = infra_state_to_env("gcp", _gcp_state())
+    assert env["GCP_PROJECT_ID"] == "my-proj"
+    assert env["GCP_SERVICE_ACCOUNT"] == "ab-my-agent@my-proj.iam.gserviceaccount.com"
+    assert env["GCP_ARTIFACT_REGISTRY_REPO"] == "agentbreeder"
+    assert env["GCP_REGION"] == "us-central1"
+    assert env["GCP_VPC_CONNECTOR"].endswith("/connectors/ab-my-agent")
+    # Data tier lands in the greenfield VPC.
+    assert env["GCP_VPC_NAME"] == "ab-my-agent-vpc"
+    assert all(isinstance(k, str) and isinstance(v, str) for k, v in env.items())
+
+
+def _azure_state() -> InfraState:
+    """A representative greenfield InfraState as AzureProvisioner.provision() returns it."""
+    return InfraState(
+        cloud="azure",
+        region="eastus",
+        provisioned_by="agentbreeder.AzureProvisioner",
+        provisioned_at=datetime.now(UTC),
+        mode="provisioned",
+        resources={
+            "resource_group": {
+                "id": "/subscriptions/sub-123/resourceGroups/ab-my-agent-rg",
+                "name": "ab-my-agent-rg",
+                "region": "eastus",
+            },
+            "container_apps_environment": {"id": "...", "name": "ab-my-agent-env"},
+            "acr": {
+                "id": "...",
+                "name": "abmyagentacr",
+                "login_server": "abmyagentacr.azurecr.io",
+            },
+            "managed_identity": {"id": "...", "name": "ab-my-agent-id"},
+            "vnet": {
+                "id": "...",
+                "name": "ab-my-agent-vnet",
+                "db_subnet_id": "/subscriptions/sub-123/.../subnets/db",
+            },
+            "key_vault": {"id": "...", "name": "abkv", "uri": "https://abkv.vault.azure.net/"},
+        },
+    )
+
+
+def test_azure_mapper_emits_the_env_the_aca_deployer_reads() -> None:
+    env = infra_state_to_env("azure", _azure_state())
+    assert env["AZURE_SUBSCRIPTION_ID"] == "sub-123"
+    assert env["AZURE_RESOURCE_GROUP"] == "ab-my-agent-rg"
+    assert env["AZURE_CONTAINER_APPS_ENV"] == "ab-my-agent-env"
+    assert env["AZURE_REGISTRY_SERVER"] == "abmyagentacr.azurecr.io"
+    assert env["AZURE_LOCATION"] == "eastus"
+    # Data tier lands in the greenfield VNet's delegated subnet.
+    assert env["AZURE_VNET_NAME"] == "ab-my-agent-vnet"
+    assert env["AZURE_DB_SUBNET_ID"].endswith("/subnets/db")
+    assert env["AZURE_KEYVAULT_URL"] == "https://abkv.vault.azure.net/"
+    assert all(isinstance(k, str) and isinstance(v, str) for k, v in env.items())
+
+
 def test_unsupported_cloud_raises() -> None:
     state = _aws_state()
-    state.cloud = "gcp"
+    state.cloud = "kubernetes"
     with pytest.raises(NotImplementedError):
-        infra_state_to_env("gcp", state)
+        infra_state_to_env("kubernetes", state)

--- a/tests/unit/test_provisioners_gcp_vpc.py
+++ b/tests/unit/test_provisioners_gcp_vpc.py
@@ -1,0 +1,135 @@
+"""GCP greenfield VPC provisioning (multi-cloud parity #505, #436/#382).
+
+When ``GCP_PROVISION_VPC`` is set (the CLI ``deploy --provision`` path), the GCP
+provisioner builds a dedicated custom-mode VPC + subnet (+ Cloud NAT + PSA) so
+the agent and data tier share a private network, mirroring the AWS greenfield
+VPC. SDK calls are patched at the ``_ensure_*`` boundary.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from engine.provisioners import InfraValidationInput
+from engine.provisioners.gcp import (
+    GCPProvisioner,
+    _should_provision_vpc_network,
+    _truncate_network_id,
+)
+from engine.provisioners.state import InfraState
+
+
+def _payload(extra: dict | None = None) -> InfraValidationInput:
+    fields = {
+        "GOOGLE_CLOUD_PROJECT": "test-proj",
+        "GCP_REGION": "us-central1",
+        "GCP_AGENT_NAME": "demo",
+    }
+    if extra:
+        fields.update(extra)
+    return InfraValidationInput(cloud="gcp", region="us-central1", mode="simple", fields=fields)
+
+
+@pytest.fixture
+def provisioner():
+    p = GCPProvisioner()
+    net_info = {
+        "name": "ab-demo-vpc",
+        "network_url": "projects/test-proj/global/networks/ab-demo-vpc",
+        "subnet": "ab-demo-vpc-subnet",
+        "subnet_cidr": "10.20.0.0/20",
+        "region": "us-central1",
+        "project": "test-proj",
+        "router": "ab-demo-vpc-router",
+        "nat": "ab-demo-vpc-nat",
+        "psa_range": "ab-demo-vpc-psa",
+    }
+    with (
+        patch.object(p, "_ensure_artifact_registry_repo", new=AsyncMock(return_value=None)),
+        patch.object(p, "_ensure_service_account", new=AsyncMock(return_value=None)),
+        patch.object(p, "_bind_iam_roles", new=AsyncMock(return_value=None)),
+        patch.object(p, "_ensure_vpc_network", new=AsyncMock(return_value=net_info)),
+        patch.object(
+            p,
+            "_ensure_vpc_connector",
+            new=AsyncMock(
+                return_value="projects/test-proj/locations/us-central1/connectors/ab-demo"
+            ),
+        ),
+    ):
+        yield p
+
+
+# -- predicate + naming -----------------------------------------------------
+
+
+@pytest.mark.parametrize("flag", [True, "true", "1", "yes"])
+def test_should_provision_vpc_network_true(flag) -> None:
+    assert _should_provision_vpc_network({"GCP_PROVISION_VPC": flag}) is True
+
+
+def test_should_provision_vpc_network_default_false() -> None:
+    assert _should_provision_vpc_network({}) is False
+
+
+def test_truncate_network_id_starts_with_letter_and_lowercase() -> None:
+    out = _truncate_network_id("My_Agent")
+    assert out[0].isalpha()
+    assert out == out.lower()
+    assert len(out) <= 63
+
+
+# -- provision() orchestration ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provision_creates_vpc_when_flag_set(provisioner) -> None:
+    state = await provisioner.provision(_payload({"GCP_PROVISION_VPC": "true"}))
+    provisioner._ensure_vpc_network.assert_awaited_once()
+    assert "network" in state.resources
+    assert state.resources["network"]["name"] == "ab-demo-vpc"
+
+
+@pytest.mark.asyncio
+async def test_provision_skips_vpc_by_default(provisioner) -> None:
+    state = await provisioner.provision(_payload())
+    provisioner._ensure_vpc_network.assert_not_awaited()
+    assert "network" not in state.resources
+
+
+@pytest.mark.asyncio
+async def test_provisioned_network_drives_the_connector(provisioner) -> None:
+    # The connector must land on the freshly-created VPC, not "default".
+    await provisioner.provision(
+        _payload({"GCP_PROVISION_VPC": "true", "GCP_PROVISION_VPC_CONNECTOR": "true"})
+    )
+    provisioner._ensure_vpc_connector.assert_awaited_once()
+    assert provisioner._ensure_vpc_connector.await_args.kwargs["network"] == "ab-demo-vpc"
+
+
+@pytest.mark.asyncio
+async def test_destroy_deletes_network() -> None:
+    p = GCPProvisioner()
+    state = InfraState(
+        cloud="gcp",
+        region="us-central1",
+        provisioned_by="x",
+        provisioned_at=datetime.now(UTC),
+        mode="provisioned",
+        resources={
+            "network": {
+                "name": "ab-demo-vpc",
+                "subnet": "ab-demo-vpc-subnet",
+                "region": "us-central1",
+                "project": "test-proj",
+                "router": "ab-demo-vpc-router",
+            }
+        },
+    )
+    with patch.object(p, "_delete_vpc_network", new=AsyncMock(return_value=None)) as m:
+        await p.destroy(state)
+    m.assert_awaited_once()
+    assert m.await_args.kwargs["info"]["name"] == "ab-demo-vpc"

--- a/tests/unit/test_runtime_google_adk.py
+++ b/tests/unit/test_runtime_google_adk.py
@@ -337,6 +337,20 @@ def _load_adk_server_module(module_alias: str) -> types.ModuleType:
     fake_google.genai = fake_genai
     fake_genai.types = fake_genai_types
 
+    # Snapshot the real google.* modules so we can restore them afterwards.
+    # Without this, the fake `google` namespace leaks into sys.modules and
+    # breaks later tests that import the real google.cloud.run_v2 protos
+    # (e.g. the Cloud Run deployer's idempotency tests).
+    stub_keys = (
+        "google",
+        "google.adk",
+        "google.adk.runners",
+        "google.adk.sessions",
+        "google.genai",
+        "google.genai.types",
+    )
+    saved = {key: sys.modules.get(key) for key in stub_keys}
+
     sys.modules["google"] = fake_google
     sys.modules["google.adk"] = fake_adk
     sys.modules["google.adk.runners"] = fake_runners
@@ -344,13 +358,22 @@ def _load_adk_server_module(module_alias: str) -> types.ModuleType:
     sys.modules["google.genai"] = fake_genai
     sys.modules["google.genai.types"] = fake_genai_types
 
-    spec = importlib.util.spec_from_file_location(
-        module_alias,
-        "engine/runtimes/templates/google_adk_server.py",
-    )
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
+    try:
+        spec = importlib.util.spec_from_file_location(
+            module_alias,
+            "engine/runtimes/templates/google_adk_server.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        # The loaded module has already bound the fake Runner/session symbols at
+        # import time, so it keeps working after we restore the real modules.
+        return mod
+    finally:
+        for key, original in saved.items():
+            if original is None:
+                sys.modules.pop(key, None)
+            else:
+                sys.modules[key] = original
 
 
 class TestGoogleADKServerRunnerReuse:

--- a/tests/unit/test_runtime_port_honoring.py
+++ b/tests/unit/test_runtime_port_honoring.py
@@ -1,0 +1,103 @@
+"""Tests that every Python runtime's container honours the ``$PORT`` env var.
+
+When the observability sidecar is injected, the deployer makes the sidecar the
+ingress container on 8080 and moves the agent to an internal port (8081) by
+setting ``PORT=8081`` on the agent container. If the agent's ``CMD`` hardcodes
+``--port 8080`` it collides with the sidecar and Cloud Run/ECS kills the
+revision with ``address already in use`` — the startup probe never passes.
+
+Every runtime must therefore launch uvicorn on ``${PORT:-8080}`` so a single
+container still defaults to 8080 while a sidecar'd agent obeys ``PORT=8081``.
+Previously only the LangGraph runtime did this; the others silently broke the
+sidecar pattern for their frameworks.
+"""
+
+from __future__ import annotations
+
+import importlib
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from engine.config_parser import AgentConfig, FrameworkType
+
+
+def _agent_dir(files: dict[str, str]) -> Path:
+    d = Path(tempfile.mkdtemp())
+    for name, content in files.items():
+        (d / name).write_text(content)
+    return d
+
+
+def _config(framework: FrameworkType) -> AgentConfig:
+    return AgentConfig(
+        name="port-agent",
+        version="1.0.0",
+        team="test",
+        owner="test@example.com",
+        framework=framework,
+        model={"primary": "claude-sonnet-4-6"},
+        deploy={"cloud": "local"},
+    )
+
+
+_RUNTIME_CASES = [
+    pytest.param(
+        FrameworkType.claude_sdk,
+        "engine.runtimes.claude_sdk:ClaudeSDKRuntime",
+        {
+            "agent.py": "import anthropic\nagent = anthropic.AsyncAnthropic()",
+            "requirements.txt": "anthropic\n",
+        },
+        id="claude_sdk",
+    ),
+    pytest.param(
+        FrameworkType.langgraph,
+        "engine.runtimes.langgraph:LangGraphRuntime",
+        {"agent.py": "graph = object()\n", "requirements.txt": "langgraph\n"},
+        id="langgraph",
+    ),
+    pytest.param(
+        FrameworkType.crewai,
+        "engine.runtimes.crewai:CrewAIRuntime",
+        {"agent.py": "crew = object()\n", "requirements.txt": "crewai\n"},
+        id="crewai",
+    ),
+    pytest.param(
+        FrameworkType.openai_agents,
+        "engine.runtimes.openai_agents:OpenAIAgentsRuntime",
+        {"agent.py": "agent = object()\n", "requirements.txt": "openai-agents\n"},
+        id="openai_agents",
+    ),
+    pytest.param(
+        FrameworkType.google_adk,
+        "engine.runtimes.google_adk:GoogleADKRuntime",
+        {"agent.py": "root_agent = object()\n", "requirements.txt": "google-adk\n"},
+        id="google_adk",
+    ),
+    pytest.param(
+        FrameworkType.custom,
+        "engine.runtimes.custom:CustomRuntime",
+        {"agent.py": "app = object()\n", "requirements.txt": "flask\n"},
+        id="custom",
+    ),
+]
+
+
+def _load_runtime(path: str) -> object:
+    module_name, cls_name = path.split(":")
+    return getattr(importlib.import_module(module_name), cls_name)()
+
+
+@pytest.mark.parametrize("framework, runtime_path, files", _RUNTIME_CASES)
+def test_dockerfile_cmd_honors_port_env(
+    framework: FrameworkType, runtime_path: str, files: dict[str, str]
+) -> None:
+    runtime = _load_runtime(runtime_path)
+    image = runtime.build(_agent_dir(files), _config(framework))
+    dockerfile = (image.context_dir / "Dockerfile").read_text()
+    # The launch CMD must defer the port to $PORT (defaulting to 8080), never
+    # hardcode --port 8080 (which collides with the sidecar on the ingress port).
+    assert "${PORT:-8080}" in dockerfile
+    assert '"--port", "8080"' not in dockerfile

--- a/tests/unit/test_runtime_wheel_staging.py
+++ b/tests/unit/test_runtime_wheel_staging.py
@@ -1,0 +1,150 @@
+"""Tests for local-wheel staging in Python runtime Dockerfiles.
+
+When an agent is deployed from an unpublished dev checkout, the runtime is
+bundled as a local ``*.whl`` referenced via
+``AGENTBREEDER_RUNTIME_REQUIREMENT=./<wheel>``. That wheel must be ``COPY``ed
+into the image *before* ``pip install -r requirements.txt`` runs, otherwise the
+path requirement is unresolvable and the build fails with a non-zero pip exit.
+
+These tests cover the shared :func:`inject_wheel_copies` helper and verify each
+Python runtime's ``build()`` honours a bundled wheel — previously only the
+LangGraph runtime did, breaking dev-checkout deploys of every other framework.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from engine.config_parser import AgentConfig, FrameworkType
+from engine.runtimes.base import inject_wheel_copies
+
+
+def _agent_dir(files: dict[str, str]) -> Path:
+    d = Path(tempfile.mkdtemp())
+    for name, content in files.items():
+        (d / name).write_text(content)
+    return d
+
+
+class TestInjectWheelCopies:
+    def test_no_wheels_is_noop(self, tmp_path: Path) -> None:
+        template = (
+            "FROM python:3.11-slim\nCOPY requirements.txt .\nRUN pip install -r requirements.txt\n"
+        )
+        assert inject_wheel_copies(template, tmp_path) == template
+
+    def test_single_wheel_copied_before_pip(self, tmp_path: Path) -> None:
+        (tmp_path / "agentbreeder-2.1.1.dev1-py3-none-any.whl").write_text("")
+        template = "COPY requirements.txt .\nRUN pip install --no-cache-dir -r requirements.txt\n"
+        result = inject_wheel_copies(template, tmp_path)
+        assert "COPY agentbreeder-2.1.1.dev1-py3-none-any.whl ./" in result
+        # Wheel COPY must precede the pip install line.
+        assert result.index("COPY agentbreeder-2.1.1.dev1") < result.index("pip install")
+        # And must come after the requirements.txt COPY (cache ordering preserved).
+        assert result.index("COPY requirements.txt") < result.index("COPY agentbreeder-2.1.1.dev1")
+
+    def test_multiple_wheels_sorted(self, tmp_path: Path) -> None:
+        (tmp_path / "b_pkg.whl").write_text("")
+        (tmp_path / "a_pkg.whl").write_text("")
+        template = "COPY requirements.txt .\nRUN pip install -r requirements.txt\n"
+        result = inject_wheel_copies(template, tmp_path)
+        assert result.index("COPY a_pkg.whl") < result.index("COPY b_pkg.whl")
+
+    def test_only_first_requirements_copy_replaced(self, tmp_path: Path) -> None:
+        (tmp_path / "x.whl").write_text("")
+        template = "COPY requirements.txt .\nRUN pip install -r requirements.txt\nCOPY requirements.txt .\n"
+        result = inject_wheel_copies(template, tmp_path)
+        assert result.count("COPY x.whl ./") == 1
+
+
+def _config(framework: FrameworkType, model: str = "claude-sonnet-4-6") -> AgentConfig:
+    return AgentConfig(
+        name="wheel-agent",
+        version="1.0.0",
+        team="test",
+        owner="test@example.com",
+        framework=framework,
+        model={"primary": model},
+        deploy={"cloud": "local"},
+    )
+
+
+# (framework, runtime import path, agent files) for each pip-based Python runtime.
+_RUNTIME_CASES = [
+    pytest.param(
+        FrameworkType.claude_sdk,
+        "engine.runtimes.claude_sdk:ClaudeSDKRuntime",
+        {
+            "agent.py": "import anthropic\nagent = anthropic.AsyncAnthropic()",
+            "requirements.txt": "anthropic\n",
+        },
+        id="claude_sdk",
+    ),
+    pytest.param(
+        FrameworkType.langgraph,
+        "engine.runtimes.langgraph:LangGraphRuntime",
+        {"agent.py": "graph = object()\n", "requirements.txt": "langgraph\n"},
+        id="langgraph",
+    ),
+    pytest.param(
+        FrameworkType.crewai,
+        "engine.runtimes.crewai:CrewAIRuntime",
+        {"agent.py": "crew = object()\n", "requirements.txt": "crewai\n"},
+        id="crewai",
+    ),
+    pytest.param(
+        FrameworkType.openai_agents,
+        "engine.runtimes.openai_agents:OpenAIAgentsRuntime",
+        {"agent.py": "agent = object()\n", "requirements.txt": "openai-agents\n"},
+        id="openai_agents",
+    ),
+    pytest.param(
+        FrameworkType.google_adk,
+        "engine.runtimes.google_adk:GoogleADKRuntime",
+        {"agent.py": "root_agent = object()\n", "requirements.txt": "google-adk\n"},
+        id="google_adk",
+    ),
+    pytest.param(
+        # Custom fallback path (no BYO Dockerfile): the generated fallback
+        # Dockerfile must stage wheels. BYO Dockerfiles are intentionally left
+        # untouched — those users own their own wheel handling.
+        FrameworkType.custom,
+        "engine.runtimes.custom:CustomRuntime",
+        {"agent.py": "app = object()\n", "requirements.txt": "flask\n"},
+        id="custom",
+    ),
+]
+
+
+def _load_runtime(path: str) -> object:
+    module_name, cls_name = path.split(":")
+    import importlib
+
+    return getattr(importlib.import_module(module_name), cls_name)()
+
+
+@pytest.mark.parametrize("framework, runtime_path, files", _RUNTIME_CASES)
+def test_build_stages_bundled_wheel(
+    framework: FrameworkType, runtime_path: str, files: dict[str, str]
+) -> None:
+    agent_dir = _agent_dir(files)
+    (agent_dir / "agentbreeder-2.1.1.dev112-py3-none-any.whl").write_text("")
+    runtime = _load_runtime(runtime_path)
+    image = runtime.build(agent_dir, _config(framework))
+    dockerfile = (image.context_dir / "Dockerfile").read_text()
+    assert "COPY agentbreeder-2.1.1.dev112-py3-none-any.whl ./" in dockerfile
+    assert dockerfile.index("agentbreeder-2.1.1.dev112") < dockerfile.index("pip install")
+
+
+@pytest.mark.parametrize("framework, runtime_path, files", _RUNTIME_CASES)
+def test_build_without_wheel_has_no_copy(
+    framework: FrameworkType, runtime_path: str, files: dict[str, str]
+) -> None:
+    agent_dir = _agent_dir(files)
+    runtime = _load_runtime(runtime_path)
+    image = runtime.build(agent_dir, _config(framework))
+    dockerfile = (image.context_dir / "Dockerfile").read_text()
+    assert ".whl ./" not in dockerfile

--- a/website/content/docs/cli-reference.mdx
+++ b/website/content/docs/cli-reference.mdx
@@ -129,7 +129,7 @@ agentbreeder quickstart [--cloud TARGET] [--no-browser] [--skip-seed] [--dev] [-
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--cloud` | — | Also deploy to cloud after local setup. `aws` (ECS Fargate), `gcp` (Cloud Run), and `azure` (Container Apps) all ship with full governance parity. This CLI path deploys into **existing** infra (plus auto-provisioned RDS/Redis data backends); greenfield provisioning ships via the [Studio deploy wizard](deployment#deploying-from-studio). Secret auto-mirror ships for GCP + Azure; on AWS, pre-create secrets in Secrets Manager. See the [deploy-target status table](#agentbreeder-deploy). |
+| `--cloud` | — | Also deploy to cloud after local setup. `aws` (ECS Fargate), `gcp` (Cloud Run), and `azure` (Container Apps) all ship with full governance parity. This CLI path deploys into **existing** infra (plus auto-provisioned managed Postgres/Redis data backends); greenfield provisioning ships via `agentbreeder deploy --provision` (AWS, GCP, Azure) or the [Studio deploy wizard](deployment#deploying-from-studio). Secret auto-mirror ships for GCP + Azure; on AWS, pre-create secrets in Secrets Manager. See the [deploy-target status table](#agentbreeder-deploy). |
 | `--no-browser` | Off | Don't open Studio at `http://localhost:3001` |
 | `--skip-seed` | Off | Skip ChromaDB + Neo4j seeding (fast restart) |
 | `--dev` | Off | Build API and Studio from local source instead of pulling images |
@@ -307,7 +307,7 @@ agentbreeder deploy CONFIG_PATH [--target TARGET] [--json] [--remote | --local]
 | `--target`, `-t` | No | `local` | Deploy target. See supported values below. |
 | `--remote` | No | Auto | POST to the API server (RBAC + audit enforced). Auto-enabled when `$AGENTBREEDER_URL` is set. |
 | `--local` | No | Auto | Run the deploy engine in-process. Use for dev / offline work; bypasses RBAC + audit. |
-| `--provision`, `-p` | No | Off | Greenfield-provision the cloud footprint (VPC, subnets, NAT, cluster, IAM) for a fresh account before deploying, then inject the IDs into the deploy. **AWS only; local mode only** for now (`--local --provision`). The footprint is recorded in `.agentbreeder/infra-state.json` and removed by `agentbreeder teardown`. |
+| `--provision`, `-p` | No | Off | Greenfield-provision the cloud footprint (network, registry, cluster/environment, IAM) for a fresh account before deploying, then inject the IDs into the deploy. **Supports AWS, GCP, and Azure; local mode only** (`--local --provision`). The footprint is recorded in `.agentbreeder/infra-state.json` and removed by `agentbreeder teardown`. |
 | `--json` | No | Off | Emit JSON to stdout (for CI/scripting). |
 
 **Remote vs. local mode**
@@ -328,32 +328,34 @@ Mode is picked by these rules, in order:
 This is the **canonical deploy-target status table** for AgentBreeder — other docs link here rather than repeating it. As of **v2.6.0**, the same `agent.yaml` deploys with **full governance parity** — the sidecar (guardrails, cost, tracing) plus secret mirroring — to **Local**, **AWS ECS Fargate**, **GCP Cloud Run**, and **Azure Container Apps**. **AWS App Runner** is single-container: it deploys *without* a sidecar and **rejects** `guardrails:` / `secrets:` at `validate-infra`. **Kubernetes** and **Claude-managed** are in flight.
 
 **Greenfield vs. existing account.** The **CLI** (`agentbreeder deploy`) deploys
-into **existing infrastructure** — a VPC, subnets, cluster, and execution role you
-already have (the per-cloud BYO contract) — **or**, on **AWS**, greenfield-provisions
-that footprint from scratch with `--provision`. For **GCP/Azure**, greenfield ships
-through the **Studio deploy wizard** (Step 3 → *Provision for me*); CLI `--provision`
-for those clouds is on the
-[roadmap](https://github.com/agentbreeder/agentbreeder/issues/383). Independently,
-**both surfaces auto-provision the data tier** (RDS pgvector / ElastiCache Redis) when
-an agent declares `memory:` or a knowledge base without a `backend_url`.
+into **existing infrastructure** — a network, cluster/environment, registry, and
+execution identity you already have (the per-cloud BYO contract) — **or**
+greenfield-provisions that footprint from scratch with `--provision` on **AWS,
+GCP, and Azure**. The Studio deploy wizard (Step 3 → *Provision for me*) offers
+the same greenfield path. Independently, **both surfaces auto-provision the data
+tier** (managed Postgres pgvector / managed Redis) when an agent declares
+`memory:` or a knowledge base without a `backend_url`.
 
 | Target | Status | Greenfield provisioning | Sidecar (governance) | Secret auto-mirror |
 |--------|--------|--------------------------|----------------------|--------------------|
 | `local` (Docker Compose) | ✅ Shipped | ✅ (nothing to provision) | ✅ | n/a (local `.env`) |
 | `ecs-fargate` (AWS) | ✅ Shipped | ✅ **CLI `--provision`** + Studio wizard¹ | ✅ | 🟡 Roadmap — pre-create in Secrets Manager |
-| `cloud-run` (GCP) | ✅ Shipped | ✅ Studio wizard¹ · CLI BYO + auto data tier | ✅ | ✅ |
-| `container-apps` (Azure) | ✅ Shipped | ✅ Studio wizard¹ · CLI BYO + auto data tier | ✅ | ✅ |
+| `cloud-run` (GCP) | ✅ Shipped | ✅ **CLI `--provision`** + Studio wizard¹ | ✅ | ✅ |
+| `container-apps` (Azure) | ✅ Shipped | ✅ **CLI `--provision`** + Studio wizard¹ | ✅ | ✅ |
 | `app-runner` (AWS) | ✅ Shipped (single-container) | CLI BYO only — `--provision`/wizard provision ECS Fargate, not App Runner | ❌ — rejects `guardrails:`/`secrets:` | ❌ — not supported |
 | `kubernetes` (EKS/GKE/AKS/self-hosted) | 🟡 In flight | ❌ — needs existing cluster + kubeconfig | ✅ (when usable) | 🟡 Roadmap |
 | `claude-managed` (Anthropic) | 🟡 In flight | n/a — runtime is Anthropic-managed | n/a | n/a |
 
-¹ **AWS** greenfield ships from the CLI today (`agentbreeder deploy --target
-ecs-fargate --provision --local`) and from **Studio → Deploys → New deploy** (the
-`/deploy-wizard` flow) + the deployments job API (`POST /api/v1/deployments` with
-`infra_mode: "provision"`). See [Deployment → Greenfield mode](deployment#user-input-contract-per-cloud-byo-existing-infra)
-and [Deploying from Studio](deployment#deploying-from-studio). For **GCP/Azure**, CLI
-`--provision` is not yet shipped — use the Studio wizard, deploy into existing infra
-(BYO), or pre-create the footprint first.
+¹ Greenfield ships from the CLI on all three clouds today — e.g. `agentbreeder
+deploy --target ecs-fargate --provision --local` (AWS), `--target cloud-run
+--provision --local` (GCP), `--target container-apps --provision --local`
+(Azure) — and from **Studio → Deploys → New deploy** (the `/deploy-wizard` flow)
++ the deployments job API (`POST /api/v1/deployments` with `infra_mode:
+"provision"`). GCP greenfield builds a dedicated VPC + subnet + Cloud NAT + a
+Private Service Access range (for Cloud SQL private IP); Azure greenfield builds
+the resource group, Log Analytics, Container Apps environment, ACR, and managed
+identity. See [Deployment → Greenfield mode](deployment#user-input-contract-per-cloud-byo-existing-infra)
+and [Deploying from Studio](deployment#deploying-from-studio).
 
 Each `--target` value maps to one cloud + runtime combination:
 

--- a/website/content/docs/deployment.mdx
+++ b/website/content/docs/deployment.mdx
@@ -32,15 +32,17 @@ Container Apps with the per-cloud user-input contract below.
     **Studio** deploy into them. This is the path the two verified walkthroughs
     on this page use.
   - **Greenfield** — a fresh account with no networking. AgentBreeder provisions
-    the whole footprint (VPC, subnets, NAT, security groups, cluster, IAM, and —
-    when declared — RDS) for you. On **AWS** this ships from the **CLI**
-    (`agentbreeder deploy --target ecs-fargate --provision`) **and** the Studio
-    deploy wizard (Step 3 → *Provision for me*). For **GCP/Azure**, greenfield
-    ships through the Studio wizard today; CLI parity is on the
-    [roadmap](https://github.com/agentbreeder/agentbreeder/issues/383).
+    the whole footprint for you. On **all three clouds** this ships from the
+    **CLI** (`agentbreeder deploy --target <cloud> --provision`) **and** the
+    Studio deploy wizard (Step 3 → *Provision for me*). AWS builds the VPC,
+    subnets, NAT, security groups, ECS cluster, IAM, and — when declared — RDS;
+    GCP builds a VPC + subnet + Cloud NAT + a Private Service Access range (for
+    Cloud SQL private IP) + Artifact Registry + service account; Azure builds the
+    resource group, Log Analytics, Container Apps environment, ACR, and managed
+    identity.
 
   Independently of which path you pick, the CLI and Studio both **auto-provision
-  the data tier** (RDS pgvector / ElastiCache Redis) when an agent declares
+  the data tier** (managed Postgres pgvector / managed Redis) when an agent declares
   `memory:` or a knowledge base without a `backend_url`. For the at-a-glance
   matrix, see the
   [deploy-target status table in the CLI reference](cli-reference#agentbreeder-deploy);
@@ -139,11 +141,11 @@ pre-existing cluster, subnets, or roles.
 
 <Callout type="info" title="Studio equivalent + GCP/Azure">
   The Studio deploy wizard (Step 3 → *Provision for me*) runs the same
-  `AWSProvisioner.provision()` path with live SSE progress and partial-rollback;
-  see [Deploying from Studio](#deploying-from-studio). On **GCP/Azure**,
-  greenfield ships via the Studio wizard today — CLI `--provision` for those
-  clouds is on the [roadmap](https://github.com/agentbreeder/agentbreeder/issues/383).
-  `--provision` is **local mode** only for now (use `--local`).
+  provisioner path with live SSE progress and partial-rollback;
+  see [Deploying from Studio](#deploying-from-studio). CLI `--provision` ships for
+  **AWS, GCP, and Azure** — e.g. `agentbreeder deploy --target cloud-run
+  --provision --local` (GCP) or `--target container-apps --provision --local`
+  (Azure). `--provision` is **local mode** only for now (use `--local`).
 </Callout>
 
 | Resource | Notes |
@@ -195,17 +197,18 @@ You still need the four IAM roles documented in [One-time IAM grants](#one-time-
 **Greenfield mode (Studio → "Provision for me"):**
 
 For fresh GCP projects, AgentBreeder can create infrastructure on your behalf
-in place of the "Full mode" inputs above. Like AWS, this runs through the
-**Studio deploy wizard** and the deployments job API today; CLI parity
-(`deploy --target gcp --provision`) is on the
-[roadmap](https://github.com/agentbreeder/agentbreeder/issues/383). Only
-`GOOGLE_CLOUD_PROJECT` and `GCP_REGION` are required; everything else is opt-in
-via environment flags.
+in place of the "Full mode" inputs above. This ships from the **CLI**
+(`agentbreeder deploy --target cloud-run --provision --local`), the **Studio
+deploy wizard**, and the deployments job API. Only `GOOGLE_CLOUD_PROJECT` and
+`GCP_REGION` are required; everything else is opt-in via environment flags. The
+CLI `--provision` path turns on the VPC + connector flags below automatically so
+the agent and data tier share a private network.
 
 | Flag | Effect |
 |---|---|
 | _default_ | Artifact Registry repo `agentbreeder` + per-agent Service Account `ab-<agent-name>` + 4 IAM roles |
-| `GCP_PROVISION_VPC_CONNECTOR=1` | Adds a Serverless VPC Access connector `ab-<agent-name>` (e2-micro, 2–3 instances) on the `default` VPC. Wire it into Cloud Run by setting `GCP_VPC_CONNECTOR` to the connector name from `.agentbreeder/infra-state.json`. |
+| `GCP_PROVISION_VPC=1` | Greenfield-creates a custom-mode VPC `ab-<agent-name>-vpc` + regional subnet (private Google access) + Cloud NAT (egress) + a Private Service Access range (for Cloud SQL private IP). The connector and Cloud SQL then target this network instead of `default`. Set automatically by CLI `--provision`. |
+| `GCP_PROVISION_VPC_CONNECTOR=1` | Adds a Serverless VPC Access connector `ab-<agent-name>` (e2-micro, 2–3 instances) on the provisioned VPC (or `default`). Wire it into Cloud Run by setting `GCP_VPC_CONNECTOR` to the connector name from `.agentbreeder/infra-state.json`. |
 | `GCP_PROVISION_CLOUD_SQL=1` | Adds a private-IP Cloud SQL Postgres 15 instance `{agent_name}-memory` (default `db-f1-micro`), database `agentbreeder_memory`, user `agentbreeder`. Random password is written to Secret Manager — never to disk. Implies the VPC connector unless `GCP_CLOUD_SQL_PRIVATE_IP=0`. |
 
 VPC connector tuning (all optional):


### PR DESCRIPTION
## Summary

Brings **GCP Cloud Run** and **Azure Container Apps** deploys to full parity with the AWS ECS path, closing epic #505 ("Three clouds, one command"). Unifies the greenfield-provisioning + container-build + deploy flow across all three clouds and hardens the GCP path after live validation.

## What's in here (3 commits, kept distinct)

1. **`feat(deployers,provisioners)`** — GCP + Azure deploy parity with AWS: shared greenfield mapper (`_greenfield.py`), Azure Container Apps + GCP Cloud Run deployers aligned with the AWS ECS deployer, GCP VPC provisioner.
2. **`refactor(deployers)`** — shared Docker client factory (`_docker.py`, DRY across AWS/GCP/Azure) + gate GCP greenfield VPC creation behind an explicit opt-in predicate.
3. **`fix(runtimes,deployers)`** — runtime Dockerfile templates honor `$PORT` (fixes Cloud Run sidecar port collisions); remove `security_context` from the Cloud Run sidecar spec (Cloud Run v2 Container schema has no such field — the Admin API rejected the revision); stage local wheels for dev-checkout deploys; fix a `sys.modules` leak in the google_adk runtime test that polluted the Cloud Run deployer tests.

## Tests

- Full unit suite green: **5438 passed, 3 skipped**.
- New regression tests: `$PORT` honoring across all runtimes, wheel staging, Cloud Run v2 container-field validity, GCP VPC provisioning, Azure deployer, greenfield mapper, GCP/Azure parity.

## Docs

- `website/content/docs/cli-reference.mdx` and `deployment.mdx` updated in-branch (cross-repo doc sync).

## Review / Gate

- Quality gate: all gates (tests, security, build, cloud-security) passed.
- Code review: 0 critical, 0 high, 3 minor (logged, non-blocking).

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)
