### PR TITLE
Studio Conversational Builder (Waves 1–4): chat → eject → deploy + cloud sandbox + analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,10 @@ linkedin-content.docx
 .diskdiag*.txt
 .verify.txt
 
+# Gate-tool scratch dir (regenerated each run, never committed)
+.tmp-gate/
+.tmp-gate
+
 # Loose local preview/marketing image scratch (not part of the repo)
 /arch-layers.png
 /blog-full.png

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,21 @@ output/
 # Internal research and competitive intelligence — not for public repo
 research/
 linkedin-content.docx
+
+# Local scratch / diagnostic output (never committed)
+.a1.txt
+.audit_out.txt
+.diskdiag*.txt
+.verify.txt
+
+# Loose local preview/marketing image scratch (not part of the repo)
+/arch-layers.png
+/blog-full.png
+/blog-post-full.png
+/comparison-table.png
+/comparison-updated.png
+/hero-preview.png
+/hero2-preview.png
+/postcard.png
+/postcard-square.png
+/postcard-stack.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
   called from within a running event loop (runs the registry lookup in a worker thread).
 
 ### Added
+- **Studio Conversational Builder (Waves 1–4)** — a chat-first agent builder: converse to a
+  validated `agent.yaml`, eject to real code in a sandbox (Claude or Codex engine), and deploy
+  through the governed pipeline, all from one thread. Wave 4 adds a managed **CloudSandbox** over a
+  pluggable backend (`AGENTBREEDER_SANDBOX=cloud`, `AGENTBREEDER_SANDBOX_BACKEND=e2b` via the
+  optional `[cloud]` extra) with per-session microVM isolation, path containment, byte/exec caps,
+  and a default-deny egress allowlist; a PII-free product-analytics funnel (ingest + funnel API with
+  p50/p90 time-to-first-deploy, and a team-scoped **Studio › Builder** view); and a Codex eject
+  gated e2e for engine parity. Cloud deployments meter actual sandbox-minutes (429 pre-check) in the
+  companion `agentbreeder-cloud` change. (#555)
 - **CLI greenfield AWS provisioning** — `agentbreeder deploy --provision` (`-p`) now stands up the
   full AWS footprint (VPC, public/private subnets, NAT gateway, ECS cluster, IAM execution role,
   security groups) before deploying, for accounts with no pre-existing infrastructure. The

--- a/alembic/versions/024_add_builder_sessions.py
+++ b/alembic/versions/024_add_builder_sessions.py
@@ -1,0 +1,49 @@
+"""Add ``builder_sessions`` table (Wave 3 conversational builder).
+
+Revision ID: 024
+Revises: 023
+Create Date: 2026-06-14
+
+Server-side resumable BuilderSession resource backing the Studio conversational
+agent builder's eject-to-code flow. state JSON holds conversation history, the
+evolving agent.yaml, generated files, and the deploy job handle. Tenant-scoped
+by team.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+revision: str = "024"
+down_revision: str | None = "023"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "builder_sessions",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("team", sa.String(100), nullable=False),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("engine", sa.String(20), nullable=False, server_default="claude"),
+        sa.Column("state", sa.JSON(), server_default="{}"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("ix_builder_sessions_team", "builder_sessions", ["team"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_builder_sessions_team", table_name="builder_sessions")
+    op.drop_table("builder_sessions")

--- a/alembic/versions/025_add_analytics_events.py
+++ b/alembic/versions/025_add_analytics_events.py
@@ -1,0 +1,47 @@
+"""Add analytics_events table (W4 funnel).
+
+Revision ID: 025
+Revises: 024
+Create Date: 2026-06-14
+
+Structural product-analytics events backing the Studio Builder funnel view.
+PII-free by design: only event name, engine, team, session_id, and structural
+props are stored (cloud-security §11.2). A retention/TTL job prunes old rows.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+revision: str = "025"
+down_revision: str | None = "024"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "analytics_events",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("event", sa.String(64), nullable=False),
+        sa.Column("engine", sa.String(20), nullable=True),
+        sa.Column("team", sa.String(100), nullable=True),
+        sa.Column("session_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("props", sa.JSON(), server_default="{}"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("ix_analytics_events_event", "analytics_events", ["event"])
+    op.create_index("ix_analytics_events_team", "analytics_events", ["team"])
+    op.create_index("ix_analytics_events_created_at", "analytics_events", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_analytics_events_created_at", table_name="analytics_events")
+    op.drop_index("ix_analytics_events_team", table_name="analytics_events")
+    op.drop_index("ix_analytics_events_event", table_name="analytics_events")
+    op.drop_table("analytics_events")

--- a/api/main.py
+++ b/api/main.py
@@ -17,6 +17,7 @@ from api.routes import (
     approvals,
     audit,
     auth,
+    builder_sessions,
     builders,
     compliance,
     costs,
@@ -191,6 +192,13 @@ from api.routes.deployments import limiter as _deployments_limiter  # noqa: E402
 app.state.limiter = _deployments_limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
+# Builder session SSE bus (Wave 3, spec §6). Set at module load so the bus
+# exists even when the app is used without the lifespan context (e.g. bare
+# TestClient(app) in tests). The lifespan handler re-assigns it on startup.
+from api.services.builder_session_service import SessionEventBus as _SessionEventBus  # noqa: E402
+
+app.state.builder_event_bus = _SessionEventBus()
+
 # CORS
 app.add_middleware(
     CORSMiddleware,
@@ -207,6 +215,7 @@ app.add_middleware(APIVersionMiddleware)
 app.include_router(auth.router)
 app.include_router(agents.router)
 app.include_router(builders.router)
+app.include_router(builder_sessions.router)
 app.include_router(deploys.router)
 app.include_router(deployments.router)
 app.include_router(prompts.router)

--- a/api/main.py
+++ b/api/main.py
@@ -192,9 +192,9 @@ from api.routes.deployments import limiter as _deployments_limiter  # noqa: E402
 app.state.limiter = _deployments_limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
-# Builder session SSE bus (Wave 3, spec §6). Set at module load so the bus
-# exists even when the app is used without the lifespan context (e.g. bare
-# TestClient(app) in tests). The lifespan handler re-assigns it on startup.
+# Builder session SSE bus (Wave 3, spec §6). Set at module load (not in the
+# lifespan handler) so the bus exists even when the app is used without the
+# lifespan context (e.g. bare TestClient(app) in tests).
 from api.services.builder_session_service import SessionEventBus as _SessionEventBus  # noqa: E402
 
 app.state.builder_event_bus = _SessionEventBus()

--- a/api/main.py
+++ b/api/main.py
@@ -14,6 +14,7 @@ from api.routes import (
     a2a,
     agentops,
     agents,
+    analytics,
     approvals,
     audit,
     auth,
@@ -246,6 +247,7 @@ app.include_router(secrets_route.router)
 
 # v2 routes (preview)
 app.include_router(agents_v2.router)
+app.include_router(analytics.router)
 
 
 @app.get("/health")

--- a/api/models/database.py
+++ b/api/models/database.py
@@ -1030,3 +1030,19 @@ class ComplianceScan(Base):
         Index("ix_compliance_scans_ran_at", "ran_at"),
         Index("ix_compliance_scans_overall_status", "overall_status"),
     )
+
+
+class AnalyticsEvent(Base):
+    """Structural product-analytics event (W4). PII-free: no message/prompt bodies."""
+
+    __tablename__ = "analytics_events"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    event: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    engine: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    team: Mapped[str | None] = mapped_column(String(100), nullable=True, index=True)
+    session_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    props: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), index=True
+    )

--- a/api/models/database.py
+++ b/api/models/database.py
@@ -163,6 +163,30 @@ class DeployJob(Base):
     agent: Mapped[Agent] = relationship(back_populates="deploy_jobs")
 
 
+class BuilderSession(Base):
+    """A resumable conversational-builder session (Wave 3).
+
+    state JSON holds: {history: [...], agent_yaml: str|None, files: {path: content},
+    deploy_job_id: str|None, satisfied: [...refs]}. Tenant-scoped by team; deploy
+    still flows through the governed /deploys pipeline (never bypassed)."""
+
+    __tablename__ = "builder_sessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    team: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    engine: Mapped[str] = mapped_column(String(20), default="claude", nullable=False)
+    state: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+
 class Tool(Base):
     """A tool or MCP server in the registry."""
 

--- a/api/models/schemas.py
+++ b/api/models/schemas.py
@@ -1584,8 +1584,8 @@ class AnalyticsEventIngest(BaseModel):
     """PII-free structural product-analytics event (design §11.2)."""
 
     event: str = Field(..., min_length=1, max_length=64)
-    engine: str | None = None
-    session_id: str | None = None
+    engine: str | None = Field(default=None, max_length=20)
+    session_id: uuid.UUID | None = None  # typed -> pydantic 422s on bad UUIDs
     props: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/api/models/schemas.py
+++ b/api/models/schemas.py
@@ -438,6 +438,29 @@ class DeployJobResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class BuilderSessionResponse(BaseModel):
+    id: str
+    team: str
+    engine: str
+    agent_yaml: str | None = None
+    files: dict[str, str] = Field(default_factory=dict)
+    deploy_job_id: str | None = None
+    history: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class BuilderSessionCreateRequest(BaseModel):
+    engine: str = "claude"  # "claude" | "codex"
+
+
+class BuilderMessageRequest(BaseModel):
+    content: str = Field(..., min_length=1, max_length=10_000)
+
+
+class BuilderEjectRequest(BaseModel):
+    instruction: str = Field(..., min_length=1, max_length=4000)
+    engine: str | None = None  # override session engine for this run
+
+
 class DeployLogEntry(BaseModel):
     timestamp: str
     level: str

--- a/api/models/schemas.py
+++ b/api/models/schemas.py
@@ -1575,3 +1575,39 @@ class PrincipalGroupResponse(BaseModel):
 
 class GroupMemberAdd(BaseModel):
     member_id: str = Field(..., description="User email or service_principal ID")
+
+
+# --- Analytics (W4 builder funnel) ---
+
+
+class AnalyticsEventIngest(BaseModel):
+    """PII-free structural product-analytics event (design §11.2)."""
+
+    event: str = Field(..., min_length=1, max_length=64)
+    engine: str | None = None
+    session_id: str | None = None
+    props: dict[str, Any] = Field(default_factory=dict)
+
+
+class FunnelStage(BaseModel):
+    key: str
+    label: str
+    count: int
+    dropoff_pct: float  # vs previous stage; 0.0 for the first
+
+
+class EngineScorecard(BaseModel):
+    engine: str
+    samples: int
+    spec_validity_rate: float
+    deploy_success_rate: float
+    turns_to_spec: float
+    hallucinated_field_rate: float
+
+
+class FunnelMetrics(BaseModel):
+    period: str
+    time_to_first_deploy_p50_s: float | None = None
+    time_to_first_deploy_p90_s: float | None = None
+    stages: list[FunnelStage] = Field(default_factory=list)
+    engines: list[EngineScorecard] = Field(default_factory=list)

--- a/api/routes/analytics.py
+++ b/api/routes/analytics.py
@@ -1,0 +1,140 @@
+"""/api/v1/analytics/* — product funnel ingest + aggregation (W4).
+
+PII rule (design §11.2): events are structural only. The ingest endpoint stores
+event/engine/team/session_id/props; callers must never send message or prompt
+bodies. A retention job (TTL) prunes old rows (see ops runbook).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.auth import get_current_user
+from api.database import get_db
+from api.models.database import AnalyticsEvent, User
+from api.models.schemas import (
+    AnalyticsEventIngest,
+    ApiResponse,
+    EngineScorecard,
+    FunnelMetrics,
+    FunnelStage,
+)
+
+router = APIRouter(prefix="/api/v1", tags=["analytics"])
+
+# Macro-stages shown in the headline funnel (design §11.4 — collapse the 11 raw events).
+_FUNNEL: list[tuple[str, str]] = [
+    ("builder_session_started", "Converse"),
+    ("spec_validated", "Spec validated"),
+    ("eject_to_code_started", "Eject"),
+    ("deploy_started", "Deploy"),
+    ("deploy_succeeded", "Live"),
+]
+
+_PERIODS = {"7d": 7, "30d": 30, "all": 3650}
+
+
+def _percentile(values: list[float], pct: int) -> float | None:
+    """Linear-interpolated percentile; None for an empty sample."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    k = (len(ordered) - 1) * (pct / 100)
+    lo = int(k)
+    hi = min(lo + 1, len(ordered) - 1)
+    if lo == hi:
+        return ordered[lo]
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * (k - lo)
+
+
+def _scorecard_from_rows(
+    *,
+    engine: str,
+    samples: int,
+    valid: int,
+    deployed: int,
+    total_turns: int,
+    hallucinated: int,
+) -> EngineScorecard:
+    def rate(n: int) -> float:
+        return round(n / samples, 4) if samples else 0.0
+
+    return EngineScorecard(
+        engine=engine,
+        samples=samples,
+        spec_validity_rate=rate(valid),
+        deploy_success_rate=rate(deployed),
+        turns_to_spec=round(total_turns / samples, 2) if samples else 0.0,
+        hallucinated_field_rate=rate(hallucinated),
+    )
+
+
+@router.post("/analytics/events", status_code=201)
+async def ingest_event(
+    body: AnalyticsEventIngest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ApiResponse[dict]:
+    row = AnalyticsEvent(
+        event=body.event,
+        engine=body.engine,
+        team=getattr(user, "team", None),
+        session_id=uuid.UUID(body.session_id) if body.session_id else None,
+        props=body.props or {},
+    )
+    db.add(row)
+    await db.commit()
+    return ApiResponse(data={"id": str(row.id)})
+
+
+@router.get("/analytics/funnel")
+async def get_funnel(
+    period: str = Query("7d"),
+    _user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ApiResponse[FunnelMetrics]:
+    days = _PERIODS.get(period, 7)
+    since = datetime.now(UTC) - timedelta(days=days)
+
+    counts: dict[str, int] = {}
+    for key, _label in _FUNNEL:
+        res = await db.execute(
+            select(func.count())
+            .select_from(AnalyticsEvent)
+            .where(AnalyticsEvent.event == key, AnalyticsEvent.created_at >= since)
+        )
+        counts[key] = int(res.scalar_one())
+
+    stages: list[FunnelStage] = []
+    prev: int | None = None
+    for key, label in _FUNNEL:
+        c = counts[key]
+        dropoff = 0.0 if prev in (None, 0) else round((1 - c / prev) * 100, 1)
+        stages.append(FunnelStage(key=key, label=label, count=c, dropoff_pct=dropoff))
+        prev = c
+
+    # p50/p90 time-to-first-deploy from deploy_succeeded props
+    res = await db.execute(
+        select(AnalyticsEvent.props).where(
+            AnalyticsEvent.event == "deploy_succeeded",
+            AnalyticsEvent.created_at >= since,
+        )
+    )
+    times = [
+        float(p["time_to_deploy_s"])
+        for (p,) in res.all()
+        if isinstance(p, dict) and p.get("time_to_deploy_s") is not None
+    ]
+    metrics = FunnelMetrics(
+        period=period,
+        stages=stages,
+        engines=[],  # full per-engine joins are a follow-on; helpers above are unit-covered
+        time_to_first_deploy_p50_s=_percentile(times, 50),
+        time_to_first_deploy_p90_s=_percentile(times, 90),
+    )
+    return ApiResponse(data=metrics)

--- a/api/routes/analytics.py
+++ b/api/routes/analytics.py
@@ -146,7 +146,10 @@ async def get_funnel(
     prev: int | None = None
     for key, label in _FUNNEL:
         c = counts[key]
-        dropoff = 0.0 if prev in (None, 0) else round((1 - c / prev) * 100, 1)
+        if prev is None or prev == 0:
+            dropoff = 0.0
+        else:
+            dropoff = round((1 - c / prev) * 100, 1)
         stages.append(FunnelStage(key=key, label=label, count=c, dropoff_pct=dropoff))
         prev = c
 

--- a/api/routes/analytics.py
+++ b/api/routes/analytics.py
@@ -7,10 +7,10 @@ bodies. A retention job (TTL) prunes old rows (see ops runbook).
 
 from __future__ import annotations
 
-import uuid
+import math
 from datetime import UTC, datetime, timedelta
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -35,6 +35,29 @@ _FUNNEL: list[tuple[str, str]] = [
     ("deploy_started", "Deploy"),
     ("deploy_succeeded", "Live"),
 ]
+
+# Server-side allowlist — mirrors dashboard/src/lib/analytics.ts ANALYTICS_EVENTS.
+# Unknown events are rejected so a client cannot pollute the funnel taxonomy.
+_INGESTABLE_EVENTS: frozenset[str] = frozenset(
+    {
+        "builder_session_started",
+        "user_message_sent",
+        "stack_recommended",
+        "setup_card_shown",
+        "setup_card_completed",
+        "spec_validated",
+        "eject_to_code_started",
+        "eject_to_code_completed",
+        "coding_agent_turn",
+        "deploy_started",
+        "deploy_succeeded",
+        "deploy_failed",
+        "first_invoke",
+    }
+)
+
+# Sane upper bound (7 days, in seconds) so a poisoned props value can't skew p90.
+_MAX_DEPLOY_SECONDS = 604800.0
 
 _PERIODS = {"7d": 7, "30d": 30, "all": 3650}
 
@@ -80,11 +103,13 @@ async def ingest_event(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> ApiResponse[dict]:
+    if body.event not in _INGESTABLE_EVENTS:
+        raise HTTPException(status_code=422, detail=f"unknown analytics event: {body.event!r}")
     row = AnalyticsEvent(
         event=body.event,
         engine=body.engine,
-        team=getattr(user, "team", None),
-        session_id=uuid.UUID(body.session_id) if body.session_id else None,
+        team=getattr(user, "team", None),  # server-stamped; never client-supplied
+        session_id=body.session_id,  # typed uuid.UUID | None (pydantic-validated)
         props=body.props or {},
     )
     db.add(row)
@@ -95,18 +120,25 @@ async def ingest_event(
 @router.get("/analytics/funnel")
 async def get_funnel(
     period: str = Query("7d"),
-    _user: User = Depends(get_current_user),
+    user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> ApiResponse[FunnelMetrics]:
     days = _PERIODS.get(period, 7)
     since = datetime.now(UTC) - timedelta(days=days)
+    # Scope to the caller's team — never expose cross-tenant funnel data. A
+    # global/staff view would be a separate, admin-gated endpoint.
+    team = getattr(user, "team", None)
 
     counts: dict[str, int] = {}
     for key, _label in _FUNNEL:
         res = await db.execute(
             select(func.count())
             .select_from(AnalyticsEvent)
-            .where(AnalyticsEvent.event == key, AnalyticsEvent.created_at >= since)
+            .where(
+                AnalyticsEvent.event == key,
+                AnalyticsEvent.created_at >= since,
+                AnalyticsEvent.team == team,
+            )
         )
         counts[key] = int(res.scalar_one())
 
@@ -118,18 +150,25 @@ async def get_funnel(
         stages.append(FunnelStage(key=key, label=label, count=c, dropoff_pct=dropoff))
         prev = c
 
-    # p50/p90 time-to-first-deploy from deploy_succeeded props
+    # p50/p90 time-to-first-deploy from deploy_succeeded props (team-scoped).
     res = await db.execute(
         select(AnalyticsEvent.props).where(
             AnalyticsEvent.event == "deploy_succeeded",
             AnalyticsEvent.created_at >= since,
+            AnalyticsEvent.team == team,
         )
     )
-    times = [
-        float(p["time_to_deploy_s"])
-        for (p,) in res.all()
-        if isinstance(p, dict) and p.get("time_to_deploy_s") is not None
-    ]
+    # Defensive coercion: ignore non-numeric / non-finite / out-of-range values so a
+    # client-poisoned props field cannot 500 the route or skew the percentile.
+    times: list[float] = []
+    for (p,) in res.all():
+        if not isinstance(p, dict):
+            continue
+        v = p.get("time_to_deploy_s")
+        if isinstance(v, bool) or not isinstance(v, (int, float)):
+            continue
+        if math.isfinite(v) and 0 <= v <= _MAX_DEPLOY_SECONDS:
+            times.append(float(v))
     metrics = FunnelMetrics(
         period=period,
         stages=stages,

--- a/api/routes/builder_sessions.py
+++ b/api/routes/builder_sessions.py
@@ -16,15 +16,22 @@ from api.database import get_db
 from api.models.database import User
 from api.models.schemas import (
     ApiResponse,
+    BuilderEjectRequest,
     BuilderMessageRequest,
     BuilderSessionCreateRequest,
     BuilderSessionResponse,
 )
 from api.routes.builders import _builder_key_name, _no_key_detail
-from api.services.builder_session_service import BuilderSessionService, SessionEventBus
+from api.services.builder_session_service import (
+    BuilderSessionService,
+    CloudSandboxUnavailable,
+    SessionEventBus,
+)
 from engine.providers.anthropic_provider import AnthropicProvider
 from engine.providers.base import AuthenticationError, ProviderError
 from engine.providers.models import ProviderConfig, ProviderType
+from engine.providers.openai_provider import OpenAIProvider
+from engine.sandbox.base import select_sandbox_mode
 from engine.secrets.factory import get_workspace_backend
 
 logger = logging.getLogger(__name__)
@@ -34,6 +41,28 @@ router = APIRouter(prefix="/api/v1/builder/sessions", tags=["builder-sessions"])
 
 def _bus(request: Request) -> SessionEventBus:
     return request.app.state.builder_event_bus
+
+
+def _provider_and_secret(engine_name: str, user: User):
+    """Return (secret_name, provider_factory) for the engine's BYO key."""
+    if engine_name == "codex":
+        secret = f"AGENTBREEDER_CODEX_BUILDER_KEY__{user.id}"
+
+        def make_codex(key: str) -> OpenAIProvider:
+            return OpenAIProvider(
+                ProviderConfig(provider_type=ProviderType.openai, api_key=key)
+            )
+
+        return secret, make_codex
+    # default claude
+    secret = _builder_key_name(user)
+
+    def make_claude(key: str) -> AnthropicProvider:
+        return AnthropicProvider(
+            ProviderConfig(provider_type=ProviderType.anthropic, api_key=key)
+        )
+
+    return secret, make_claude
 
 
 def _to_response(sess: object) -> BuilderSessionResponse:
@@ -130,6 +159,65 @@ async def post_message(
                 "event": "error",
                 "data": json.dumps(
                     {"detail": "Upstream Claude API error.", "code": "upstream_error"}
+                ),
+            }
+        finally:
+            await provider.close()
+
+    return EventSourceResponse(generator())
+
+
+@router.post("/{session_id}/eject")
+async def eject_to_code(
+    session_id: uuid.UUID,
+    body: BuilderEjectRequest,
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> EventSourceResponse:
+    svc = BuilderSessionService(db, _bus(request))
+    sess = await svc.get(session_id, team=user.team)
+    if sess is None:
+        raise HTTPException(status_code=404, detail="Builder session not found")
+
+    engine_name = body.engine or sess.engine
+    if engine_name not in ("claude", "codex"):
+        raise HTTPException(status_code=400, detail="engine must be 'claude' or 'codex'")
+
+    # Fail closed: code execution is only allowed in local sandbox mode. The
+    # 409 fires BEFORE any sandbox/provider/stream is constructed, so the
+    # multi-tenant cloud never runs user code in-process (CloudSandbox is W4).
+    if select_sandbox_mode() != "local":
+        raise HTTPException(
+            status_code=409,
+            detail="Code generation requires local sandbox mode (cloud sandbox lands in Wave 4).",
+        )
+
+    secret_name, make_provider = _provider_and_secret(engine_name, user)
+    backend, _ws = get_workspace_backend()
+    api_key = await backend.get(secret_name)
+    if not api_key:
+        raise HTTPException(status_code=400, detail=_no_key_detail(secret_name))
+
+    async def generator() -> AsyncGenerator[dict, None]:
+        provider = make_provider(api_key)
+        try:
+            async for frame in svc.run_eject(sess, provider, body.instruction, engine_name):
+                yield frame
+        except CloudSandboxUnavailable:
+            logger.warning("builder /eject: sandbox unavailable for session %s", session_id)
+            yield {
+                "event": "error",
+                "data": json.dumps(
+                    {"detail": "Sandbox unavailable.", "code": "sandbox_unavailable"}
+                ),
+            }
+        except (AuthenticationError, ProviderError):
+            logger.warning("builder /eject: provider error for session %s", session_id)
+            yield {
+                "event": "error",
+                "data": json.dumps(
+                    {"detail": "Coding agent provider error.", "code": "provider_error"}
                 ),
             }
         finally:

--- a/api/routes/builder_sessions.py
+++ b/api/routes/builder_sessions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import logging
 import uuid
 from collections.abc import AsyncGenerator
 
@@ -21,8 +23,11 @@ from api.models.schemas import (
 from api.routes.builders import _builder_key_name, _no_key_detail
 from api.services.builder_session_service import BuilderSessionService, SessionEventBus
 from engine.providers.anthropic_provider import AnthropicProvider
+from engine.providers.base import AuthenticationError, ProviderError
 from engine.providers.models import ProviderConfig, ProviderType
 from engine.secrets.factory import get_workspace_backend
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/builder/sessions", tags=["builder-sessions"])
 
@@ -109,6 +114,24 @@ async def post_message(
         try:
             async for frame in svc.run_interview_turn(sess, provider, body.content):
                 yield frame
+        except AuthenticationError:
+            logger.warning(
+                "builder /messages: auth failed for session %s (key not logged)", session_id
+            )
+            yield {
+                "event": "error",
+                "data": json.dumps(
+                    {"detail": "Claude API authentication failed.", "code": "auth_error"}
+                ),
+            }
+        except ProviderError:
+            logger.warning("builder /messages: upstream error for session %s", session_id)
+            yield {
+                "event": "error",
+                "data": json.dumps(
+                    {"detail": "Upstream Claude API error.", "code": "upstream_error"}
+                ),
+            }
         finally:
             await provider.close()
 

--- a/api/routes/builder_sessions.py
+++ b/api/routes/builder_sessions.py
@@ -1,0 +1,76 @@
+"""BuilderSession API (Wave 3, spec §6) — create / get / list (more in C4-C6)."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.auth import get_current_user
+from api.database import get_db
+from api.models.database import User
+from api.models.schemas import (
+    ApiResponse,
+    BuilderSessionCreateRequest,
+    BuilderSessionResponse,
+)
+from api.services.builder_session_service import BuilderSessionService, SessionEventBus
+
+router = APIRouter(prefix="/api/v1/builder/sessions", tags=["builder-sessions"])
+
+
+def _bus(request: Request) -> SessionEventBus:
+    return request.app.state.builder_event_bus
+
+
+def _to_response(sess: object) -> BuilderSessionResponse:
+    st = getattr(sess, "state", None) or {}
+    return BuilderSessionResponse(
+        id=str(sess.id),
+        team=sess.team,
+        engine=sess.engine,
+        agent_yaml=st.get("agent_yaml"),
+        files=st.get("files", {}),
+        deploy_job_id=st.get("deploy_job_id"),
+        history=st.get("history", []),
+    )
+
+
+@router.post("", response_model=ApiResponse[BuilderSessionResponse])
+async def create_session(
+    body: BuilderSessionCreateRequest,
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ApiResponse[BuilderSessionResponse]:
+    if body.engine not in ("claude", "codex"):
+        raise HTTPException(status_code=400, detail="engine must be 'claude' or 'codex'")
+    svc = BuilderSessionService(db, _bus(request))
+    sess = await svc.create(team=user.team, user_id=user.id, engine=body.engine)
+    return ApiResponse(data=_to_response(sess))
+
+
+@router.get("", response_model=ApiResponse[list[BuilderSessionResponse]])
+async def list_sessions(
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ApiResponse[list[BuilderSessionResponse]]:
+    svc = BuilderSessionService(db, _bus(request))
+    rows = await svc.list_for_team(user.team)
+    return ApiResponse(data=[_to_response(s) for s in rows])
+
+
+@router.get("/{session_id}", response_model=ApiResponse[BuilderSessionResponse])
+async def get_session(
+    session_id: uuid.UUID,
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ApiResponse[BuilderSessionResponse]:
+    svc = BuilderSessionService(db, _bus(request))
+    sess = await svc.get(session_id, team=user.team)
+    if sess is None:
+        raise HTTPException(status_code=404, detail="Builder session not found")
+    return ApiResponse(data=_to_response(sess))

--- a/api/routes/builder_sessions.py
+++ b/api/routes/builder_sessions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import uuid
@@ -13,6 +14,7 @@ from sse_starlette.sse import EventSourceResponse
 
 from api.auth import get_current_user
 from api.database import get_db
+from api.middleware.rbac import enforce_team_role
 from api.models.database import User
 from api.models.schemas import (
     ApiResponse,
@@ -20,13 +22,17 @@ from api.models.schemas import (
     BuilderMessageRequest,
     BuilderSessionCreateRequest,
     BuilderSessionResponse,
+    DeployRequest,
 )
 from api.routes.builders import _builder_key_name, _no_key_detail
+from api.routes.deploys import _resolve_deploy_team
+from api.services.audit_service import AuditService
 from api.services.builder_session_service import (
     BuilderSessionService,
     CloudSandboxUnavailable,
     SessionEventBus,
 )
+from api.services.deploy_service import DeployService
 from engine.providers.anthropic_provider import AnthropicProvider
 from engine.providers.base import AuthenticationError, ProviderError
 from engine.providers.models import ProviderConfig, ProviderType
@@ -49,18 +55,14 @@ def _provider_and_secret(engine_name: str, user: User):
         secret = f"AGENTBREEDER_CODEX_BUILDER_KEY__{user.id}"
 
         def make_codex(key: str) -> OpenAIProvider:
-            return OpenAIProvider(
-                ProviderConfig(provider_type=ProviderType.openai, api_key=key)
-            )
+            return OpenAIProvider(ProviderConfig(provider_type=ProviderType.openai, api_key=key))
 
         return secret, make_codex
     # default claude
     secret = _builder_key_name(user)
 
     def make_claude(key: str) -> AnthropicProvider:
-        return AnthropicProvider(
-            ProviderConfig(provider_type=ProviderType.anthropic, api_key=key)
-        )
+        return AnthropicProvider(ProviderConfig(provider_type=ProviderType.anthropic, api_key=key))
 
     return secret, make_claude
 
@@ -163,6 +165,98 @@ async def post_message(
             }
         finally:
             await provider.close()
+
+    return EventSourceResponse(generator())
+
+
+@router.post("/{session_id}/deploy", response_model=ApiResponse[BuilderSessionResponse])
+async def deploy_from_session(
+    session_id: uuid.UUID,
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ApiResponse[BuilderSessionResponse]:
+    """Deploy the session's validated agent.yaml via the governed deploy path.
+
+    This does NOT introduce a parallel deploy pipeline (CLAUDE.md §2 —
+    governance is non-negotiable). It reuses the exact primitives the
+    ``POST /api/v1/deploys`` route uses: ``_resolve_deploy_team`` →
+    ``enforce_team_role`` (the substantive team-scoped RBAC check) →
+    ``DeployService.create_agent_and_deploy`` (the 8-step pipeline that also
+    auto-registers the agent) → ``AuditService.log_event``. The resulting
+    ``deploy_job_id`` is persisted onto the session state so the Studio chat
+    can poll / stream deploy status.
+    """
+    svc = BuilderSessionService(db, _bus(request))
+    sess = await svc.get(session_id, team=user.team)
+    if sess is None:
+        raise HTTPException(status_code=404, detail="Builder session not found")
+    agent_yaml = (sess.state or {}).get("agent_yaml")
+    if not agent_yaml:
+        raise HTTPException(
+            status_code=400, detail="Session has no validated agent.yaml to deploy yet."
+        )
+
+    # Reuse the EXACT governed deploy path (RBAC + pipeline + audit). No bypass.
+    body = DeployRequest(config_yaml=agent_yaml, target="local")
+    team_id, _agent = await _resolve_deploy_team(body, db)
+    await enforce_team_role(user, team_id, "deployer")
+    _new_agent, job = await DeployService.create_agent_and_deploy(
+        db, yaml_content=agent_yaml, target="local"
+    )
+    await AuditService.log_event(
+        actor=user.email,
+        action="deploy.create",
+        resource_type="deploy_job",
+        resource_name=str(job.id),
+        resource_id=str(job.id),
+        team=team_id,
+        details={"agent_id": str(job.agent_id), "target": "local"},
+        ip_address=request.client.host if request.client else None,
+    )
+
+    state = dict(sess.state or {})
+    state["deploy_job_id"] = str(job.id)
+    await svc.save_state(sess, state)
+    await db.commit()
+    return ApiResponse(data=_to_response(sess))
+
+
+@router.get("/{session_id}/stream")
+async def stream_session(
+    session_id: uuid.UUID,
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> EventSourceResponse:
+    """Aggregate SSE feed for a session over the in-memory event bus.
+
+    Subscribes to the session's bus topic and relays every published frame
+    (interview tokens, eject file-changes, deploy progress) to the client.
+    Emits a ``ping`` every 15s of idle to keep the connection alive and to
+    notice client disconnects.
+    """
+    svc = BuilderSessionService(db, _bus(request))
+    sess = await svc.get(session_id, team=user.team)
+    if sess is None:
+        raise HTTPException(status_code=404, detail="Builder session not found")
+    bus = _bus(request)
+
+    async def generator() -> AsyncGenerator[dict, None]:
+        async with bus.subscribe(str(session_id)) as queue:
+            # Flush an immediate frame so response headers are sent right away
+            # (sse-starlette holds headers until the first chunk) and the
+            # client knows the stream is live before any work is published.
+            yield {"event": "ready", "data": json.dumps({"session_id": str(session_id)})}
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    evt = await asyncio.wait_for(queue.get(), timeout=15)
+                except TimeoutError:
+                    yield {"event": "ping", "data": ""}
+                    continue
+                yield evt
 
     return EventSourceResponse(generator())
 

--- a/api/routes/builder_sessions.py
+++ b/api/routes/builder_sessions.py
@@ -3,19 +3,26 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import AsyncGenerator
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
+from sse_starlette.sse import EventSourceResponse
 
 from api.auth import get_current_user
 from api.database import get_db
 from api.models.database import User
 from api.models.schemas import (
     ApiResponse,
+    BuilderMessageRequest,
     BuilderSessionCreateRequest,
     BuilderSessionResponse,
 )
+from api.routes.builders import _builder_key_name, _no_key_detail
 from api.services.builder_session_service import BuilderSessionService, SessionEventBus
+from engine.providers.anthropic_provider import AnthropicProvider
+from engine.providers.models import ProviderConfig, ProviderType
+from engine.secrets.factory import get_workspace_backend
 
 router = APIRouter(prefix="/api/v1/builder/sessions", tags=["builder-sessions"])
 
@@ -74,3 +81,35 @@ async def get_session(
     if sess is None:
         raise HTTPException(status_code=404, detail="Builder session not found")
     return ApiResponse(data=_to_response(sess))
+
+
+@router.post("/{session_id}/messages")
+async def post_message(
+    session_id: uuid.UUID,
+    body: BuilderMessageRequest,
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> EventSourceResponse:
+    svc = BuilderSessionService(db, _bus(request))
+    sess = await svc.get(session_id, team=user.team)
+    if sess is None:
+        raise HTTPException(status_code=404, detail="Builder session not found")
+
+    secret_name = _builder_key_name(user)
+    backend, _ws = get_workspace_backend()
+    api_key = await backend.get(secret_name)
+    if not api_key:
+        raise HTTPException(status_code=400, detail=_no_key_detail(secret_name))
+
+    async def generator() -> AsyncGenerator[dict, None]:
+        provider = AnthropicProvider(
+            ProviderConfig(provider_type=ProviderType.anthropic, api_key=api_key)
+        )
+        try:
+            async for frame in svc.run_interview_turn(sess, provider, body.content):
+                yield frame
+        finally:
+            await provider.close()
+
+    return EventSourceResponse(generator())

--- a/api/routes/builder_sessions.py
+++ b/api/routes/builder_sessions.py
@@ -201,9 +201,12 @@ async def deploy_from_session(
     body = DeployRequest(config_yaml=agent_yaml, target="local")
     team_id, _agent = await _resolve_deploy_team(body, db)
     await enforce_team_role(user, team_id, "deployer")
-    _new_agent, job = await DeployService.create_agent_and_deploy(
-        db, yaml_content=agent_yaml, target="local"
-    )
+    try:
+        _new_agent, job = await DeployService.create_agent_and_deploy(
+            db, yaml_content=agent_yaml, target="local"
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
     await AuditService.log_event(
         actor=user.email,
         action="deploy.create",
@@ -236,11 +239,11 @@ async def stream_session(
     Emits a ``ping`` every 15s of idle to keep the connection alive and to
     notice client disconnects.
     """
-    svc = BuilderSessionService(db, _bus(request))
+    bus = _bus(request)
+    svc = BuilderSessionService(db, bus)
     sess = await svc.get(session_id, team=user.team)
     if sess is None:
         raise HTTPException(status_code=404, detail="Builder session not found")
-    bus = _bus(request)
 
     async def generator() -> AsyncGenerator[dict, None]:
         async with bus.subscribe(str(session_id)) as queue:

--- a/api/routes/builders.py
+++ b/api/routes/builders.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+from collections.abc import AsyncGenerator
+from dataclasses import asdict
 from pathlib import Path
 from typing import Any, Literal
 
@@ -13,13 +15,19 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import PlainTextResponse
 from jsonschema import Draft202012Validator
 from pydantic import BaseModel, Field, field_validator
+from sse_starlette.sse import EventSourceResponse
 from starlette.concurrency import run_in_threadpool
 
 from api.auth import get_current_user
 from api.middleware.rbac import require_role
 from api.models.database import User
 from api.models.schemas import ApiResponse
-from engine.agent_chat_builder import MAX_HISTORY_MESSAGES, ChatTurnResult, run_chat_turn
+from engine.agent_chat_builder import (
+    MAX_HISTORY_MESSAGES,
+    ChatTurnResult,
+    run_chat_turn,
+    run_chat_turn_stream,
+)
 from engine.providers.anthropic_provider import AnthropicProvider
 from engine.providers.base import AuthenticationError, ProviderError
 from engine.providers.models import ProviderConfig, ProviderType
@@ -57,6 +65,13 @@ def _load_schema(resource_type: str) -> dict[str, Any]:
     schema = json.loads(schema_file.read_text())
     _SCHEMA_CACHE[resource_type] = schema
     return schema
+
+
+def _no_key_detail(secret_name: str) -> str:
+    return (
+        "No Claude key connected. Add your Claude API key in "
+        f"Settings → Secrets as '{secret_name}'."
+    )
 
 
 def _validate_resource_type(resource_type: str) -> None:
@@ -398,12 +413,7 @@ async def chat_build(
     if not api_key:
         raise HTTPException(
             status_code=400,
-            detail=(
-                "No Claude key connected. "
-                "Add your Claude API key to chat-to-build: "
-                "go to Settings → Secrets and create "
-                f"'{secret_name}'."
-            ),
+            detail=_no_key_detail(secret_name),
         )
 
     # ── 2. Construct a fresh provider with the BYO key ───────────────────
@@ -466,3 +476,64 @@ async def chat_build(
         await provider.close()
 
     return ApiResponse(data=result)
+
+
+@router.post("/chat/stream")
+async def chat_build_stream(
+    body: ChatBuildRequest,
+    current_user: User = Depends(get_current_user),
+) -> EventSourceResponse:
+    """Streaming variant of POST /builders/chat.
+
+    Identical BYO-key security contract: the key is read server-side from the
+    workspace secrets backend (AGENTBREEDER_CLAUDE_BUILDER_KEY__{user.id}),
+    never stored, never returned, never logged. Emits SSE events:
+      - "token": {"text": "..."}   incremental assistant text
+      - "done":  the final ChatTurnResult as JSON
+      - "error": {"detail": "..."} on upstream/auth failure
+    """
+    secret_name = _builder_key_name(current_user)
+    backend, _ws = get_workspace_backend()
+    api_key: str | None = await backend.get(secret_name)
+    if not api_key:
+        raise HTTPException(
+            status_code=400,
+            detail=_no_key_detail(secret_name),
+        )
+
+    history = [{"role": m.role, "content": m.content} for m in body.messages]
+
+    async def generator() -> AsyncGenerator[dict[str, str], None]:
+        provider = None
+        try:
+            provider = AnthropicProvider(
+                ProviderConfig(provider_type=ProviderType.anthropic, api_key=api_key)
+            )
+            async for evt in run_chat_turn_stream(provider, history):
+                if evt.type == "token":
+                    yield {"event": "token", "data": json.dumps({"text": evt.text})}
+                elif evt.type == "setup_request" and evt.setup is not None:
+                    yield {"event": "setup_request", "data": json.dumps(asdict(evt.setup))}
+                elif evt.type == "done" and evt.result is not None:
+                    yield {"event": "done", "data": json.dumps(asdict(evt.result))}
+        except AuthenticationError:
+            logger.warning(
+                "chat_build_stream: auth failed for '%s' (key not logged)", secret_name
+            )
+            yield {
+                "event": "error",
+                "data": json.dumps({"detail": "Claude API authentication failed.", "code": "auth_error"}),
+            }
+        except ProviderError:
+            logger.warning(
+                "chat_build_stream: upstream error for '%s'.", secret_name
+            )
+            yield {
+                "event": "error",
+                "data": json.dumps({"detail": "Upstream Claude API error.", "code": "upstream_error"}),
+            }
+        finally:
+            if provider is not None:
+                await provider.close()
+
+    return EventSourceResponse(generator())

--- a/api/routes/builders.py
+++ b/api/routes/builders.py
@@ -517,20 +517,20 @@ async def chat_build_stream(
                 elif evt.type == "done" and evt.result is not None:
                     yield {"event": "done", "data": json.dumps(asdict(evt.result))}
         except AuthenticationError:
-            logger.warning(
-                "chat_build_stream: auth failed for '%s' (key not logged)", secret_name
-            )
+            logger.warning("chat_build_stream: auth failed for '%s' (key not logged)", secret_name)
             yield {
                 "event": "error",
-                "data": json.dumps({"detail": "Claude API authentication failed.", "code": "auth_error"}),
+                "data": json.dumps(
+                    {"detail": "Claude API authentication failed.", "code": "auth_error"}
+                ),
             }
         except ProviderError:
-            logger.warning(
-                "chat_build_stream: upstream error for '%s'.", secret_name
-            )
+            logger.warning("chat_build_stream: upstream error for '%s'.", secret_name)
             yield {
                 "event": "error",
-                "data": json.dumps({"detail": "Upstream Claude API error.", "code": "upstream_error"}),
+                "data": json.dumps(
+                    {"detail": "Upstream Claude API error.", "code": "upstream_error"}
+                ),
             }
         finally:
             if provider is not None:

--- a/api/services/builder_session_service.py
+++ b/api/services/builder_session_service.py
@@ -98,10 +98,17 @@ class BuilderSessionService:
                 r = evt.result
                 if r.agent_yaml:
                     state["agent_yaml"] = r.agent_yaml
-                    yield {"event": "spec_update", "data": _json(
-                        {"agent_yaml": r.agent_yaml, "valid": r.valid, "errors": r.errors})}
+                    yield {
+                        "event": "spec_update",
+                        "data": _json(
+                            {"agent_yaml": r.agent_yaml, "valid": r.valid, "errors": r.errors}
+                        ),
+                    }
                 history.append({"role": "assistant", "content": r.assistant_message})
                 yield {"event": "done", "data": _json(asdict(r))}
 
         state["history"] = history
         await self.save_state(sess, state)
+        # Durable commit: the streaming response can outlive get_db's commit
+        # timing, so flush alone is not enough — persist explicitly here.
+        await self._db.commit()

--- a/api/services/builder_session_service.py
+++ b/api/services/builder_session_service.py
@@ -1,0 +1,77 @@
+"""BuilderSession persistence, the per-session SSE event bus, and (in later
+C-tasks) orchestration of interview / eject / deploy turns. Mirrors the
+deploy event-bus pattern.
+
+Governance: the coding agent writes into a sandbox; nothing is auto-deployed.
+Deploy still flows through the existing /deploys pipeline (Parse -> RBAC ->
+Resolve -> Build -> Provision -> Deploy -> Health -> Register)."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.models.database import BuilderSession
+
+
+class SessionEventBus:
+    """In-process pub/sub keyed by session id (swap for Redis in cloud, W4)."""
+
+    def __init__(self) -> None:
+        self._subs: dict[str, set[asyncio.Queue[dict[str, str]]]] = {}
+
+    @contextlib.asynccontextmanager
+    async def subscribe(self, sid: str) -> AsyncIterator[asyncio.Queue[dict[str, str]]]:
+        q: asyncio.Queue[dict[str, str]] = asyncio.Queue()
+        self._subs.setdefault(sid, set()).add(q)
+        try:
+            yield q
+        finally:
+            self._subs.get(sid, set()).discard(q)
+
+    async def publish(self, sid: str, event: dict[str, str]) -> None:
+        for q in list(self._subs.get(sid, set())):
+            await q.put(event)
+
+
+class BuilderSessionService:
+    def __init__(self, db: AsyncSession, bus: SessionEventBus) -> None:
+        self._db = db
+        self._bus = bus
+
+    async def create(self, *, team: str, user_id: uuid.UUID, engine: str) -> BuilderSession:
+        sess = BuilderSession(
+            team=team,
+            user_id=user_id,
+            engine=engine,
+            state={
+                "history": [],
+                "agent_yaml": None,
+                "files": {},
+                "deploy_job_id": None,
+                "satisfied": [],
+            },
+        )
+        self._db.add(sess)
+        await self._db.flush()
+        return sess
+
+    async def get(self, sid: uuid.UUID, *, team: str) -> BuilderSession | None:
+        row = await self._db.get(BuilderSession, sid)
+        if row is None or row.team != team:
+            return None
+        return row
+
+    async def list_for_team(self, team: str) -> list[BuilderSession]:
+        res = await self._db.execute(select(BuilderSession).where(BuilderSession.team == team))
+        return list(res.scalars().all())
+
+    async def save_state(self, sess: BuilderSession, state: dict[str, Any]) -> None:
+        sess.state = state
+        await self._db.flush()

--- a/api/services/builder_session_service.py
+++ b/api/services/builder_session_service.py
@@ -21,10 +21,26 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.models.database import BuilderSession
 from engine.agent_chat_builder import run_chat_turn_stream
+from engine.coding_agent.engines import engine_for
+from engine.sandbox.base import select_sandbox_mode
+from engine.sandbox.local import LocalSandbox
 
 
 def _json(obj: Any) -> str:
     return _jsonlib.dumps(obj)
+
+
+class CloudSandboxUnavailable(RuntimeError):  # noqa: N818 — semantic name; not an error suffix
+    """Cloud sandbox selected but not available yet (Wave 4)."""
+
+
+def _make_sandbox() -> LocalSandbox:
+    mode = select_sandbox_mode()
+    if mode == "local":
+        return LocalSandbox()
+    if mode == "cloud":
+        raise CloudSandboxUnavailable("CloudSandbox is not available yet (Wave 4)")
+    raise CloudSandboxUnavailable("Sandbox is disabled (AGENTBREEDER_SANDBOX=disabled)")
 
 
 class SessionEventBus:
@@ -112,3 +128,40 @@ class BuilderSessionService:
         # Durable commit: the streaming response can outlive get_db's commit
         # timing, so flush alone is not enough — persist explicitly here.
         await self._db.commit()
+
+    async def run_eject(self, sess, provider, instruction: str, engine_name: str):
+        """Run the coding agent in a sandbox; stream events; persist files."""
+        sandbox = _make_sandbox()
+        state = dict(sess.state or {})
+        for path, content in (state.get("files") or {}).items():
+            await sandbox.write(path, content)
+        if state.get("agent_yaml"):
+            await sandbox.write("agent.yaml", state["agent_yaml"])
+
+        engine = engine_for(engine_name, provider=provider)
+        try:
+            async for evt in engine.run(instruction, state.get("history", []), sandbox):
+                if evt.type == "token":
+                    yield {"event": "token", "data": _json({"text": evt.text})}
+                elif evt.type == "tool_call":
+                    yield {"event": "tool_call", "data": _json({"tool": evt.tool_name})}
+                elif evt.type == "file_change":
+                    try:
+                        content = await sandbox.read(evt.path)
+                    except FileNotFoundError:
+                        content = ""
+                    yield {
+                        "event": "file_change",
+                        "data": _json(
+                            {"path": evt.path, "diff": evt.diff, "content": content}
+                        ),
+                    }
+                elif evt.type == "done":
+                    yield {"event": "complete", "data": _json({"summary": evt.text})}
+                elif evt.type == "error":
+                    yield {"event": "error", "data": _json({"detail": evt.error})}
+            state["files"] = {p: await sandbox.read(p) for p in await sandbox.list(".")}
+            await self.save_state(sess, state)
+            await self._db.commit()
+        finally:
+            await sandbox.close()

--- a/api/services/builder_session_service.py
+++ b/api/services/builder_session_service.py
@@ -10,14 +10,21 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json as _jsonlib
 import uuid
 from collections.abc import AsyncIterator
+from dataclasses import asdict
 from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.models.database import BuilderSession
+from engine.agent_chat_builder import run_chat_turn_stream
+
+
+def _json(obj: Any) -> str:
+    return _jsonlib.dumps(obj)
 
 
 class SessionEventBus:
@@ -75,3 +82,26 @@ class BuilderSessionService:
     async def save_state(self, sess: BuilderSession, state: dict[str, Any]) -> None:
         sess.state = state
         await self._db.flush()
+
+    async def run_interview_turn(self, sess, provider, user_text: str):
+        """Async-generate SSE frames for one interview turn; persists history."""
+        state = dict(sess.state or {})
+        history = list(state.get("history", []))
+        history.append({"role": "user", "content": user_text})
+
+        async for evt in run_chat_turn_stream(provider, history):
+            if evt.type == "token":
+                yield {"event": "token", "data": _json({"text": evt.text})}
+            elif evt.type == "setup_request" and evt.setup is not None:
+                yield {"event": "setup_request", "data": _json(asdict(evt.setup))}
+            elif evt.type == "done" and evt.result is not None:
+                r = evt.result
+                if r.agent_yaml:
+                    state["agent_yaml"] = r.agent_yaml
+                    yield {"event": "spec_update", "data": _json(
+                        {"agent_yaml": r.agent_yaml, "valid": r.valid, "errors": r.errors})}
+                history.append({"role": "assistant", "content": r.assistant_message})
+                yield {"event": "done", "data": _json(asdict(r))}
+
+        state["history"] = history
+        await self.save_state(sess, state)

--- a/api/services/builder_session_service.py
+++ b/api/services/builder_session_service.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json as _jsonlib
+import time
 import uuid
 from collections.abc import AsyncIterator
 from dataclasses import asdict
@@ -22,7 +23,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.models.database import BuilderSession
 from engine.agent_chat_builder import run_chat_turn_stream
 from engine.coding_agent.engines import engine_for
-from engine.sandbox.base import select_sandbox_mode
+from engine.sandbox.backends import make_backend_from_env
+from engine.sandbox.base import Sandbox, select_sandbox_mode
+from engine.sandbox.cloud import CloudSandbox
 from engine.sandbox.local import LocalSandbox
 
 
@@ -34,12 +37,12 @@ class CloudSandboxUnavailable(RuntimeError):  # noqa: N818 — semantic name; no
     """Cloud sandbox selected but not available yet (Wave 4)."""
 
 
-def _make_sandbox() -> LocalSandbox:
+def _make_sandbox() -> Sandbox:
     mode = select_sandbox_mode()
     if mode == "local":
         return LocalSandbox()
     if mode == "cloud":
-        raise CloudSandboxUnavailable("CloudSandbox is not available yet (Wave 4)")
+        return CloudSandbox(make_backend_from_env())
     raise CloudSandboxUnavailable("Sandbox is disabled (AGENTBREEDER_SANDBOX=disabled)")
 
 
@@ -139,6 +142,7 @@ class BuilderSessionService:
             await sandbox.write("agent.yaml", state["agent_yaml"])
 
         engine = engine_for(engine_name, provider=provider)
+        t0 = time.monotonic()
         try:
             async for evt in engine.run(instruction, state.get("history", []), sandbox):
                 if evt.type == "token":
@@ -152,14 +156,24 @@ class BuilderSessionService:
                         content = ""
                     yield {
                         "event": "file_change",
-                        "data": _json(
-                            {"path": evt.path, "diff": evt.diff, "content": content}
-                        ),
+                        "data": _json({"path": evt.path, "diff": evt.diff, "content": content}),
                     }
                 elif evt.type == "done":
-                    yield {"event": "complete", "data": _json({"summary": evt.text})}
+                    yield {
+                        "event": "complete",
+                        "data": _json(
+                            {
+                                "summary": evt.text,
+                                "code": "ok",
+                                "sandbox_seconds": round(time.monotonic() - t0, 3),
+                            }
+                        ),
+                    }
                 elif evt.type == "error":
-                    yield {"event": "error", "data": _json({"detail": evt.error})}
+                    yield {
+                        "event": "error",
+                        "data": _json({"detail": evt.error, "code": "engine_error"}),
+                    }
             state["files"] = {p: await sandbox.read(p) for p in await sandbox.list(".")}
             await self.save_state(sess, state)
             await self._db.commit()

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -59,6 +59,7 @@ import IncidentsPage from "@/pages/incidents";
 import CompliancePage from "@/pages/compliance";
 import DeployWizardPage from "@/pages/deploy-wizard";
 import AgentWizardPage from "@/pages/agent-wizard";
+import BuilderInsightsPage from "@/pages/builder-insights";
 import { Loader2 } from "lucide-react";
 
 const queryClient = new QueryClient({
@@ -177,6 +178,7 @@ export default function App() {
               <Route path="teams" element={<TeamsPage />} />
               <Route path="teams/:id" element={<TeamDetailPage />} />
               <Route path="costs" element={<CostsPage />} />
+              <Route path="builder-insights" element={<BuilderInsightsPage />} />
               <Route path="budgets" element={<BudgetsPage />} />
               <Route path="audit" element={<AuditPage />} />
               <Route path="lineage" element={<LineagePage />} />

--- a/dashboard/src/components/agent-wizard/ChatBuildPanel.test.tsx
+++ b/dashboard/src/components/agent-wizard/ChatBuildPanel.test.tsx
@@ -677,6 +677,65 @@ describe("ChatBuildPanel — eject to code", () => {
     expect(screen.getByText("agent.py")).toBeInTheDocument();
   });
 
+  it("emits the eject funnel analytics events", async () => {
+    vi.mocked(api.builders.chatStream).mockImplementation(async (_m, onEvent) => {
+      onEvent("done", { assistant_message: "", agent_yaml: VALID_YAML, valid: true, errors: [] });
+    });
+    vi.mocked(api.builderSessions.create).mockResolvedValue(
+      apiResp({
+        id: "sess-analytics",
+        team: "engineering",
+        engine: "claude",
+        agent_yaml: VALID_YAML,
+        files: {},
+        deploy_job_id: null,
+        history: [],
+      } as never),
+    );
+    vi.mocked(api.builderSessions.eject).mockImplementation(
+      async (_id: string, _instruction: string, onEvent: (e: string, d: unknown) => void) => {
+        onEvent("file_change", { path: "agent.py", diff: "+x", content: "print('hi')\n" });
+        onEvent("complete", { summary: "done" });
+      },
+    );
+
+    // Spy on the CustomEvent dispatch that track() uses.
+    const events: { event: string; props: Record<string, unknown> }[] = [];
+    const dispatchSpy = vi
+      .spyOn(window, "dispatchEvent")
+      .mockImplementation((e: Event) => {
+        if (e instanceof CustomEvent && e.type === "agentbreeder:analytics") {
+          events.push(e.detail);
+        }
+        return true;
+      });
+
+    try {
+      renderPanel();
+      fireEvent.change(await screen.findByTestId("chat-input"), { target: { value: "build it" } });
+      fireEvent.click(screen.getByTestId("send-btn"));
+
+      const ejectBtn = await screen.findByTestId("eject-code-btn");
+      fireEvent.click(ejectBtn);
+
+      await waitFor(() =>
+        expect(events.map((e) => e.event)).toEqual(
+          expect.arrayContaining([
+            "eject_to_code_started",
+            "coding_agent_turn",
+            "eject_to_code_completed",
+          ]),
+        ),
+      );
+      const started = events.find((e) => e.event === "eject_to_code_started");
+      expect(started?.props).toMatchObject({ engine: "claude" });
+      const turn = events.find((e) => e.event === "coding_agent_turn");
+      expect(turn?.props).toMatchObject({ path: "agent.py" });
+    } finally {
+      dispatchSpy.mockRestore();
+    }
+  });
+
   it("surfaces an error when eject emits an error event", async () => {
     vi.mocked(api.builders.chatStream).mockImplementation(async (_m, onEvent) => {
       onEvent("done", { assistant_message: "", agent_yaml: VALID_YAML, valid: true, errors: [] });

--- a/dashboard/src/components/agent-wizard/ChatBuildPanel.test.tsx
+++ b/dashboard/src/components/agent-wizard/ChatBuildPanel.test.tsx
@@ -676,4 +676,100 @@ describe("ChatBuildPanel — eject to code", () => {
     fireEvent.click(screen.getByTestId("artifact-tab-code"));
     expect(screen.getByText("agent.py")).toBeInTheDocument();
   });
+
+  it("surfaces an error when eject emits an error event", async () => {
+    vi.mocked(api.builders.chatStream).mockImplementation(async (_m, onEvent) => {
+      onEvent("done", { assistant_message: "", agent_yaml: VALID_YAML, valid: true, errors: [] });
+    });
+    vi.mocked(api.builderSessions.create).mockResolvedValue(
+      apiResp({
+        id: "sess-err",
+        team: "engineering",
+        engine: "claude",
+        agent_yaml: VALID_YAML,
+        files: {},
+        deploy_job_id: null,
+        history: [],
+      } as never),
+    );
+    vi.mocked(api.builderSessions.eject).mockImplementation(
+      async (_id: string, _instruction: string, onEvent: (e: string, d: unknown) => void) => {
+        onEvent("error", { detail: "boom" });
+      },
+    );
+
+    renderPanel();
+    fireEvent.change(await screen.findByTestId("chat-input"), { target: { value: "build it" } });
+    fireEvent.click(screen.getByTestId("send-btn"));
+
+    const ejectBtn = await screen.findByTestId("eject-code-btn");
+    fireEvent.click(ejectBtn);
+
+    // The error is surfaced via the chat error banner (same path as sendError).
+    await waitFor(() => expect(screen.getByText("boom")).toBeInTheDocument());
+  });
+
+  it("reuses a single builder session across multiple ejects", async () => {
+    vi.mocked(api.builders.chatStream).mockImplementation(async (_m, onEvent) => {
+      onEvent("done", { assistant_message: "", agent_yaml: VALID_YAML, valid: true, errors: [] });
+    });
+    vi.mocked(api.builderSessions.create).mockResolvedValue(
+      apiResp({
+        id: "sess-reuse",
+        team: "engineering",
+        engine: "claude",
+        agent_yaml: VALID_YAML,
+        files: {},
+        deploy_job_id: null,
+        history: [],
+      } as never),
+    );
+    vi.mocked(api.builderSessions.eject).mockImplementation(
+      async (_id: string, _instruction: string, onEvent: (e: string, d: unknown) => void) => {
+        onEvent("file_change", { path: "agent.py", diff: "+x", content: "print('hi')\n" });
+        onEvent("complete", { summary: "done" });
+      },
+    );
+
+    renderPanel();
+    fireEvent.change(await screen.findByTestId("chat-input"), { target: { value: "build it" } });
+    fireEvent.click(screen.getByTestId("send-btn"));
+
+    // First eject (button lives on the Spec tab).
+    const ejectBtn = await screen.findByTestId("eject-code-btn");
+    fireEvent.click(ejectBtn);
+    await waitFor(() => expect(api.builderSessions.create).toHaveBeenCalledTimes(1));
+    // Eject auto-switches to the Code tab; go back to Spec to eject again.
+    await waitFor(() => expect(screen.getByText("agent.py")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("artifact-tab-spec"));
+
+    // Second eject reuses the session — create is NOT called again.
+    fireEvent.click(screen.getByTestId("eject-code-btn"));
+    await waitFor(() => expect(api.builderSessions.eject).toHaveBeenCalledTimes(2));
+    expect(api.builderSessions.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("Deploy tab shows deploy controls but not the spec YAML", async () => {
+    vi.mocked(api.builders.chatStream).mockImplementation(async (_m, onEvent) => {
+      onEvent("done", { assistant_message: "", agent_yaml: VALID_YAML, valid: true, errors: [] });
+    });
+
+    renderPanel();
+    fireEvent.change(await screen.findByTestId("chat-input"), { target: { value: "build it" } });
+    fireEvent.click(screen.getByTestId("send-btn"));
+
+    // Spec tab (default) shows the YAML preview + Create/Eject controls.
+    await waitFor(() => expect(screen.getByTestId("create-agent-btn")).toBeInTheDocument());
+    expect(screen.getByText(/owner: alice@example.com/)).toBeInTheDocument();
+    expect(screen.getByTestId("eject-code-btn")).toBeInTheDocument();
+
+    // Switch to the Deploy tab.
+    fireEvent.click(screen.getByTestId("artifact-tab-deploy"));
+
+    // Deploy controls remain; spec YAML and Create/Eject are hidden.
+    expect(screen.getByTestId("deploy-agent-btn")).toBeInTheDocument();
+    expect(screen.queryByText(/owner: alice@example.com/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("create-agent-btn")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("eject-code-btn")).not.toBeInTheDocument();
+  });
 });

--- a/dashboard/src/components/agent-wizard/ChatBuildPanel.test.tsx
+++ b/dashboard/src/components/agent-wizard/ChatBuildPanel.test.tsx
@@ -5,12 +5,12 @@
  */
 // React import omitted — JSX transform handles it automatically
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { api } from "@/lib/api";
 import { ChatBuildPanel } from "./ChatBuildPanel";
-import type { SecretSummary, ChatBuildResult, ApiResponse, ApiMeta } from "@/lib/api";
+import type { SecretSummary, ApiResponse, ApiMeta } from "@/lib/api";
 
 // ---------------------------------------------------------------------------
 // Mock the API module
@@ -24,9 +24,18 @@ vi.mock("@/lib/api", () => ({
     },
     builders: {
       chat: vi.fn(),
+      chatStream: vi.fn(),
     },
     agents: {
       fromYaml: vi.fn(),
+    },
+    deploys: {
+      create: vi.fn(),
+      getDetail: vi.fn(),
+    },
+    mcpServers: {
+      create: vi.fn(),
+      discover: vi.fn(),
     },
   },
 }));
@@ -93,18 +102,14 @@ function withKeyResponse() {
   return Promise.resolve(apiResp([makeSummary(BUILDER_KEY_SECRET)]));
 }
 
-function chatResp(result: ChatBuildResult): ApiResponse<ChatBuildResult> {
-  return apiResp(result);
-}
-
-function renderPanel() {
+function renderPanel(initialPrompt?: string) {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
   return render(
     <QueryClientProvider client={qc}>
       <MemoryRouter>
-        <ChatBuildPanel />
+        <ChatBuildPanel initialPrompt={initialPrompt} />
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -212,13 +217,14 @@ describe("ChatBuildPanel — chat", () => {
   });
 
   it("sends a message and shows the assistant reply", async () => {
-    const chatResult: ChatBuildResult = {
-      assistant_message: "What framework would you like?",
-      agent_yaml: null,
-      valid: false,
-      errors: [],
-    };
-    vi.mocked(api.builders.chat).mockResolvedValue(chatResp(chatResult));
+    vi.mocked(api.builders.chatStream).mockImplementation(async (_m, onEvent) => {
+      onEvent("done", {
+        assistant_message: "What framework would you like?",
+        agent_yaml: null,
+        valid: false,
+        errors: [],
+      });
+    });
 
     renderPanel();
 
@@ -234,10 +240,10 @@ describe("ChatBuildPanel — chat", () => {
     });
   });
 
-  it("calls builders.chat with the correct message history", async () => {
-    vi.mocked(api.builders.chat).mockResolvedValue(
-      chatResp({ assistant_message: "Got it!", agent_yaml: null, valid: false, errors: [] }),
-    );
+  it("calls builders.chatStream with the correct message history", async () => {
+    vi.mocked(api.builders.chatStream).mockImplementation(async (_m, onEvent) => {
+      onEvent("done", { assistant_message: "Got it!", agent_yaml: null, valid: false, errors: [] });
+    });
 
     renderPanel();
 
@@ -249,16 +255,17 @@ describe("ChatBuildPanel — chat", () => {
     fireEvent.click(screen.getByTestId("send-btn"));
 
     await waitFor(() => {
-      expect(api.builders.chat).toHaveBeenCalledWith([
-        { role: "user", content: "Build a data agent" },
-      ]);
+      expect(api.builders.chatStream).toHaveBeenCalledWith(
+        [{ role: "user", content: "Build a data agent" }],
+        expect.any(Function),
+      );
     });
   });
 
   it("clears input after sending", async () => {
-    vi.mocked(api.builders.chat).mockResolvedValue(
-      chatResp({ assistant_message: "Ok!", agent_yaml: null, valid: false, errors: [] }),
-    );
+    vi.mocked(api.builders.chatStream).mockImplementation(async (_m, onEvent) => {
+      onEvent("done", { assistant_message: "Ok!", agent_yaml: null, valid: false, errors: [] });
+    });
 
     renderPanel();
     await waitFor(() => expect(screen.getByTestId("chat-input")).toBeInTheDocument());
@@ -270,6 +277,63 @@ describe("ChatBuildPanel — chat", () => {
     await waitFor(() => {
       expect(textarea.value).toBe("");
     });
+  });
+
+  it("renders an inline setup card and continues the thread after it is completed", async () => {
+    // First turn emits a setup_request (secret); second turn (after the card is
+    // satisfied) returns a plain reply. The confirmation message must be threaded
+    // into the second chatStream call's history.
+    let call = 0;
+    vi.mocked(api.builders.chatStream).mockImplementation(async (_m, onEvent) => {
+      call += 1;
+      if (call === 1) {
+        onEvent("setup_request", { kind: "secret", name: "ZENDESK_API_KEY", reason: "read tickets" });
+        onEvent("done", { assistant_message: "", agent_yaml: null, valid: false, errors: [] });
+      } else {
+        onEvent("done", { assistant_message: "Great, all set!", agent_yaml: null, valid: false, errors: [] });
+      }
+    });
+    vi.mocked(api.secrets.create).mockResolvedValue(apiResp(makeSummary("ZENDESK_API_KEY")));
+
+    renderPanel();
+    await waitFor(() => expect(screen.getByTestId("chat-input")).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId("chat-input"), {
+      target: { value: "a support agent that reads Zendesk" },
+    });
+    fireEvent.click(screen.getByTestId("send-btn"));
+
+    // The inline setup card appears.
+    const card = await screen.findByTestId("setup-card");
+    expect(within(card).getByText(/read tickets/i)).toBeInTheDocument();
+
+    // Provide the secret and connect.
+    fireEvent.change(within(card).getByTestId("setup-secret-input"), {
+      target: { value: "sk-zendesk-abc" },
+    });
+    fireEvent.click(within(card).getByTestId("setup-card-submit"));
+
+    await waitFor(() =>
+      expect(api.secrets.create).toHaveBeenCalledWith({
+        name: "ZENDESK_API_KEY",
+        value: "sk-zendesk-abc",
+      }),
+    );
+
+    // The conversation continues: a 2nd chatStream call whose history carries the
+    // confirmation user message referencing the secret name.
+    await waitFor(() => {
+      const secondCall = vi
+        .mocked(api.builders.chatStream)
+        .mock.calls.find((c) => {
+          const msgs = c[0] as { role: string; content: string }[];
+          return msgs.some((m) => m.content.includes("ZENDESK_API_KEY"));
+        });
+      expect(secondCall).toBeDefined();
+    });
+
+    // The card is dismissed once satisfied.
+    await waitFor(() => expect(screen.queryByTestId("setup-card")).not.toBeInTheDocument());
   });
 });
 
@@ -290,9 +354,9 @@ describe("ChatBuildPanel — valid spec", () => {
     "model:\n  primary: claude-sonnet-4-6\ndeploy:\n  cloud: aws\n";
 
   it("shows 'Create agent' button when spec is valid", async () => {
-    vi.mocked(api.builders.chat).mockResolvedValue(
-      chatResp({ assistant_message: "", agent_yaml: VALID_YAML, valid: true, errors: [] }),
-    );
+    vi.mocked(api.builders.chatStream).mockImplementation(async (_m, onEvent) => {
+      onEvent("done", { assistant_message: "", agent_yaml: VALID_YAML, valid: true, errors: [] });
+    });
 
     renderPanel();
     await waitFor(() => expect(screen.getByTestId("chat-input")).toBeInTheDocument());
@@ -307,9 +371,9 @@ describe("ChatBuildPanel — valid spec", () => {
   });
 
   it("calls agents.fromYaml and navigates on create", async () => {
-    vi.mocked(api.builders.chat).mockResolvedValue(
-      chatResp({ assistant_message: "", agent_yaml: VALID_YAML, valid: true, errors: [] }),
-    );
+    vi.mocked(api.builders.chatStream).mockImplementation(async (_m, onEvent) => {
+      onEvent("done", { assistant_message: "", agent_yaml: VALID_YAML, valid: true, errors: [] });
+    });
     vi.mocked(api.agents.fromYaml).mockResolvedValue(
       apiResp({ id: "agent-123", name: "my-agent" } as never),
     );
@@ -342,14 +406,14 @@ describe("ChatBuildPanel — invalid spec", () => {
   });
 
   it("shows errors and no 'Create agent' button when spec is invalid", async () => {
-    vi.mocked(api.builders.chat).mockResolvedValue(
-      chatResp({
+    vi.mocked(api.builders.chatStream).mockImplementation(async (_m, onEvent) => {
+      onEvent("done", {
         assistant_message: "",
         agent_yaml: "name: bad",
         valid: false,
         errors: ["team: 'team' is a required property"],
-      }),
-    );
+      });
+    });
 
     renderPanel();
     await waitFor(() => expect(screen.getByTestId("chat-input")).toBeInTheDocument());
@@ -364,5 +428,181 @@ describe("ChatBuildPanel — invalid spec", () => {
     // Create button must NOT appear for an invalid spec
     expect(screen.queryByTestId("create-agent-btn")).not.toBeInTheDocument();
     expect(screen.getByText(/is a required property/i)).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Deploy from chat
+// ---------------------------------------------------------------------------
+
+describe("ChatBuildPanel — deploy from chat", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNavigate.mockClear();
+    vi.mocked(api.secrets.list).mockImplementation(withKeyResponse);
+  });
+
+  it("deploys the built agent and tails logs to the thread", async () => {
+    vi.spyOn(api.builders, "chatStream").mockImplementation(async (_m, onEvent) => {
+      onEvent("done", {
+        assistant_message: "",
+        agent_yaml: "name: my-agent\nversion: 1.0.0\n",
+        valid: true,
+        errors: [],
+      });
+    });
+    vi.spyOn(api.deploys, "create").mockResolvedValue({
+      data: { id: "job1", status: "parsing" }, meta: { page: 1, per_page: 1, total: 1 }, errors: [],
+    } as never);
+    const getDetailSpy = vi
+      .spyOn(api.deploys, "getDetail")
+      .mockResolvedValue({
+        data: {
+          id: "job1", agent_id: "a1", agent_name: "my-agent", status: "completed",
+          target: "local", error_message: null, started_at: "", completed_at: "",
+          logs: [{ timestamp: "t1", level: "info", message: "Building image…", step: null }],
+        },
+        meta: { page: 1, per_page: 1, total: 1 }, errors: [],
+      } as never);
+
+    renderPanel();
+    fireEvent.change(await screen.findByTestId("chat-input"), { target: { value: "build it" } });
+    fireEvent.click(screen.getByTestId("send-btn"));
+
+    const card = await screen.findByTestId("spec-ready-card");
+    fireEvent.click(within(card).getByTestId("deploy-agent-btn"));
+
+    await waitFor(() => expect(getDetailSpy).toHaveBeenCalledWith("job1"));
+    await waitFor(() => expect(screen.getByText(/Building image/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole("link", { name: /Agent deployed/i })).toBeInTheDocument());
+    expect(screen.getByRole("link", { name: /Agent deployed/i })).toHaveAttribute("href", "/agents/a1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Streaming
+// ---------------------------------------------------------------------------
+
+describe("ChatBuildPanel streaming", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNavigate.mockClear();
+    vi.mocked(api.secrets.list).mockImplementation(withKeyResponse);
+  });
+
+  it("renders streamed tokens incrementally then the done reply", async () => {
+    vi.mocked(api.builders.chatStream).mockImplementation(async (_m, onEvent) => {
+      onEvent("token", { text: "Hel" });
+      onEvent("token", { text: "lo" });
+      onEvent("done", {
+        assistant_message: "Hello",
+        agent_yaml: null,
+        valid: false,
+        errors: [],
+      });
+    });
+
+    renderPanel();
+    fireEvent.change(await screen.findByTestId("chat-input"), { target: { value: "hi" } });
+    fireEvent.click(screen.getByTestId("send-btn"));
+
+    await waitFor(() => expect(screen.getByText("Hello")).toBeInTheDocument());
+  });
+
+  it("accumulates token text during streaming and clears it on done", async () => {
+    let capturedOnEvent: ((event: string, data: unknown) => void) | undefined;
+
+    vi.mocked(api.builders.chatStream).mockImplementation(async (_m, onEvent) => {
+      capturedOnEvent = onEvent;
+      // Simulate async streaming — resolve without calling done yet
+    });
+
+    renderPanel();
+    fireEvent.change(await screen.findByTestId("chat-input"), { target: { value: "stream me" } });
+    fireEvent.click(screen.getByTestId("send-btn"));
+
+    // Simulate token events arriving
+    await waitFor(() => expect(capturedOnEvent).toBeDefined());
+    capturedOnEvent!("token", { text: "Part" });
+    capturedOnEvent!("token", { text: " one" });
+
+    await waitFor(() => expect(screen.getByText("Part one")).toBeInTheDocument());
+
+    capturedOnEvent!("done", {
+      assistant_message: "Part one done",
+      agent_yaml: null,
+      valid: false,
+      errors: [],
+    });
+
+    // After done, the final assistant message replaces the streaming bubble
+    await waitFor(() => expect(screen.getByText("Part one done")).toBeInTheDocument());
+  });
+
+  it("shows error banner when chatStream emits an error event", async () => {
+    vi.mocked(api.builders.chatStream).mockImplementation(async (_m, onEvent) => {
+      onEvent("error", { detail: "Builder API key missing." });
+    });
+
+    renderPanel();
+    fireEvent.change(await screen.findByTestId("chat-input"), { target: { value: "oops" } });
+    fireEvent.click(screen.getByTestId("send-btn"));
+
+    await waitFor(() =>
+      expect(screen.getByText("Builder API key missing.")).toBeInTheDocument(),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: initialPrompt auto-send
+// ---------------------------------------------------------------------------
+
+describe("ChatBuildPanel initialPrompt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNavigate.mockClear();
+  });
+
+  it("auto-sends initialPrompt and shows user bubble when key is connected", async () => {
+    vi.mocked(api.secrets.list).mockImplementation(withKeyResponse);
+    vi.mocked(api.builders.chatStream).mockImplementation(async (_m, onEvent) => {
+      onEvent("done", {
+        assistant_message: "Got your request!",
+        agent_yaml: null,
+        valid: false,
+        errors: [],
+      });
+    });
+
+    renderPanel("hello world");
+
+    // User bubble appears automatically
+    await waitFor(() => {
+      expect(screen.getByText("hello world")).toBeInTheDocument();
+    });
+    // chatStream was called exactly once (auto-send)
+    await waitFor(() => {
+      expect(api.builders.chatStream).toHaveBeenCalledTimes(1);
+    });
+    expect(api.builders.chatStream).toHaveBeenCalledWith(
+      [{ role: "user", content: "hello world" }],
+      expect.any(Function),
+    );
+  });
+
+  it("does NOT auto-call chatStream on mount when no initialPrompt is given", async () => {
+    vi.mocked(api.secrets.list).mockImplementation(withKeyResponse);
+    vi.mocked(api.builders.chatStream).mockImplementation(async (_m, onEvent) => {
+      onEvent("done", { assistant_message: "reply", agent_yaml: null, valid: false, errors: [] });
+    });
+
+    renderPanel(); // no initialPrompt
+
+    // Wait for chat UI to be ready
+    await waitFor(() => expect(screen.getByTestId("chat-input")).toBeInTheDocument());
+
+    // chatStream should NOT have been called
+    expect(api.builders.chatStream).not.toHaveBeenCalled();
   });
 });

--- a/dashboard/src/components/agent-wizard/ChatBuildPanel.test.tsx
+++ b/dashboard/src/components/agent-wizard/ChatBuildPanel.test.tsx
@@ -33,6 +33,12 @@ vi.mock("@/lib/api", () => ({
       create: vi.fn(),
       getDetail: vi.fn(),
     },
+    builderSessions: {
+      create: vi.fn(),
+      get: vi.fn(),
+      eject: vi.fn(),
+      deploy: vi.fn(),
+    },
     mcpServers: {
       create: vi.fn(),
       discover: vi.fn(),
@@ -604,5 +610,70 @@ describe("ChatBuildPanel initialPrompt", () => {
 
     // chatStream should NOT have been called
     expect(api.builders.chatStream).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Eject to code (Wave 3)
+// ---------------------------------------------------------------------------
+
+describe("ChatBuildPanel — eject to code", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNavigate.mockClear();
+    vi.mocked(api.secrets.list).mockImplementation(withKeyResponse);
+  });
+
+  const VALID_YAML =
+    "name: my-agent\nversion: 1.0.0\nteam: engineering\n" +
+    "owner: alice@example.com\nframework: langgraph\n" +
+    "model:\n  primary: claude-sonnet-4-6\ndeploy:\n  cloud: aws\n";
+
+  it("ejects the validated spec to code and shows generated files in the Code tab", async () => {
+    vi.mocked(api.builders.chatStream).mockImplementation(async (_m, onEvent) => {
+      onEvent("done", { assistant_message: "", agent_yaml: VALID_YAML, valid: true, errors: [] });
+    });
+    vi.mocked(api.builderSessions.create).mockResolvedValue(
+      apiResp({
+        id: "sess-1",
+        team: "engineering",
+        engine: "claude",
+        agent_yaml: VALID_YAML,
+        files: {},
+        deploy_job_id: null,
+        history: [],
+      } as never),
+    );
+    vi.mocked(api.builderSessions.eject).mockImplementation(
+      async (_id: string, _instruction: string, onEvent: (e: string, d: unknown) => void) => {
+        onEvent("file_change", { path: "agent.py", diff: "+x", content: "print('hi')\n" });
+        onEvent("complete", { summary: "done" });
+      },
+    );
+
+    renderPanel();
+    fireEvent.change(await screen.findByTestId("chat-input"), { target: { value: "build it" } });
+    fireEvent.click(screen.getByTestId("send-btn"));
+
+    // Validated spec appears with the Eject-to-code action.
+    const ejectBtn = await screen.findByTestId("eject-code-btn");
+    fireEvent.click(ejectBtn);
+
+    // A session is lazily created, then the eject stream runs.
+    await waitFor(() => expect(api.builderSessions.create).toHaveBeenCalledWith("claude"));
+    await waitFor(() =>
+      expect(api.builderSessions.eject).toHaveBeenCalledWith(
+        "sess-1",
+        expect.any(String),
+        expect.any(Function),
+      ),
+    );
+
+    // On "complete" the panel auto-switches to the Code tab; the file is shown.
+    await waitFor(() => expect(screen.getByText("agent.py")).toBeInTheDocument());
+
+    // Explicitly clicking the Code tab keeps the file visible (CodeArtifactPanel rendered).
+    fireEvent.click(screen.getByTestId("artifact-tab-code"));
+    expect(screen.getByText("agent.py")).toBeInTheDocument();
   });
 });

--- a/dashboard/src/components/agent-wizard/ChatBuildPanel.tsx
+++ b/dashboard/src/components/agent-wizard/ChatBuildPanel.tsx
@@ -39,6 +39,10 @@ import { CodeArtifactPanel } from "./CodeArtifactPanel";
  */
 const BUILDER_KEY_PREFIX = "AGENTBREEDER_CLAUDE_BUILDER_KEY";
 
+/** Ordered keys for the artifact-panel tabs. Drives render + keyboard nav. */
+const ARTIFACT_TABS = ["spec", "code", "deploy"] as const;
+type ArtifactTab = (typeof ARTIFACT_TABS)[number];
+
 /**
  * Return the workspace secret name for the current user's BYO Claude API key.
  * Mirrors the Python function _builder_key_name(user) in api/routes/builders.py.
@@ -217,12 +221,20 @@ function SpecReadyCard({
   errors,
   onEjectToCode,
   ejecting,
+  view = "full",
 }: {
   agentYaml: string;
   valid: boolean;
   errors: string[];
   onEjectToCode: () => void;
   ejecting: boolean;
+  /**
+   * Which controls to render. "full" (default) shows the YAML spec preview plus
+   * Create / Deploy / Eject. "deploy" hides the spec YAML and the Create/Eject
+   * controls, leaving only the deploy button + logs + endpoint link — this backs
+   * the Deploy tab while sharing the same mounted instance (deploy state preserved).
+   */
+  view?: "full" | "deploy";
 }) {
   const navigate = useNavigate();
   const [logs, setLogs] = useState<string[]>([]);
@@ -305,31 +317,37 @@ function SpecReadyCard({
     >
       <div className="flex items-center gap-2 text-sm font-medium text-green-600 dark:text-green-400">
         <CheckCircle className="size-4" />
-        Agent spec ready
+        {view === "deploy" ? "Deploy agent" : "Agent spec ready"}
       </div>
-      <pre className="rounded-lg bg-background border border-border px-3 py-2 text-[11px] leading-relaxed overflow-x-auto max-h-48">
-        {agentYaml}
-      </pre>
-      <Button
-        data-testid="create-agent-btn"
-        onClick={() => createMutation.mutate()}
-        disabled={createMutation.isPending}
-        className="w-full"
-      >
-        {createMutation.isPending ? (
-          <>
-            <Loader2 className="mr-2 size-4 animate-spin" />
-            Creating agent…
-          </>
-        ) : (
-          "Create agent"
-        )}
-      </Button>
-      {createMutation.isError && (
-        <p className="text-xs text-destructive flex items-center gap-1">
-          <AlertCircle className="size-3" />
-          {(createMutation.error as Error).message}
-        </p>
+      {view === "full" && (
+        <pre className="rounded-lg bg-background border border-border px-3 py-2 text-[11px] leading-relaxed overflow-x-auto max-h-48">
+          {agentYaml}
+        </pre>
+      )}
+      {view === "full" && (
+        <>
+          <Button
+            data-testid="create-agent-btn"
+            onClick={() => createMutation.mutate()}
+            disabled={createMutation.isPending}
+            className="w-full"
+          >
+            {createMutation.isPending ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" />
+                Creating agent…
+              </>
+            ) : (
+              "Create agent"
+            )}
+          </Button>
+          {createMutation.isError && (
+            <p className="text-xs text-destructive flex items-center gap-1">
+              <AlertCircle className="size-3" />
+              {(createMutation.error as Error).message}
+            </p>
+          )}
+        </>
       )}
       <Button
         data-testid="deploy-agent-btn"
@@ -353,22 +371,24 @@ function SpecReadyCard({
           {deployError}
         </p>
       )}
-      <Button
-        data-testid="eject-code-btn"
-        variant="outline"
-        onClick={onEjectToCode}
-        disabled={ejecting}
-        className="w-full"
-      >
-        {ejecting ? (
-          <>
-            <Loader2 className="mr-2 size-4 animate-spin" />
-            Generating code…
-          </>
-        ) : (
-          "Eject to code"
-        )}
-      </Button>
+      {view === "full" && (
+        <Button
+          data-testid="eject-code-btn"
+          variant="outline"
+          onClick={onEjectToCode}
+          disabled={ejecting}
+          className="w-full"
+        >
+          {ejecting ? (
+            <>
+              <Loader2 className="mr-2 size-4 animate-spin" />
+              Generating code…
+            </>
+          ) : (
+            "Eject to code"
+          )}
+        </Button>
+      )}
       {logs.length > 0 && (
         <pre className="rounded-lg bg-background border border-border px-3 py-2 text-[11px] max-h-40 overflow-y-auto">
           {logs.join("\n")}
@@ -404,11 +424,30 @@ export function ChatBuildPanel({ initialPrompt }: { initialPrompt?: string } = {
   // ── Eject-to-code (Wave 3) ───────────────────────────────────────────
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [files, setFiles] = useState<Record<string, string>>({});
-  const [artifactTab, setArtifactTab] = useState<"spec" | "code" | "deploy">("spec");
+  const [artifactTab, setArtifactTab] = useState<ArtifactTab>("spec");
   const [ejecting, setEjecting] = useState(false);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const tabRefs = useRef<Partial<Record<ArtifactTab, HTMLButtonElement | null>>>({});
+
+  // ── Roving-tabindex keyboard nav for the artifact tablist ─────────────
+  const handleTabKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
+      e.preventDefault();
+      setArtifactTab((current) => {
+        const idx = ARTIFACT_TABS.indexOf(current);
+        const delta = e.key === "ArrowRight" ? 1 : -1;
+        const next =
+          ARTIFACT_TABS[(idx + delta + ARTIFACT_TABS.length) % ARTIFACT_TABS.length];
+        // Focus the newly selected tab after React commits the update.
+        requestAnimationFrame(() => tabRefs.current[next]?.focus());
+        return next;
+      });
+    },
+    [],
+  );
 
   // Per-user secret name — stable once the user is loaded.
   const secretName = user ? builderKeySecretName(user.id) : null;
@@ -565,10 +604,8 @@ export function ChatBuildPanel({ initialPrompt }: { initialPrompt?: string } = {
             const change = data as { path: string; diff: string; content: string };
             setFiles((prev) => ({ ...prev, [change.path]: change.content }));
           } else if (event === "complete") {
-            setEjecting(false);
             setArtifactTab("code");
           } else if (event === "error") {
-            setEjecting(false);
             setSendError((data as { detail?: string }).detail ?? "Code generation failed.");
           }
         },
@@ -690,16 +727,27 @@ export function ChatBuildPanel({ initialPrompt }: { initialPrompt?: string } = {
             data-testid="artifact-panel"
             className="rounded-xl border border-border overflow-hidden"
           >
-            <div role="tablist" className="flex border-b border-border bg-muted/40">
-              {(["spec", "code", "deploy"] as const).map((tab) => {
+            <div
+              role="tablist"
+              aria-label="Build artifacts"
+              onKeyDown={handleTabKeyDown}
+              className="flex border-b border-border bg-muted/40"
+            >
+              {ARTIFACT_TABS.map((tab) => {
                 const label = tab === "spec" ? "Spec" : tab === "code" ? "Code" : "Deploy";
                 const selected = artifactTab === tab;
                 return (
                   <button
                     key={tab}
+                    ref={(el) => {
+                      tabRefs.current[tab] = el;
+                    }}
                     type="button"
                     role="tab"
+                    id={`artifact-tab-${tab}`}
                     aria-selected={selected}
+                    aria-controls="artifact-tabpanel"
+                    tabIndex={selected ? 0 : -1}
                     data-testid={`artifact-tab-${tab}`}
                     onClick={() => setArtifactTab(tab)}
                     className={cn(
@@ -714,10 +762,17 @@ export function ChatBuildPanel({ initialPrompt }: { initialPrompt?: string } = {
                 );
               })}
             </div>
-            <div role="tabpanel" className="p-4">
+            <div
+              role="tabpanel"
+              id="artifact-tabpanel"
+              aria-labelledby={`artifact-tab-${artifactTab}`}
+              tabIndex={0}
+              className="p-4"
+            >
               {/* The spec card owns the deploy flow + logs, so it stays mounted
                   across tab switches (hidden, not unmounted, to preserve deploy
-                  state). It backs both the Spec and Deploy tabs. */}
+                  state). It backs both the Spec and Deploy tabs — the `view` prop
+                  narrows it to deploy-only controls on the Deploy tab. */}
               <div className={cn(artifactTab === "code" && "hidden")}>
                 <SpecReadyCard
                   agentYaml={pendingSpec.agent_yaml!}
@@ -725,6 +780,7 @@ export function ChatBuildPanel({ initialPrompt }: { initialPrompt?: string } = {
                   errors={pendingSpec.errors}
                   onEjectToCode={() => void handleEject()}
                   ejecting={ejecting}
+                  view={artifactTab === "deploy" ? "deploy" : "full"}
                 />
               </div>
               {artifactTab === "code" && (

--- a/dashboard/src/components/agent-wizard/ChatBuildPanel.tsx
+++ b/dashboard/src/components/agent-wizard/ChatBuildPanel.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { track } from "@/lib/analytics";
 import { useAuth } from "@/hooks/use-auth";
 import { SetupCard } from "./SetupCard";
 import { CodeArtifactPanel } from "./CodeArtifactPanel";
@@ -594,6 +595,7 @@ export function ChatBuildPanel({ initialPrompt }: { initialPrompt?: string } = {
   const handleEject = useCallback(async () => {
     setEjecting(true);
     setSendError(null);
+    track("eject_to_code_started", { engine: "claude" });
     try {
       const id = await ensureSession();
       await api.builderSessions.eject(
@@ -602,8 +604,10 @@ export function ChatBuildPanel({ initialPrompt }: { initialPrompt?: string } = {
         (event, data) => {
           if (event === "file_change") {
             const change = data as { path: string; diff: string; content: string };
+            track("coding_agent_turn", { path: change.path });
             setFiles((prev) => ({ ...prev, [change.path]: change.content }));
           } else if (event === "complete") {
+            track("eject_to_code_completed");
             setArtifactTab("code");
           } else if (event === "error") {
             setSendError((data as { detail?: string }).detail ?? "Code generation failed.");

--- a/dashboard/src/components/agent-wizard/ChatBuildPanel.tsx
+++ b/dashboard/src/components/agent-wizard/ChatBuildPanel.tsx
@@ -11,13 +11,19 @@
  */
 
 import { useRef, useEffect, useCallback, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Bot, Send, User, Key, Loader2, CheckCircle, AlertCircle, Plus } from "lucide-react";
-import { api, type ChatBuildMessage, type ChatBuildResult } from "@/lib/api";
+import {
+  api,
+  type ChatBuildMessage,
+  type ChatBuildResult,
+  type ChatBuildSetupRequest,
+} from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/hooks/use-auth";
+import { SetupCard } from "./SetupCard";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -214,6 +220,10 @@ function SpecReadyCard({
   errors: string[];
 }) {
   const navigate = useNavigate();
+  const [logs, setLogs] = useState<string[]>([]);
+  const [endpoint, setEndpoint] = useState<string | null>(null);
+  const [deploying, setDeploying] = useState(false);
+  const [deployError, setDeployError] = useState<string | null>(null);
 
   const createMutation = useMutation({
     mutationFn: () => api.agents.fromYaml(agentYaml),
@@ -222,6 +232,44 @@ function SpecReadyCard({
       navigate(`/agents/${agent.id}`);
     },
   });
+
+  async function handleDeploy() {
+    setDeploying(true);
+    setLogs([]);
+    setEndpoint(null);
+    setDeployError(null);
+    try {
+      // TODO(Wave 2): expose deploy target selector (currently local-only)
+      const job = await api.deploys.create({ config_yaml: agentYaml, target: "local" });
+      const jobId = job.data.id;
+      const seen = new Set<string>();
+      const terminal = new Set(["completed", "failed"]);
+      // Poll up to ~5 min (250 * 1.2s) — guard against an unbounded loop.
+      for (let i = 0; i < 250; i++) {
+        const detail = (await api.deploys.getDetail(jobId)).data;
+        for (const entry of detail.logs) {
+          const key = `${entry.timestamp}:${entry.message}`;
+          if (!seen.has(key)) {
+            seen.add(key);
+            setLogs((prev) => [...prev, entry.message]);
+          }
+        }
+        if (terminal.has(detail.status)) {
+          if (detail.status === "completed") {
+            setEndpoint(`/agents/${detail.agent_id}`);
+          } else {
+            setDeployError(detail.error_message ?? "Deploy failed.");
+          }
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 1200));
+      }
+    } catch (err) {
+      setDeployError((err as Error).message || "Deploy failed.");
+    } finally {
+      setDeploying(false);
+    }
+  }
 
   if (!valid) {
     return (
@@ -278,6 +326,41 @@ function SpecReadyCard({
           {(createMutation.error as Error).message}
         </p>
       )}
+      <Button
+        data-testid="deploy-agent-btn"
+        variant="secondary"
+        onClick={() => void handleDeploy()}
+        disabled={deploying}
+        className="w-full"
+      >
+        {deploying ? (
+          <>
+            <Loader2 className="mr-2 size-4 animate-spin" />
+            Deploying…
+          </>
+        ) : (
+          "Deploy now"
+        )}
+      </Button>
+      {deployError && (
+        <p className="text-xs text-destructive flex items-center gap-1">
+          <AlertCircle className="size-3" />
+          {deployError}
+        </p>
+      )}
+      {logs.length > 0 && (
+        <pre className="rounded-lg bg-background border border-border px-3 py-2 text-[11px] max-h-40 overflow-y-auto">
+          {logs.join("\n")}
+        </pre>
+      )}
+      {endpoint && (
+        <Link
+          to={endpoint}
+          className="text-xs underline text-green-600"
+        >
+          Agent deployed — view it
+        </Link>
+      )}
     </div>
   );
 }
@@ -286,12 +369,16 @@ function SpecReadyCard({
 // Main ChatBuildPanel component
 // ---------------------------------------------------------------------------
 
-export function ChatBuildPanel() {
+export function ChatBuildPanel({ initialPrompt }: { initialPrompt?: string } = {}) {
   const { user } = useAuth();
   const [entries, setEntries] = useState<ChatEntry[]>([]);
   const [input, setInput] = useState("");
   const [pendingSpec, setPendingSpec] = useState<ChatBuildResult | null>(null);
   const [keyConnected, setKeyConnected] = useState(false);
+  const [streaming, setStreaming] = useState<string | null>(null);
+  const [sending, setSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const [pendingSetup, setPendingSetup] = useState<ChatBuildSetupRequest | null>(null);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -310,37 +397,15 @@ export function ChatBuildPanel() {
     (secretName !== null &&
       (secretsList?.data ?? []).some((s) => s.name === secretName));
 
+  // ── Auto-send ref — declared early; effect is placed after sendStreaming ──
+  const autoSentRef = useRef(false);
+
   // ── Auto-scroll ───────────────────────────────────────────────────────
   useEffect(() => {
     if (scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
-  }, [entries, pendingSpec]);
-
-  // ── Chat mutation ─────────────────────────────────────────────────────
-  const chatMutation = useMutation({
-    mutationFn: (msgs: ChatBuildMessage[]) => api.builders.chat(msgs),
-    onSuccess: (res) => {
-      const result = res.data;
-
-      if (result.agent_yaml) {
-        // Claude submitted a spec — show the spec card.
-        setPendingSpec(result);
-        if (result.assistant_message) {
-          setEntries((prev) => [
-            ...prev,
-            { id: generateId(), role: "assistant", content: result.assistant_message },
-          ]);
-        }
-      } else {
-        // Plain text reply — add to conversation.
-        setEntries((prev) => [
-          ...prev,
-          { id: generateId(), role: "assistant", content: result.assistant_message },
-        ]);
-      }
-    },
-  });
+  }, [entries, pendingSpec, streaming]);
 
   // ── Build the message history to send ────────────────────────────────
   function buildHistory(currentInput: string): ChatBuildMessage[] {
@@ -352,9 +417,71 @@ export function ChatBuildPanel() {
     return history;
   }
 
+  // ── Streaming send ────────────────────────────────────────────────────
+  const sendStreaming = useCallback(
+    async (msgs: ChatBuildMessage[]) => {
+      setSending(true);
+      setStreaming("");
+      setSendError(null);
+      let acc = "";
+      let setupRequested = false;
+      try {
+        await api.builders.chatStream(msgs, (event, data) => {
+          if (event === "token") {
+            acc += (data as { text: string }).text;
+            setStreaming(acc);
+          } else if (event === "setup_request") {
+            // The agent needs a dependency — render an inline card in the thread.
+            setupRequested = true;
+            setPendingSetup(data as ChatBuildSetupRequest);
+          } else if (event === "done") {
+            const result = data as ChatBuildResult;
+            setStreaming(null);
+            if (result.setup_request) {
+              // Fallback: the done payload also carries the setup request.
+              setupRequested = true;
+              setPendingSetup(result.setup_request);
+            }
+            if (result.agent_yaml) {
+              // Claude submitted a spec — show the spec card.
+              setPendingSpec(result);
+              if (result.assistant_message) {
+                setEntries((prev) => [
+                  ...prev,
+                  { id: generateId(), role: "assistant", content: result.assistant_message },
+                ]);
+              }
+            } else if (!setupRequested) {
+              // Plain text reply — add to conversation. Skipped while a setup card
+              // is pending so we don't show an empty assistant bubble.
+              setEntries((prev) => [
+                ...prev,
+                { id: generateId(), role: "assistant", content: result.assistant_message || acc },
+              ]);
+            } else if (result.assistant_message) {
+              // Setup pending, but the model also said something — keep it.
+              setEntries((prev) => [
+                ...prev,
+                { id: generateId(), role: "assistant", content: result.assistant_message },
+              ]);
+            }
+          } else if (event === "error") {
+            setSendError((data as { detail?: string }).detail ?? "Something went wrong.");
+          }
+        });
+      } catch (err) {
+        setSendError((err as Error).message || "Something went wrong.");
+      } finally {
+        setSending(false);
+        setStreaming(null);
+      }
+    },
+    [],
+  );
+
   const handleSend = useCallback(() => {
     const trimmed = input.trim();
-    if (!trimmed || chatMutation.isPending) return;
+    if (!trimmed || sending) return;
 
     // Add user message to UI immediately.
     setEntries((prev) => [
@@ -363,15 +490,42 @@ export function ChatBuildPanel() {
     ]);
     setInput("");
     setPendingSpec(null);
+    setPendingSetup(null);
+    setSendError(null);
 
     // Reset textarea height.
     if (inputRef.current) {
       inputRef.current.style.height = "auto";
     }
 
-    chatMutation.mutate(buildHistory(trimmed));
+    void sendStreaming(buildHistory(trimmed));
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [input, entries, chatMutation]);
+  }, [input, entries, sending, sendStreaming]);
+
+  // ── Inline setup card completed → thread the confirmation and continue ─
+  // Defined as a plain closure (not memoised) so it always sees the latest
+  // `entries` when SetupCard fires onComplete.
+  function handleSetupComplete(confirmation: string) {
+    setPendingSetup(null);
+    setEntries((prev) => [
+      ...prev,
+      { id: generateId(), role: "user", content: confirmation },
+    ]);
+    void sendStreaming(buildHistory(confirmation));
+  }
+
+  // ── Auto-send initialPrompt once the key is confirmed ────────────────
+  // Placed here so sendStreaming + buildHistory are already in scope.
+  useEffect(() => {
+    if (!hasKey || !initialPrompt || autoSentRef.current) return;
+    autoSentRef.current = true;
+    setEntries((prev) => [
+      ...prev,
+      { id: generateId(), role: "user", content: initialPrompt },
+    ]);
+    void sendStreaming(buildHistory(initialPrompt));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasKey]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
@@ -409,7 +563,7 @@ export function ChatBuildPanel() {
         ref={scrollRef}
         className="flex-1 overflow-y-auto p-4 space-y-4 min-h-0"
       >
-        {entries.length === 0 && !chatMutation.isPending && (
+        {entries.length === 0 && !sending && (
           <div className="text-center text-sm text-muted-foreground pt-8 space-y-2">
             <Bot className="size-8 mx-auto text-primary/40" />
             <p>Describe the agent you want to build.</p>
@@ -424,8 +578,15 @@ export function ChatBuildPanel() {
           <ChatBubble key={entry.id} entry={entry} />
         ))}
 
-        {/* Loading indicator */}
-        {chatMutation.isPending && (
+        {/* Streaming bubble — shows incremental tokens or a spinner while waiting for the first token */}
+        {streaming !== null && (
+          <ChatBubble
+            entry={{ id: "streaming", role: "assistant", content: streaming || "…" }}
+          />
+        )}
+
+        {/* Loading spinner — shown while sending but before any token arrives */}
+        {sending && streaming === null && (
           <div className="flex gap-3">
             <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
               <Bot className="size-4" />
@@ -434,6 +595,15 @@ export function ChatBuildPanel() {
               <Loader2 className="size-4 animate-spin text-muted-foreground" />
             </div>
           </div>
+        )}
+
+        {/* Inline dependency-capture card */}
+        {pendingSetup && (
+          <SetupCard
+            request={pendingSetup}
+            onComplete={handleSetupComplete}
+            onSkip={() => setPendingSetup(null)}
+          />
         )}
 
         {/* Spec card */}
@@ -446,11 +616,10 @@ export function ChatBuildPanel() {
         )}
 
         {/* Error banner */}
-        {chatMutation.isError && (
+        {sendError && (
           <div className="rounded-lg border border-destructive/40 bg-destructive/5 px-4 py-3 text-sm text-destructive flex items-center gap-2">
             <AlertCircle className="size-4 shrink-0" />
-            {(chatMutation.error as Error).message ||
-              "Something went wrong. Please try again."}
+            {sendError}
           </div>
         )}
       </div>
@@ -475,11 +644,11 @@ export function ChatBuildPanel() {
           <Button
             size="icon"
             onClick={handleSend}
-            disabled={!input.trim() || chatMutation.isPending}
+            disabled={!input.trim() || sending}
             data-testid="send-btn"
             className="shrink-0"
           >
-            {chatMutation.isPending ? (
+            {sending ? (
               <Loader2 className="size-4 animate-spin" />
             ) : (
               <Send className="size-4" />

--- a/dashboard/src/components/agent-wizard/ChatBuildPanel.tsx
+++ b/dashboard/src/components/agent-wizard/ChatBuildPanel.tsx
@@ -423,6 +423,9 @@ export function ChatBuildPanel({ initialPrompt }: { initialPrompt?: string } = {
   const [pendingSetup, setPendingSetup] = useState<ChatBuildSetupRequest | null>(null);
 
   // ── Eject-to-code (Wave 3) ───────────────────────────────────────────
+  // Active coding engine for this builder session. Single source of truth for
+  // both the lazy session creation and analytics tagging.
+  const engine: "claude" | "codex" = "claude";
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [files, setFiles] = useState<Record<string, string>>({});
   const [artifactTab, setArtifactTab] = useState<ArtifactTab>("spec");
@@ -585,17 +588,17 @@ export function ChatBuildPanel({ initialPrompt }: { initialPrompt?: string } = {
   // Created on first eject. Returns the session id (unwraps ApiResponse.data).
   const ensureSession = useCallback(async (): Promise<string> => {
     if (sessionId) return sessionId;
-    const res = await api.builderSessions.create("claude");
+    const res = await api.builderSessions.create(engine);
     const id = res.data.id;
     setSessionId(id);
     return id;
-  }, [sessionId]);
+  }, [sessionId, engine]);
 
   // ── Eject the validated spec to generated code ────────────────────────
   const handleEject = useCallback(async () => {
     setEjecting(true);
     setSendError(null);
-    track("eject_to_code_started", { engine: "claude" });
+    track("eject_to_code_started", { engine });
     try {
       const id = await ensureSession();
       await api.builderSessions.eject(

--- a/dashboard/src/components/agent-wizard/ChatBuildPanel.tsx
+++ b/dashboard/src/components/agent-wizard/ChatBuildPanel.tsx
@@ -24,6 +24,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/hooks/use-auth";
 import { SetupCard } from "./SetupCard";
+import { CodeArtifactPanel } from "./CodeArtifactPanel";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -214,10 +215,14 @@ function SpecReadyCard({
   agentYaml,
   valid,
   errors,
+  onEjectToCode,
+  ejecting,
 }: {
   agentYaml: string;
   valid: boolean;
   errors: string[];
+  onEjectToCode: () => void;
+  ejecting: boolean;
 }) {
   const navigate = useNavigate();
   const [logs, setLogs] = useState<string[]>([]);
@@ -348,6 +353,22 @@ function SpecReadyCard({
           {deployError}
         </p>
       )}
+      <Button
+        data-testid="eject-code-btn"
+        variant="outline"
+        onClick={onEjectToCode}
+        disabled={ejecting}
+        className="w-full"
+      >
+        {ejecting ? (
+          <>
+            <Loader2 className="mr-2 size-4 animate-spin" />
+            Generating code…
+          </>
+        ) : (
+          "Eject to code"
+        )}
+      </Button>
       {logs.length > 0 && (
         <pre className="rounded-lg bg-background border border-border px-3 py-2 text-[11px] max-h-40 overflow-y-auto">
           {logs.join("\n")}
@@ -379,6 +400,12 @@ export function ChatBuildPanel({ initialPrompt }: { initialPrompt?: string } = {
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
   const [pendingSetup, setPendingSetup] = useState<ChatBuildSetupRequest | null>(null);
+
+  // ── Eject-to-code (Wave 3) ───────────────────────────────────────────
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [files, setFiles] = useState<Record<string, string>>({});
+  const [artifactTab, setArtifactTab] = useState<"spec" | "code" | "deploy">("spec");
+  const [ejecting, setEjecting] = useState(false);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -514,6 +541,45 @@ export function ChatBuildPanel({ initialPrompt }: { initialPrompt?: string } = {
     void sendStreaming(buildHistory(confirmation));
   }
 
+  // ── Lazy builder-session creation ─────────────────────────────────────
+  // Created on first eject. Returns the session id (unwraps ApiResponse.data).
+  const ensureSession = useCallback(async (): Promise<string> => {
+    if (sessionId) return sessionId;
+    const res = await api.builderSessions.create("claude");
+    const id = res.data.id;
+    setSessionId(id);
+    return id;
+  }, [sessionId]);
+
+  // ── Eject the validated spec to generated code ────────────────────────
+  const handleEject = useCallback(async () => {
+    setEjecting(true);
+    setSendError(null);
+    try {
+      const id = await ensureSession();
+      await api.builderSessions.eject(
+        id,
+        "Generate the agent.py, tools, and tests for this spec.",
+        (event, data) => {
+          if (event === "file_change") {
+            const change = data as { path: string; diff: string; content: string };
+            setFiles((prev) => ({ ...prev, [change.path]: change.content }));
+          } else if (event === "complete") {
+            setEjecting(false);
+            setArtifactTab("code");
+          } else if (event === "error") {
+            setEjecting(false);
+            setSendError((data as { detail?: string }).detail ?? "Code generation failed.");
+          }
+        },
+      );
+    } catch (err) {
+      setSendError((err as Error).message || "Code generation failed.");
+    } finally {
+      setEjecting(false);
+    }
+  }, [ensureSession]);
+
   // ── Auto-send initialPrompt once the key is confirmed ────────────────
   // Placed here so sendStreaming + buildHistory are already in scope.
   useEffect(() => {
@@ -606,13 +672,68 @@ export function ChatBuildPanel({ initialPrompt }: { initialPrompt?: string } = {
           />
         )}
 
-        {/* Spec card */}
-        {pendingSpec && (
+        {/* Spec card / artifact panel.
+            Invalid specs render the bare card (no tabs). A valid spec gets the
+            tabbed artifact panel: Spec · Code · Deploy. */}
+        {pendingSpec && !pendingSpec.valid && (
           <SpecReadyCard
             agentYaml={pendingSpec.agent_yaml!}
             valid={pendingSpec.valid}
             errors={pendingSpec.errors}
+            onEjectToCode={() => void handleEject()}
+            ejecting={ejecting}
           />
+        )}
+
+        {pendingSpec && pendingSpec.valid && (
+          <div
+            data-testid="artifact-panel"
+            className="rounded-xl border border-border overflow-hidden"
+          >
+            <div role="tablist" className="flex border-b border-border bg-muted/40">
+              {(["spec", "code", "deploy"] as const).map((tab) => {
+                const label = tab === "spec" ? "Spec" : tab === "code" ? "Code" : "Deploy";
+                const selected = artifactTab === tab;
+                return (
+                  <button
+                    key={tab}
+                    type="button"
+                    role="tab"
+                    aria-selected={selected}
+                    data-testid={`artifact-tab-${tab}`}
+                    onClick={() => setArtifactTab(tab)}
+                    className={cn(
+                      "px-4 py-2 text-sm font-medium transition-colors",
+                      selected
+                        ? "border-b-2 border-primary text-foreground"
+                        : "text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    {label}
+                  </button>
+                );
+              })}
+            </div>
+            <div role="tabpanel" className="p-4">
+              {/* The spec card owns the deploy flow + logs, so it stays mounted
+                  across tab switches (hidden, not unmounted, to preserve deploy
+                  state). It backs both the Spec and Deploy tabs. */}
+              <div className={cn(artifactTab === "code" && "hidden")}>
+                <SpecReadyCard
+                  agentYaml={pendingSpec.agent_yaml!}
+                  valid={pendingSpec.valid}
+                  errors={pendingSpec.errors}
+                  onEjectToCode={() => void handleEject()}
+                  ejecting={ejecting}
+                />
+              </div>
+              {artifactTab === "code" && (
+                <div className="h-72">
+                  <CodeArtifactPanel files={files} />
+                </div>
+              )}
+            </div>
+          </div>
         )}
 
         {/* Error banner */}

--- a/dashboard/src/components/agent-wizard/CodeArtifactPanel.test.tsx
+++ b/dashboard/src/components/agent-wizard/CodeArtifactPanel.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { CodeArtifactPanel } from "./CodeArtifactPanel";
+
+const files = { "agent.py": "print('hi')\n", "tools/search.py": "x = 1\n" };
+
+describe("CodeArtifactPanel", () => {
+  it("lists generated files", () => {
+    render(<CodeArtifactPanel files={files} />);
+    expect(screen.getByText("agent.py")).toBeInTheDocument();
+    expect(screen.getByText("tools/search.py")).toBeInTheDocument();
+  });
+
+  it("shows file contents when a file is selected", () => {
+    render(<CodeArtifactPanel files={files} />);
+    fireEvent.click(screen.getByText("tools/search.py"));
+    expect(screen.getByText(/x = 1/)).toBeInTheDocument();
+  });
+
+  it("renders an empty state when there are no files", () => {
+    render(<CodeArtifactPanel files={{}} />);
+    expect(screen.getByText(/No code generated yet/i)).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/components/agent-wizard/CodeArtifactPanel.tsx
+++ b/dashboard/src/components/agent-wizard/CodeArtifactPanel.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+
+interface CodeArtifactPanelProps {
+  files: Record<string, string>;
+}
+
+export function CodeArtifactPanel({ files }: CodeArtifactPanelProps) {
+  const paths = Object.keys(files).sort();
+  const [selected, setSelected] = useState<string | null>(paths[0] ?? null);
+
+  if (paths.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-gray-500">
+        No code generated yet. Use “Eject to code” to generate agent.py and tools.
+      </div>
+    );
+  }
+
+  const active = selected && files[selected] !== undefined ? selected : paths[0];
+
+  return (
+    <div className="flex h-full">
+      <ul className="w-48 shrink-0 overflow-auto border-r border-gray-200 text-sm">
+        {paths.map((p) => (
+          <li key={p}>
+            <button
+              type="button"
+              onClick={() => setSelected(p)}
+              className={`block w-full truncate px-3 py-2 text-left hover:bg-gray-50 ${
+                p === active ? "bg-gray-100 font-medium" : ""
+              }`}
+            >
+              {p}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <pre className="flex-1 overflow-auto bg-gray-50 p-4 text-xs leading-relaxed">
+        {files[active]}
+      </pre>
+    </div>
+  );
+}

--- a/dashboard/src/components/agent-wizard/SetupCard.test.tsx
+++ b/dashboard/src/components/agent-wizard/SetupCard.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { SetupCard } from "./SetupCard";
+import { api } from "@/lib/api";
+
+function renderCard(props: Parameters<typeof SetupCard>[0]) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <SetupCard {...props} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("SetupCard", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("secret kind stores via api.secrets.create and confirms with the name", async () => {
+    const create = vi
+      .spyOn(api.secrets, "create")
+      .mockResolvedValue({ data: { name: "ZENDESK_API_KEY", masked_value: "••••" } } as never);
+    const onComplete = vi.fn();
+
+    renderCard({
+      request: { kind: "secret", name: "ZENDESK_API_KEY", reason: "read tickets" },
+      onComplete,
+      onSkip: vi.fn(),
+    });
+
+    expect(screen.getByText(/read tickets/i)).toBeInTheDocument();
+    const input = screen.getByTestId("setup-secret-input") as HTMLInputElement;
+    expect(input.type).toBe("password");
+    fireEvent.change(input, { target: { value: "sk-zendesk-123" } });
+    fireEvent.click(screen.getByTestId("setup-card-submit"));
+
+    await waitFor(() =>
+      expect(create).toHaveBeenCalledWith({ name: "ZENDESK_API_KEY", value: "sk-zendesk-123" }),
+    );
+    await waitFor(() =>
+      expect(onComplete).toHaveBeenCalledWith(expect.stringContaining("ZENDESK_API_KEY")),
+    );
+    expect(input.value).toBe("");
+  });
+
+  it("provider kind stores a provider-key secret and confirms", async () => {
+    const create = vi
+      .spyOn(api.secrets, "create")
+      .mockResolvedValue({ data: { name: "openai/api-key", masked_value: "••••" } } as never);
+    const onComplete = vi.fn();
+
+    renderCard({
+      request: { kind: "provider", name: "openai" },
+      onComplete,
+      onSkip: vi.fn(),
+    });
+
+    fireEvent.change(screen.getByTestId("setup-secret-input"), {
+      target: { value: "sk-openai-xyz" },
+    });
+    fireEvent.click(screen.getByTestId("setup-card-submit"));
+
+    await waitFor(() =>
+      expect(create).toHaveBeenCalledWith({ name: "openai/api-key", value: "sk-openai-xyz" }),
+    );
+    await waitFor(() =>
+      expect(onComplete).toHaveBeenCalledWith(expect.stringContaining("openai")),
+    );
+  });
+
+  it("mcp kind registers + discovers and confirms with the tool count", async () => {
+    const create = vi
+      .spyOn(api.mcpServers, "create")
+      .mockResolvedValue({ data: { id: "m1", name: "zendesk" } } as never);
+    const discover = vi
+      .spyOn(api.mcpServers, "discover")
+      .mockResolvedValue({ data: { tools: [{ name: "a" }, { name: "b" }], total: 2 } } as never);
+    const onComplete = vi.fn();
+
+    renderCard({
+      request: { kind: "mcp", name: "zendesk" },
+      onComplete,
+      onSkip: vi.fn(),
+    });
+
+    fireEvent.change(screen.getByTestId("setup-mcp-endpoint"), {
+      target: { value: "https://mcp.zendesk.example/sse" },
+    });
+    fireEvent.click(screen.getByTestId("setup-card-submit"));
+
+    await waitFor(() =>
+      expect(create).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "zendesk", endpoint: "https://mcp.zendesk.example/sse" }),
+      ),
+    );
+    await waitFor(() => expect(discover).toHaveBeenCalledWith("m1"));
+    await waitFor(() => expect(onComplete).toHaveBeenCalledWith(expect.stringContaining("2 tools")));
+  });
+
+  it("surfaces an error and does not complete when the mutation fails", async () => {
+    vi.spyOn(api.secrets, "create").mockRejectedValue(new Error("backend down"));
+    const onComplete = vi.fn();
+
+    renderCard({
+      request: { kind: "secret", name: "ZENDESK_API_KEY" },
+      onComplete,
+      onSkip: vi.fn(),
+    });
+
+    fireEvent.change(screen.getByTestId("setup-secret-input"), { target: { value: "x" } });
+    fireEvent.click(screen.getByTestId("setup-card-submit"));
+
+    await waitFor(() => expect(screen.getByText(/backend down/i)).toBeInTheDocument());
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/src/components/agent-wizard/SetupCard.tsx
+++ b/dashboard/src/components/agent-wizard/SetupCard.tsx
@@ -1,0 +1,206 @@
+/**
+ * SetupCard — inline dependency-capture card rendered inside the chat thread.
+ *
+ * When the conversational builder needs a credential (secret), a model-provider
+ * key, or an MCP server, the backend emits a `setup_request` SSE event and this
+ * card appears as a first-class message. The captured value goes straight to the
+ * secrets / MCP backend (server-side, masked) — it is never kept in component
+ * state after submit and never enters the agent spec. The spec records only a
+ * reference (name).
+ */
+
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { KeyRound, Plug, Server, Loader2, AlertCircle, Check, X } from "lucide-react";
+import { api, type ChatBuildSetupRequest } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+// MCP transports supported by POST /mcp-servers (McpServerCreate.transport).
+const MCP_TRANSPORTS = ["stdio", "sse", "streamable_http"] as const;
+type McpTransport = (typeof MCP_TRANSPORTS)[number];
+
+function SetupIcon({ kind }: { kind: ChatBuildSetupRequest["kind"] }) {
+  if (kind === "mcp") return <Server className="size-4" />;
+  if (kind === "provider") return <Plug className="size-4" />;
+  return <KeyRound className="size-4" />;
+}
+
+function titleFor(req: ChatBuildSetupRequest): string {
+  if (req.kind === "mcp") return `Connect the “${req.name}” MCP server`;
+  if (req.kind === "provider") return `Add your ${req.name} API key`;
+  return `Add the secret “${req.name}”`;
+}
+
+export function SetupCard({
+  request,
+  onComplete,
+  onSkip,
+}: {
+  request: ChatBuildSetupRequest;
+  /** Called with a confirmation message to append to the thread and continue the build. */
+  onComplete: (confirmation: string) => void;
+  /** Called when the user dismisses the card without providing the dependency. */
+  onSkip: () => void;
+}) {
+  const [value, setValue] = useState(""); // secret / provider key (password)
+  const [endpoint, setEndpoint] = useState(""); // mcp endpoint
+  const [transport, setTransport] = useState<McpTransport>("stdio");
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = useMutation({
+    mutationFn: async (): Promise<string> => {
+      if (request.kind === "mcp") {
+        const created = await api.mcpServers.create({
+          name: request.name,
+          endpoint: endpoint.trim(),
+          transport,
+        });
+        const id = created.data.id;
+        let toolCount = 0;
+        try {
+          const discovered = await api.mcpServers.discover(id);
+          toolCount = discovered.data.tools?.length ?? discovered.data.total ?? 0;
+        } catch {
+          // Registration succeeded; tool discovery is best-effort (server may be
+          // offline). The agent can still reference the server by name.
+          toolCount = 0;
+        }
+        return `I've connected the MCP server '${request.name}' (${toolCount} tools discovered). You can reference its tools in the spec.`;
+      }
+
+      // secret + provider both persist a value via the secrets backend.
+      const secretName =
+        request.kind === "provider" ? `${request.name}/api-key` : request.name;
+      await api.secrets.create({ name: secretName, value: value.trim() });
+
+      if (request.kind === "provider") {
+        return `I've added my ${request.name} API key.`;
+      }
+      return `I've added the secret \`${request.name}\`.`;
+    },
+    onSuccess: (confirmation) => {
+      // Clear any captured value from state immediately — never retained.
+      setValue("");
+      setEndpoint("");
+      setError(null);
+      onComplete(confirmation);
+    },
+    onError: (err: Error) => {
+      setValue("");
+      setError(err.message || "Setup failed. Please try again.");
+    },
+  });
+
+  const canSubmit =
+    request.kind === "mcp" ? endpoint.trim().length > 0 : value.trim().length > 0;
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit || submit.isPending) return;
+    submit.mutate();
+  }
+
+  return (
+    <div
+      data-testid="setup-card"
+      className="rounded-xl border border-primary/30 bg-primary/5 p-4 space-y-3"
+    >
+      <div className="flex items-center gap-2 text-sm font-medium text-primary">
+        <SetupIcon kind={request.kind} />
+        {titleFor(request)}
+      </div>
+      {request.reason && (
+        <p className="text-xs text-muted-foreground">{request.reason}</p>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-3">
+        {request.kind === "mcp" ? (
+          <div className="space-y-2">
+            <input
+              data-testid="setup-mcp-endpoint"
+              value={endpoint}
+              onChange={(e) => setEndpoint(e.target.value)}
+              placeholder="Endpoint (URL or command)"
+              autoComplete="off"
+              className={cn(
+                "w-full rounded-lg border border-border bg-background px-3 py-2 text-sm",
+                "focus:outline-none focus:ring-2 focus:ring-primary/50",
+              )}
+            />
+            <select
+              data-testid="setup-mcp-transport"
+              value={transport}
+              onChange={(e) => setTransport(e.target.value as McpTransport)}
+              className={cn(
+                "w-full rounded-lg border border-border bg-background px-3 py-2 text-sm",
+                "focus:outline-none focus:ring-2 focus:ring-primary/50",
+              )}
+            >
+              {MCP_TRANSPORTS.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : (
+          <input
+            data-testid="setup-secret-input"
+            type="password"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder={request.kind === "provider" ? "API key" : "Secret value"}
+            autoComplete="off"
+            className={cn(
+              "w-full rounded-lg border border-border bg-background px-3 py-2 text-sm",
+              "focus:outline-none focus:ring-2 focus:ring-primary/50",
+            )}
+          />
+        )}
+
+        {error && (
+          <p className="text-xs text-destructive flex items-center gap-1">
+            <AlertCircle className="size-3" />
+            {error}
+          </p>
+        )}
+
+        <div className="flex items-center gap-2">
+          <Button
+            type="submit"
+            data-testid="setup-card-submit"
+            disabled={!canSubmit || submit.isPending}
+            className="flex-1"
+          >
+            {submit.isPending ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" />
+                Connecting…
+              </>
+            ) : (
+              <>
+                <Check className="mr-2 size-4" />
+                Connect
+              </>
+            )}
+          </Button>
+          <Button
+            type="button"
+            data-testid="setup-card-skip"
+            variant="ghost"
+            onClick={onSkip}
+            disabled={submit.isPending}
+          >
+            <X className="mr-1 size-4" />
+            Skip
+          </Button>
+        </div>
+      </form>
+
+      <p className="text-[11px] text-muted-foreground">
+        Stored securely in your workspace — never shown in the spec or returned to the browser.
+      </p>
+    </div>
+  );
+}

--- a/dashboard/src/components/home/BuildFrontDoor.test.tsx
+++ b/dashboard/src/components/home/BuildFrontDoor.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BuildFrontDoor } from "./BuildFrontDoor";
+
+describe("BuildFrontDoor", () => {
+  it("shows the prompt and example chips, and calls onStart with the chosen text", () => {
+    const onStart = vi.fn();
+    render(<BuildFrontDoor onStart={onStart} />);
+    expect(screen.getByText(/what do you want to build/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByText(/support agent/i));
+    expect(onStart).toHaveBeenCalledWith(expect.stringMatching(/support agent/i));
+  });
+
+  it("submits the freeform prompt", () => {
+    const onStart = vi.fn();
+    render(<BuildFrontDoor onStart={onStart} />);
+    fireEvent.change(screen.getByTestId("frontdoor-input"), { target: { value: "an invoice bot" } });
+    fireEvent.submit(screen.getByTestId("frontdoor-form"));
+    expect(onStart).toHaveBeenCalledWith("an invoice bot");
+  });
+});

--- a/dashboard/src/components/home/BuildFrontDoor.tsx
+++ b/dashboard/src/components/home/BuildFrontDoor.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { Sparkles, ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const EXAMPLES = [
+  "A support agent that reads our docs and Zendesk",
+  "A daily news digest agent emailed to the team",
+  "An invoice-processing agent that extracts line items",
+];
+
+export function BuildFrontDoor({ onStart }: { onStart: (prompt: string) => void }) {
+  const [value, setValue] = useState("");
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col items-center gap-6 py-12 text-center">
+      <div className="flex size-12 items-center justify-center rounded-full bg-primary/10">
+        <Sparkles className="size-6 text-primary" />
+      </div>
+      <h1 className="text-2xl font-semibold">What do you want to build today?</h1>
+      <p className="text-sm text-muted-foreground">
+        Describe your agent in plain language. I&apos;ll ask a few questions, generate a
+        ready-to-deploy <span className="font-mono">agent.yaml</span>, and ship it.
+      </p>
+      <form
+        data-testid="frontdoor-form"
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (value.trim()) onStart(value.trim());
+        }}
+        className="flex w-full items-center gap-2"
+      >
+        <input
+          data-testid="frontdoor-input"
+          aria-label="Describe the agent you want to build"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="e.g. a customer-support agent for our SaaS"
+          className={cn(
+            "flex-1 rounded-lg border border-border bg-background px-4 py-3 text-sm",
+            "focus:outline-none focus:ring-2 focus:ring-primary/50",
+          )}
+        />
+        <Button type="submit" disabled={!value.trim()} size="icon" className="shrink-0">
+          <ArrowRight className="size-4" />
+        </Button>
+      </form>
+      <div className="flex flex-wrap justify-center gap-2">
+        {EXAMPLES.map((ex) => (
+          <button
+            key={ex}
+            type="button"
+            onClick={() => onStart(ex)}
+            className="rounded-full border border-border bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted"
+          >
+            {ex}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/shell.tsx
+++ b/dashboard/src/components/shell.tsx
@@ -70,6 +70,7 @@ const MARKETPLACE_NAV = [
 const OBSERVABILITY_NAV = [
   { to: "/traces", icon: Activity, label: "Traces" },
   { to: "/costs", icon: DollarSign, label: "Costs" },
+  { to: "/builder-insights", icon: BarChart3, label: "Builder" },
 ] as const;
 
 const EVALUATION_NAV = [

--- a/dashboard/src/lib/analytics.test.ts
+++ b/dashboard/src/lib/analytics.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { track, ANALYTICS_EVENTS } from "./analytics";
+
+describe("analytics seam", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
+  });
+  it("includes the full funnel taxonomy", () => {
+    expect(ANALYTICS_EVENTS).toContain("builder_session_started");
+    expect(ANALYTICS_EVENTS).toContain("first_invoke");
+  });
+  it("POSTs the event to the ingest endpoint", () => {
+    track("eject_to_code_started", { engine: "codex" });
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/analytics/events"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/dashboard/src/lib/analytics.ts
+++ b/dashboard/src/lib/analytics.ts
@@ -1,13 +1,37 @@
-/** Minimal analytics seam (W3). A full funnel dashboard lands in W4.
- *  track() dispatches a CustomEvent so a listener (or W4 collector) can consume it. */
-export type AnalyticsEvent =
-  | "eject_to_code_started"
-  | "coding_agent_turn"
-  | "eject_to_code_completed"
-  | "deploy_started"
-  | "deploy_succeeded";
+/** Analytics seam for the conversational builder funnel.
+ *
+ *  `track()` is fire-and-forget: it POSTs the event to the ingest endpoint
+ *  (via `ingestAnalytics`, which never throws/blocks) AND dispatches an
+ *  in-page CustomEvent so live listeners (e.g. a debug panel) can observe it.
+ *  PII-free: callers must never pass message/prompt bodies in `props`. */
+import { ingestAnalytics } from "./api";
+
+/** The full conversational-builder funnel taxonomy (W4). */
+export const ANALYTICS_EVENTS = [
+  "builder_session_started",
+  "user_message_sent",
+  "stack_recommended",
+  "setup_card_shown",
+  "setup_card_completed",
+  "spec_validated",
+  "eject_to_code_started",
+  "coding_agent_turn",
+  // Retained from the W3 eject-to-code seam (ChatBuildPanel) — not part of the
+  // core funnel taxonomy but still emitted, so it stays a valid event.
+  "eject_to_code_completed",
+  "deploy_started",
+  "deploy_succeeded",
+  "deploy_failed",
+  "first_invoke",
+] as const;
+
+export type AnalyticsEvent = (typeof ANALYTICS_EVENTS)[number];
 
 export function track(event: AnalyticsEvent, props: Record<string, unknown> = {}): void {
-  if (typeof window === "undefined" || typeof window.dispatchEvent !== "function") return;
-  window.dispatchEvent(new CustomEvent("agentbreeder:analytics", { detail: { event, props } }));
+  // Fire-and-forget ingest — best-effort, never blocks the UI.
+  ingestAnalytics(event, props);
+  // Dispatch an in-page event for live listeners (W4 collectors / debug panel).
+  if (typeof window !== "undefined" && typeof window.dispatchEvent === "function") {
+    window.dispatchEvent(new CustomEvent("agentbreeder:analytics", { detail: { event, props } }));
+  }
 }

--- a/dashboard/src/lib/analytics.ts
+++ b/dashboard/src/lib/analytics.ts
@@ -1,0 +1,13 @@
+/** Minimal analytics seam (W3). A full funnel dashboard lands in W4.
+ *  track() dispatches a CustomEvent so a listener (or W4 collector) can consume it. */
+export type AnalyticsEvent =
+  | "eject_to_code_started"
+  | "coding_agent_turn"
+  | "eject_to_code_completed"
+  | "deploy_started"
+  | "deploy_succeeded";
+
+export function track(event: AnalyticsEvent, props: Record<string, unknown> = {}): void {
+  if (typeof window === "undefined" || typeof window.dispatchEvent !== "function") return;
+  window.dispatchEvent(new CustomEvent("agentbreeder:analytics", { detail: { event, props } }));
+}

--- a/dashboard/src/lib/api.test.ts
+++ b/dashboard/src/lib/api.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { streamSSE } from "@/lib/api";
+
+function sseResponse(body: string): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(body));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+describe("streamSSE", () => {
+  beforeEach(() => {
+    localStorage.setItem("ag-token", "tok");
+  });
+
+  it("parses event/data frames and invokes the handler per event", async () => {
+    const raw =
+      "event: token\ndata: {\"text\":\"Hi\"}\n\n" +
+      "event: done\ndata: {\"agent_yaml\":null}\n\n";
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(sseResponse(raw));
+
+    const seen: Array<{ event: string; data: unknown }> = [];
+    await streamSSE("/builders/chat/stream", { method: "POST", body: "{}" }, (e, d) =>
+      seen.push({ event: e, data: d }),
+    );
+
+    expect(seen).toEqual([
+      { event: "token", data: { text: "Hi" } },
+      { event: "done", data: { agent_yaml: null } },
+    ]);
+  });
+});

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1325,6 +1325,62 @@ export interface BuilderFileChange {
   content: string;
 }
 
+// ---------------------------------------------------------------------------
+// Analytics funnel types (W4)
+// ---------------------------------------------------------------------------
+
+/** One step of the conversational-builder conversion funnel. */
+export interface FunnelStage {
+  key: string;
+  label: string;
+  count: number;
+  /** Percentage of sessions lost relative to the previous stage. */
+  dropoff_pct: number;
+}
+
+/** Per coding-engine quality scorecard (claude vs codex, etc.). */
+export interface EngineScorecard {
+  engine: string;
+  samples: number;
+  spec_validity_rate: number;
+  deploy_success_rate: number;
+  turns_to_spec: number;
+  hallucinated_field_rate: number;
+}
+
+/** Aggregate builder funnel metrics for a period. */
+export interface FunnelMetrics {
+  period: string;
+  time_to_first_deploy_p50_s: number | null;
+  time_to_first_deploy_p90_s: number | null;
+  stages: FunnelStage[];
+  engines: EngineScorecard[];
+}
+
+/**
+ * Fire-and-forget POST of an analytics event to the ingest endpoint. Never
+ * throws and never blocks the caller — failures are swallowed. PII-free: only
+ * the event name, an optional engine tag, and non-sensitive props are sent.
+ * Used by the `track()` seam in `analytics.ts`.
+ */
+export function ingestAnalytics(
+  event: string,
+  props: Record<string, unknown> = {},
+): void {
+  try {
+    void fetch(`${BASE}/analytics/events`, {
+      method: "POST",
+      headers: getAuthHeaders(),
+      body: JSON.stringify({ event, engine: props.engine ?? null, props }),
+      keepalive: true,
+    }).catch(() => {
+      /* analytics is best-effort — never surface failures */
+    });
+  } catch {
+    /* fetch unavailable (SSR) — ignore */
+  }
+}
+
 // --- API functions ---
 
 export const api = {
@@ -2497,6 +2553,10 @@ export const api = {
       ),
     deploy: (id: string) =>
       request<BuilderSession>(`/builder/sessions/${id}/deploy`, { method: "POST" }),
+  },
+  analytics: {
+    funnel: (period: string = "7d") =>
+      request<FunnelMetrics>(`/analytics/funnel?period=${encodeURIComponent(period)}`),
   },
   secrets: {
     workspace: (workspace?: string) =>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -41,6 +41,66 @@ async function request<T>(path: string, init?: RequestInit): Promise<ApiResponse
   return res.json();
 }
 
+/**
+ * Stream a Server-Sent-Events endpoint using fetch (so the Authorization
+ * header works — EventSource cannot set headers). Calls `onEvent(event, data)`
+ * for each parsed `event:`/`data:` frame. Resolves when the stream closes.
+ */
+export async function streamSSE(
+  path: string,
+  init: RequestInit,
+  onEvent: (event: string, data: unknown) => void,
+): Promise<void> {
+  const res = await fetch(`${BASE}${path}`, {
+    ...init,
+    headers: { ...getAuthHeaders(), ...((init.headers as Record<string, string> | undefined) ?? {}) },
+  });
+  if (res.status === 401) {
+    localStorage.removeItem("ag-token");
+    if (window.location.pathname !== "/login") window.location.href = "/login";
+    throw new Error("Session expired");
+  }
+  if (!res.ok || !res.body) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error((body as { detail?: string }).detail ?? `API error ${res.status}`);
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      let sep: number;
+      while ((sep = buffer.indexOf("\n\n")) !== -1) {
+        const frame = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        let event = "message";
+        const dataLines: string[] = [];
+        for (const line of frame.split("\n")) {
+          if (line.startsWith("event:")) event = line.slice(6).trim();
+          else if (line.startsWith("data:")) dataLines.push(line.slice(5).trim());
+        }
+        if (dataLines.length === 0) continue;
+        const dataStr = dataLines.join("\n");
+        let data: unknown = dataStr;
+        try {
+          data = JSON.parse(dataStr);
+        } catch {
+          /* keep raw string */
+        }
+        onEvent(event, data);
+      }
+    }
+  } finally {
+    void reader.cancel();
+  }
+}
+
 // --- Agent types ---
 
 export type AgentStatus = "deploying" | "running" | "stopped" | "failed" | "degraded" | "error";
@@ -1217,6 +1277,18 @@ export interface ChatBuildMessage {
   content: string;
 }
 
+/**
+ * A dependency the agent needs that the user must provide inline before the spec
+ * can finish — emitted as a `setup_request` SSE event when the model calls the
+ * `request_setup` tool. The captured value goes straight to the secrets / MCP
+ * backend; the spec records only the reference (name).
+ */
+export interface ChatBuildSetupRequest {
+  kind: "secret" | "mcp" | "provider";
+  name: string;
+  reason?: string;
+}
+
 /** Result of one POST /builders/chat turn. */
 export interface ChatBuildResult {
   /** The assistant's text reply. Empty string when the model went straight to the tool. */
@@ -1227,6 +1299,8 @@ export interface ChatBuildResult {
   valid: boolean;
   /** Schema validation error messages when valid is false and agent_yaml is set. */
   errors: string[];
+  /** Set when the model called request_setup instead of submitting the spec. */
+  setup_request?: ChatBuildSetupRequest | null;
 }
 
 // --- API functions ---
@@ -2358,6 +2432,17 @@ export const api = {
         method: "POST",
         body: JSON.stringify({ messages }),
       }),
+    /** Streaming variant of `chat` — uses SSE so tokens arrive incrementally.
+     *  Calls `onEvent("token", { text })` per chunk and `onEvent("done", { agent_yaml })` at end. */
+    chatStream: (
+      messages: ChatBuildMessage[],
+      onEvent: (event: string, data: unknown) => void,
+    ) =>
+      streamSSE(
+        "/builders/chat/stream",
+        { method: "POST", body: JSON.stringify({ messages }) },
+        onEvent,
+      ),
   },
   secrets: {
     workspace: (workspace?: string) =>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1303,6 +1303,28 @@ export interface ChatBuildResult {
   setup_request?: ChatBuildSetupRequest | null;
 }
 
+/**
+ * A persisted conversational-builder session. Mirrors the backend
+ * `BuilderSessionResponse`: chat `history`, the generated `agent_yaml`, any
+ * ejected `files` (path → content), and the deploy job id once deployed.
+ */
+export interface BuilderSession {
+  id: string;
+  team: string;
+  engine: "claude" | "codex";
+  agent_yaml: string | null;
+  files: Record<string, string>;
+  deploy_job_id: string | null;
+  history: { role: string; content: string }[];
+}
+
+/** A single file produced/updated by an eject turn (the `file_change` SSE frame). */
+export interface BuilderFileChange {
+  path: string;
+  diff: string;
+  content: string;
+}
+
 // --- API functions ---
 
 export const api = {
@@ -2443,6 +2465,38 @@ export const api = {
         { method: "POST", body: JSON.stringify({ messages }) },
         onEvent,
       ),
+  },
+  builderSessions: {
+    create: (engine: "claude" | "codex" = "claude") =>
+      request<BuilderSession>("/builder/sessions", {
+        method: "POST",
+        body: JSON.stringify({ engine }),
+      }),
+    get: (id: string) => request<BuilderSession>(`/builder/sessions/${id}`),
+    list: () => request<BuilderSession[]>("/builder/sessions"),
+    sendMessage: (
+      id: string,
+      content: string,
+      onEvent: (event: string, data: unknown) => void,
+    ) =>
+      streamSSE(
+        `/builder/sessions/${id}/messages`,
+        { method: "POST", body: JSON.stringify({ content }) },
+        onEvent,
+      ),
+    eject: (
+      id: string,
+      instruction: string,
+      onEvent: (event: string, data: unknown) => void,
+      engine?: "claude" | "codex",
+    ) =>
+      streamSSE(
+        `/builder/sessions/${id}/eject`,
+        { method: "POST", body: JSON.stringify({ instruction, engine }) },
+        onEvent,
+      ),
+    deploy: (id: string) =>
+      request<BuilderSession>(`/builder/sessions/${id}/deploy`, { method: "POST" }),
   },
   secrets: {
     workspace: (workspace?: string) =>

--- a/dashboard/src/pages/agent-wizard.tsx
+++ b/dashboard/src/pages/agent-wizard.tsx
@@ -27,10 +27,17 @@ import {
 type BuilderMode = "form" | "chat";
 
 export default function AgentWizardPage() {
-  const [mode, setMode] = useState<BuilderMode>("form");
-  const [state, dispatch] = useReducer(reducer, initialState);
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
+
+  // If ?mode=chat is in the URL, default to chat mode.
+  const [mode, setMode] = useState<BuilderMode>(
+    searchParams.get("mode") === "chat" ? "chat" : "form",
+  );
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  // Capture ?prompt= once (stable across re-renders).
+  const promptParam = searchParams.get("prompt") ?? undefined;
 
   // On mount: read ?step=N from URL, clamp to the furthest reachable step,
   // and jump there so that reloading /agents/new?step=3 restores the right step.
@@ -151,7 +158,7 @@ export default function AgentWizardPage() {
       <main>
         {mode === "chat" ? (
           <div className="min-h-[480px] rounded-xl border border-border bg-background">
-            <ChatBuildPanel />
+            <ChatBuildPanel initialPrompt={promptParam} />
           </div>
         ) : (
           StepBody

--- a/dashboard/src/pages/builder-insights.test.tsx
+++ b/dashboard/src/pages/builder-insights.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import BuilderInsightsPage from "./builder-insights";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    analytics: {
+      funnel: vi.fn().mockResolvedValue({
+        data: {
+          period: "7d",
+          time_to_first_deploy_p50_s: 240,
+          time_to_first_deploy_p90_s: 600,
+          stages: [
+            { key: "builder_session_started", label: "Converse", count: 100, dropoff_pct: 0 },
+            { key: "deploy_succeeded", label: "Live", count: 38, dropoff_pct: 62 },
+          ],
+          engines: [],
+        },
+        meta: {}, errors: [],
+      }),
+    },
+  },
+}));
+
+function wrap(ui: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>;
+}
+
+describe("BuilderInsightsPage", () => {
+  it("renders the funnel heading and a stage label", async () => {
+    render(wrap(<BuilderInsightsPage />));
+    expect(await screen.findByText("Converse")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Builder/i })).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/pages/builder-insights.tsx
+++ b/dashboard/src/pages/builder-insights.tsx
@@ -1,0 +1,160 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { BarChart3 } from "lucide-react";
+import { api, type FunnelMetrics } from "@/lib/api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
+
+const PERIODS = ["7d", "30d", "all"] as const;
+
+function fmtSeconds(s: number | null): string {
+  if (s == null) return "--";
+  if (s < 90) return `${Math.round(s)}s`;
+  return `${(s / 60).toFixed(1)}m`;
+}
+
+export default function BuilderInsightsPage() {
+  const [period, setPeriod] = useState<(typeof PERIODS)[number]>("7d");
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["builder-funnel", period],
+    queryFn: () => api.analytics.funnel(period),
+  });
+  const metrics: FunnelMetrics | null = data?.data ?? null;
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <h1 className="flex items-center gap-2 font-display text-2xl">
+          <BarChart3 className="h-6 w-6" aria-hidden /> Builder
+        </h1>
+        <Tabs value={period} onValueChange={(v) => setPeriod(v as typeof period)}>
+          <TabsList>
+            {PERIODS.map((p) => (
+              <TabsTrigger key={p} value={p}>
+                {p}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      </div>
+
+      {isLoading && (
+        <div className="animate-pulse space-y-4" aria-busy="true">
+          <div className="h-28 rounded-lg border border-border bg-card" />
+          <div className="h-72 rounded-lg border border-border bg-card" />
+        </div>
+      )}
+
+      {error && (
+        <div className="text-sm text-destructive">
+          Failed to load builder analytics: {(error as Error).message}
+        </div>
+      )}
+
+      {metrics && (
+        <>
+          <Card>
+            <CardHeader>
+              <CardTitle>Time to first deployed agent</CardTitle>
+            </CardHeader>
+            <CardContent className="flex items-end gap-8">
+              <div>
+                <div className="text-xs text-muted-foreground">p50</div>
+                <div className="text-4xl font-semibold tabular-nums">
+                  {fmtSeconds(metrics.time_to_first_deploy_p50_s)}
+                </div>
+              </div>
+              <div>
+                <div className="text-xs text-muted-foreground">p90</div>
+                <div className="text-2xl font-medium tabular-nums text-muted-foreground">
+                  {fmtSeconds(metrics.time_to_first_deploy_p90_s)}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Conversion funnel</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {metrics.stages.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No builder sessions yet. Start one from the Agent Wizard.
+                </p>
+              ) : (
+                <ul role="list" className="space-y-3" aria-label={`Builder funnel for ${metrics.period}`}>
+                  {metrics.stages.map((s, i) => {
+                    const top = metrics.stages[0]?.count || 1;
+                    const pct = Math.round((s.count / top) * 100);
+                    const worst = Math.max(...metrics.stages.map((x) => x.dropoff_pct));
+                    const isWorst = i > 0 && s.dropoff_pct === worst && worst > 0;
+                    return (
+                      <li key={s.key} className={cn("rounded-md", isWorst && "border-l-2 border-amber-500 pl-2")}>
+                        <div className="flex items-center justify-between text-sm">
+                          <span>{s.label}</span>
+                          <span className="tabular-nums text-muted-foreground">
+                            {s.count.toLocaleString()}
+                            {i > 0 && (
+                              <span className="ml-2 text-amber-600 dark:text-amber-400">▼ {s.dropoff_pct}%</span>
+                            )}
+                          </span>
+                        </div>
+                        <div className="mt-1 h-2 w-full rounded-full bg-muted">
+                          <div
+                            className="h-full rounded-full bg-emerald-500 transition-all"
+                            style={{ width: `${pct}%` }}
+                          />
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+
+          {metrics.engines.length > 0 && (
+            <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+              {metrics.engines.map((e) => (
+                <Card key={e.engine}>
+                  <CardHeader>
+                    <CardTitle className="capitalize">
+                      {e.engine} ({e.samples})
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-2 text-sm">
+                    <ScoreRow label="Spec validity" v={e.spec_validity_rate} />
+                    <ScoreRow label="Deploy success" v={e.deploy_success_rate} />
+                    <div className="flex justify-between">
+                      <span>Turns to spec</span>
+                      <span className="tabular-nums">{e.turns_to_spec}</span>
+                    </div>
+                    <ScoreRow label="Hallucinated fields" v={e.hallucinated_field_rate} invert />
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function ScoreRow({ label, v, invert = false }: { label: string; v: number; invert?: boolean }) {
+  const good = invert ? v <= 0.2 : v >= 0.8;
+  const mid = invert ? v <= 0.4 : v >= 0.6;
+  const color = good ? "bg-emerald-500" : mid ? "bg-amber-500" : "bg-red-500";
+  return (
+    <div>
+      <div className="flex justify-between">
+        <span>{label}</span>
+        <span className="tabular-nums">{Math.round(v * 100)}%</span>
+      </div>
+      <div className="mt-1 h-1.5 w-full rounded-full bg-muted">
+        <div className={cn("h-full rounded-full", color)} style={{ width: `${Math.round(v * 100)}%` }} />
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/pages/home.tsx
+++ b/dashboard/src/pages/home.tsx
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { Bot, Wrench, Circle, ArrowRight, Activity } from "lucide-react";
 import { api, type Agent } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { PageTitle } from "@/components/page-title";
 import { GetStartedChecklist } from "@/components/get-started-checklist";
+import { BuildFrontDoor } from "@/components/home/BuildFrontDoor";
 
 const STATUS_COLORS: Record<string, string> = {
   running: "text-primary",
@@ -55,6 +56,8 @@ function RecentAgent({ agent }: { agent: Agent }) {
 }
 
 export default function HomePage() {
+  const navigate = useNavigate();
+
   const agentsQuery = useQuery({
     queryKey: ["agents", {}],
     queryFn: () => api.agents.list({ per_page: 5 }),
@@ -72,13 +75,31 @@ export default function HomePage() {
   const totalTools = toolsQuery.data?.meta.total ?? 0;
   const running = agents.filter((a) => a.status === "running").length;
 
+  // Show the conversational front door only when the workspace has no agents yet
+  // and the query has finished loading (so we don't flash it while loading).
+  const isEmptyWorkspace = !agentsQuery.isLoading && totalAgents === 0;
+
+  function handleFrontDoorStart(prompt: string) {
+    navigate(`/agents/new?prompt=${encodeURIComponent(prompt)}&mode=chat`);
+  }
+
   return (
     <div className="ab-radial-glow mx-auto max-w-5xl p-6">
       <div className="relative z-10 mb-8">
         <PageTitle subtitle="Overview">Home</PageTitle>
       </div>
 
-      <GetStartedChecklist />
+      {/* Conversational front door — primary hero when workspace is empty */}
+      {isEmptyWorkspace && (
+        <div className="relative z-10 mb-8">
+          <BuildFrontDoor onStart={handleFrontDoorStart} />
+        </div>
+      )}
+
+      {/* Setup progress — secondary block (always rendered) */}
+      <div className={isEmptyWorkspace ? "relative z-10 mb-8" : undefined}>
+        <GetStartedChecklist />
+      </div>
 
       {/* Stats */}
       <div className="relative z-10 mb-8 grid gap-3 sm:grid-cols-3">

--- a/docs/superpowers/plans/2026-06-14-studio-conversational-builder-wave1.md
+++ b/docs/superpowers/plans/2026-06-14-studio-conversational-builder-wave1.md
@@ -1,0 +1,968 @@
+# Studio Conversational Builder — Wave 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Studio's first-run a conversation that streams the agent-builder interview token-by-token and lets the user deploy the built agent without leaving the thread — locally and (for free, via the proxy) in cloud.
+
+**Architecture:** Add a streaming variant of the existing chat-to-build driver (`run_chat_turn_stream`) and an SSE endpoint (`POST /api/v1/builders/chat/stream`) that reuses the existing BYO-key security contract. On the frontend, add a reusable fetch-based SSE reader, upgrade `ChatBuildPanel` to stream tokens and to deploy-from-chat (calling the existing `/deploys` + `/deployments/{id}/stream`), and turn the home empty-state into a conversational front door. No server-side `BuilderSession` resource yet — Wave 1 keeps the conversation client-held (reusing the stateless chat contract); the resumable server session lands in Wave 3 when the coding agent needs a persistent workspace. This is a deliberate YAGNI deviation from spec §6, documented here.
+
+**Tech Stack:** Python 3.11 / FastAPI / `sse-starlette` (`EventSourceResponse`) / pytest · React 18 / TypeScript / TanStack Query / Vitest.
+
+---
+
+## File Structure
+
+**Backend**
+- Modify `engine/agent_chat_builder.py` — add `run_chat_turn_stream()` async generator + `ChatStreamEvent` dataclass; reuse existing `_handle_spec_submission()`.
+- Modify `api/routes/builders.py` — add `POST /chat/stream` SSE endpoint (mirrors `chat_build` security, returns `EventSourceResponse`).
+- Test `tests/unit/test_agent_chat_builder_stream.py` — streaming driver against a `FakeStreamingProvider`.
+- Test `tests/integration/test_builders_chat_stream.py` — endpoint auth + event shape with a mocked provider.
+
+**Frontend**
+- Modify `dashboard/src/lib/api.ts` — add `streamSSE()` helper + `api.builders.chatStream()` + reuse for deploy log tailing.
+- Modify `dashboard/src/components/agent-wizard/ChatBuildPanel.tsx` — consume streamed tokens; add `DeployFromChatCard`.
+- Create `dashboard/src/components/home/BuildFrontDoor.tsx` — conversational empty-state (prompt + example chips).
+- Modify `dashboard/src/pages/home.tsx` — render `BuildFrontDoor` as primary empty-state; demote `GetStartedChecklist` to a progress rail.
+- Test `dashboard/src/components/agent-wizard/ChatBuildPanel.test.tsx` and `dashboard/src/components/home/BuildFrontDoor.test.tsx`.
+
+**Docs**
+- Modify `website/content/docs/quickstart.mdx` and `website/content/docs/how-to.mdx` — describe the conversational front door.
+
+---
+
+## Task 1: Streaming chat-build driver
+
+**Files:**
+- Modify: `engine/agent_chat_builder.py`
+- Test: `tests/unit/test_agent_chat_builder_stream.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_agent_chat_builder_stream.py
+"""Unit tests for the streaming agent-builder driver."""
+from __future__ import annotations
+
+import pytest
+
+from engine.agent_chat_builder import ChatStreamEvent, run_chat_turn_stream
+from engine.providers.models import StreamChunk, ToolCall
+
+
+class FakeStreamingProvider:
+    """Yields a scripted sequence of StreamChunks from generate_stream()."""
+
+    def __init__(self, chunks: list[StreamChunk]) -> None:
+        self._chunks = chunks
+        self.closed = False
+
+    async def generate_stream(self, **_kwargs):
+        for chunk in self._chunks:
+            yield chunk
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_stream_emits_text_tokens_then_done():
+    provider = FakeStreamingProvider(
+        [
+            StreamChunk(content="Hi! "),
+            StreamChunk(content="What should it do?"),
+            StreamChunk(finish_reason="stop"),
+        ]
+    )
+    events = [e async for e in run_chat_turn_stream(provider, [{"role": "user", "content": "hello"}])]
+
+    tokens = [e.text for e in events if e.type == "token"]
+    done = [e for e in events if e.type == "done"]
+
+    assert "".join(tokens) == "Hi! What should it do?"
+    assert len(done) == 1
+    assert done[0].result.agent_yaml is None
+    assert done[0].result.valid is False
+
+
+@pytest.mark.asyncio
+async def test_stream_handles_spec_submission():
+    spec = (
+        '{"name":"my-agent","version":"1.0.0","team":"default",'
+        '"owner":"owner@example.com","framework":"langgraph",'
+        '"model":{"primary":"claude-sonnet-4-6"},"deploy":{"cloud":"local"}}'
+    )
+    provider = FakeStreamingProvider(
+        [
+            StreamChunk(tool_calls=[ToolCall(id="t1", function_name="submit_agent_spec", function_arguments=spec)]),
+            StreamChunk(finish_reason="tool_calls"),
+        ]
+    )
+    events = [e async for e in run_chat_turn_stream(provider, [{"role": "user", "content": "build it"}])]
+
+    done = [e for e in events if e.type == "done"]
+    assert len(done) == 1
+    assert done[0].result.agent_yaml is not None
+    assert done[0].result.valid is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/pytest tests/unit/test_agent_chat_builder_stream.py -v`
+Expected: FAIL with `ImportError: cannot import name 'ChatStreamEvent'` (and `run_chat_turn_stream`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `engine/agent_chat_builder.py` (after the `ChatTurnResult` dataclass, before `run_chat_turn`):
+
+```python
+from collections.abc import AsyncIterator
+
+
+@dataclass
+class ChatStreamEvent:
+    """One event from run_chat_turn_stream().
+
+    type == "token": `text` carries an incremental assistant text fragment.
+    type == "done":  `result` carries the final ChatTurnResult (spec or text reply).
+    """
+
+    type: str
+    text: str = ""
+    result: ChatTurnResult | None = None
+
+
+async def run_chat_turn_stream(
+    provider: Any,
+    history: list[dict[str, Any]],
+) -> AsyncIterator[ChatStreamEvent]:
+    """Streaming variant of run_chat_turn().
+
+    Yields ChatStreamEvent(type="token") for each text fragment as it arrives,
+    then exactly one ChatStreamEvent(type="done") with the final ChatTurnResult.
+    Security contract is identical to run_chat_turn(): the key lives inside the
+    injected provider and is never read, logged, or returned here.
+    """
+    if len(history) > MAX_HISTORY_MESSAGES:
+        history = history[-MAX_HISTORY_MESSAGES:]
+    history = [m for m in history if m.get("role") in {"user", "assistant"}]
+
+    messages: list[dict[str, Any]] = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        *history,
+    ]
+
+    text_parts: list[str] = []
+    tool_args: str | None = None
+
+    async for chunk in provider.generate_stream(
+        messages=messages,
+        model=DEFAULT_MODEL,
+        max_tokens=2048,
+        tools=[SUBMIT_TOOL],
+    ):
+        if chunk.content:
+            text_parts.append(chunk.content)
+            yield ChatStreamEvent(type="token", text=chunk.content)
+        if chunk.tool_calls:
+            for tc in chunk.tool_calls:
+                if tc.function_name == SUBMIT_TOOL_NAME and tc.function_arguments:
+                    tool_args = tc.function_arguments
+
+    if tool_args is not None:
+        result = _handle_spec_submission(tool_args)
+    else:
+        result = ChatTurnResult(
+            assistant_message="".join(text_parts),
+            agent_yaml=None,
+            valid=False,
+            errors=[],
+        )
+    yield ChatStreamEvent(type="done", result=result)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./venv/bin/pytest tests/unit/test_agent_chat_builder_stream.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Verify AnthropicProvider conforms to the contract**
+
+The streaming driver assumes `AnthropicProvider.generate_stream()` yields `StreamChunk.content` text fragments and, for tool use, a `StreamChunk.tool_calls[*]` whose `function_arguments` is the fully-assembled JSON. Read `engine/providers/anthropic_provider.py::generate_stream` and confirm it assembles `input_json_delta` partials into a complete arguments string before yielding (Anthropic streams tool input as `partial_json`). If it does not, add the assembly there with its own unit test — do NOT work around it in the driver.
+
+Run: `./venv/bin/pytest tests/unit/ -k "anthropic and stream" -v`
+Expected: PASS (or add a test that pins the assembled-args behavior).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add engine/agent_chat_builder.py tests/unit/test_agent_chat_builder_stream.py
+git commit -m "feat(builder): streaming chat-build driver (run_chat_turn_stream)"
+```
+
+---
+
+## Task 2: SSE endpoint `POST /builders/chat/stream`
+
+**Files:**
+- Modify: `api/routes/builders.py`
+- Test: `tests/integration/test_builders_chat_stream.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/integration/test_builders_chat_stream.py
+"""Integration tests for POST /api/v1/builders/chat/stream."""
+from __future__ import annotations
+
+import pytest
+
+from engine.agent_chat_builder import ChatStreamEvent, ChatTurnResult
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_requires_key(async_client, auth_headers, monkeypatch):
+    """With no BYO key stored, the endpoint returns 400 before constructing a provider."""
+
+    class _Backend:
+        async def get(self, _name):
+            return None
+
+    monkeypatch.setattr(
+        "api.routes.builders.get_workspace_backend", lambda: (_Backend(), None)
+    )
+
+    resp = await async_client.post(
+        "/api/v1/builders/chat/stream",
+        headers=auth_headers,
+        json={"messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 400
+    assert "key" in resp.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_chat_stream_emits_token_and_done_events(async_client, auth_headers, monkeypatch):
+    class _Backend:
+        async def get(self, _name):
+            return "sk-ant-test"
+
+    monkeypatch.setattr(
+        "api.routes.builders.get_workspace_backend", lambda: (_Backend(), None)
+    )
+
+    class _Provider:
+        def __init__(self, *_a, **_k):
+            pass
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr("api.routes.builders.AnthropicProvider", _Provider)
+
+    async def _fake_stream(_provider, _history):
+        yield ChatStreamEvent(type="token", text="Hello")
+        yield ChatStreamEvent(
+            type="done",
+            result=ChatTurnResult(assistant_message="Hello", agent_yaml=None, valid=False, errors=[]),
+        )
+
+    monkeypatch.setattr("api.routes.builders.run_chat_turn_stream", _fake_stream)
+
+    resp = await async_client.post(
+        "/api/v1/builders/chat/stream",
+        headers=auth_headers,
+        json={"messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 200
+    assert "text/event-stream" in resp.headers["content-type"]
+    body = resp.text
+    assert "event: token" in body
+    assert "event: done" in body
+    assert "Hello" in body
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./venv/bin/pytest tests/integration/test_builders_chat_stream.py -v`
+Expected: FAIL with 404 (route not registered) / missing `run_chat_turn_stream` import.
+
+- [ ] **Step 3: Write minimal implementation**
+
+At the top of `api/routes/builders.py`, extend the existing import:
+
+```python
+from engine.agent_chat_builder import (
+    ChatTurnResult,
+    run_chat_turn,
+    run_chat_turn_stream,
+)
+```
+
+Add the `sse-starlette` import near the other imports:
+
+```python
+from sse_starlette.sse import EventSourceResponse
+```
+
+Add the endpoint immediately after `chat_build`:
+
+```python
+@router.post("/chat/stream")
+async def chat_build_stream(
+    body: ChatBuildRequest,
+    current_user: User = Depends(get_current_user),
+) -> EventSourceResponse:
+    """Streaming variant of POST /builders/chat.
+
+    Identical BYO-key security contract: the key is read server-side from the
+    workspace secrets backend (AGENTBREEDER_CLAUDE_BUILDER_KEY__{user.id}),
+    never stored, never returned, never logged. Emits SSE events:
+      - "token": {"text": "..."}   incremental assistant text
+      - "done":  the final ChatTurnResult as JSON
+      - "error": {"detail": "..."} on upstream/auth failure
+    """
+    secret_name = _builder_key_name(current_user)
+    backend, _ws = get_workspace_backend()
+    api_key: str | None = await backend.get(secret_name)
+    if not api_key:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "No Claude key connected. Add your Claude API key in "
+                f"Settings → Secrets as '{secret_name}'."
+            ),
+        )
+
+    history = [{"role": m.role, "content": m.content} for m in body.messages]
+
+    async def generator() -> AsyncGenerator[dict[str, str], None]:
+        provider = AnthropicProvider(
+            ProviderConfig(provider_type=ProviderType.anthropic, api_key=api_key)
+        )
+        try:
+            async for evt in run_chat_turn_stream(provider, history):
+                if evt.type == "token":
+                    yield {"event": "token", "data": json.dumps({"text": evt.text})}
+                elif evt.type == "done" and evt.result is not None:
+                    yield {"event": "done", "data": json.dumps(asdict(evt.result))}
+        except AuthenticationError:
+            logger.warning("chat_build_stream: auth failed for '%s' (key not logged)", secret_name)
+            yield {"event": "error", "data": json.dumps({"detail": "Claude API authentication failed."})}
+        except ProviderError:
+            logger.warning("chat_build_stream: upstream error for '%s'.", secret_name)
+            yield {"event": "error", "data": json.dumps({"detail": "Upstream Claude API error."})}
+        finally:
+            await provider.close()
+
+    return EventSourceResponse(generator())
+```
+
+Ensure these are imported at the top of the file (add any missing): `import json`, `from dataclasses import asdict`, `from collections.abc import AsyncGenerator`, and the existing `AuthenticationError`, `ProviderError` from `engine.providers.base`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./venv/bin/pytest tests/integration/test_builders_chat_stream.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Verify the route is wired and auth-gated**
+
+Run: `./venv/bin/pytest tests/integration/ -k builders -v`
+Expected: PASS. Confirm `/builders/chat/stream` appears in the OpenAPI and is behind `get_current_user` (no anonymous access), consistent with the 247/247 auth-gated-routes invariant.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/routes/builders.py tests/integration/test_builders_chat_stream.py
+git commit -m "feat(api): SSE streaming endpoint POST /builders/chat/stream"
+```
+
+---
+
+## Task 3: Frontend SSE helper + `api.builders.chatStream`
+
+**Files:**
+- Modify: `dashboard/src/lib/api.ts`
+- Test: `dashboard/src/lib/api.test.ts` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// dashboard/src/lib/api.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { streamSSE } from "@/lib/api";
+
+function sseResponse(body: string): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(body));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+describe("streamSSE", () => {
+  beforeEach(() => {
+    localStorage.setItem("ag-token", "tok");
+  });
+
+  it("parses event/data frames and invokes the handler per event", async () => {
+    const raw =
+      "event: token\ndata: {\"text\":\"Hi\"}\n\n" +
+      "event: done\ndata: {\"agent_yaml\":null}\n\n";
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(sseResponse(raw));
+
+    const seen: Array<{ event: string; data: unknown }> = [];
+    await streamSSE("/builders/chat/stream", { method: "POST", body: "{}" }, (e, d) =>
+      seen.push({ event: e, data: d }),
+    );
+
+    expect(seen).toEqual([
+      { event: "token", data: { text: "Hi" } },
+      { event: "done", data: { agent_yaml: null } },
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dashboard && npx vitest run src/lib/api.test.ts`
+Expected: FAIL — `streamSSE` is not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `dashboard/src/lib/api.ts` (after the `request` helper, and export it):
+
+```typescript
+/**
+ * Stream a Server-Sent-Events endpoint using fetch (so the Authorization
+ * header works — EventSource cannot set headers). Calls `onEvent(event, data)`
+ * for each parsed `event:`/`data:` frame. Resolves when the stream closes.
+ */
+export async function streamSSE(
+  path: string,
+  init: RequestInit,
+  onEvent: (event: string, data: unknown) => void,
+): Promise<void> {
+  const res = await fetch(`${BASE}${path}`, { headers: getAuthHeaders(), ...init });
+  if (res.status === 401) {
+    localStorage.removeItem("ag-token");
+    if (window.location.pathname !== "/login") window.location.href = "/login";
+    throw new Error("Session expired");
+  }
+  if (!res.ok || !res.body) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.detail ?? `API error ${res.status}`);
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    let sep: number;
+    while ((sep = buffer.indexOf("\n\n")) !== -1) {
+      const frame = buffer.slice(0, sep);
+      buffer = buffer.slice(sep + 2);
+      let event = "message";
+      const dataLines: string[] = [];
+      for (const line of frame.split("\n")) {
+        if (line.startsWith("event:")) event = line.slice(6).trim();
+        else if (line.startsWith("data:")) dataLines.push(line.slice(5).trim());
+      }
+      if (dataLines.length === 0) continue;
+      const dataStr = dataLines.join("\n");
+      let data: unknown = dataStr;
+      try {
+        data = JSON.parse(dataStr);
+      } catch {
+        /* keep raw string */
+      }
+      onEvent(event, data);
+    }
+  }
+}
+```
+
+Add to the `builders` object in `api` (alongside `chat`):
+
+```typescript
+    chatStream: (
+      messages: ChatBuildMessage[],
+      onEvent: (event: string, data: unknown) => void,
+    ) =>
+      streamSSE(
+        "/builders/chat/stream",
+        { method: "POST", body: JSON.stringify({ messages }) },
+        onEvent,
+      ),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dashboard && npx vitest run src/lib/api.test.ts`
+Expected: PASS (1 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/src/lib/api.ts dashboard/src/lib/api.test.ts
+git commit -m "feat(studio): fetch-based SSE helper + api.builders.chatStream"
+```
+
+---
+
+## Task 4: Stream tokens in ChatBuildPanel
+
+**Files:**
+- Modify: `dashboard/src/components/agent-wizard/ChatBuildPanel.tsx`
+- Test: `dashboard/src/components/agent-wizard/ChatBuildPanel.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// dashboard/src/components/agent-wizard/ChatBuildPanel.test.tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { ChatBuildPanel } from "./ChatBuildPanel";
+import { api } from "@/lib/api";
+
+vi.mock("@/hooks/use-auth", () => ({ useAuth: () => ({ user: { id: "u1" } }) }));
+
+function renderPanel() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <ChatBuildPanel />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ChatBuildPanel streaming", () => {
+  beforeEach(() => {
+    vi.spyOn(api.secrets, "list").mockResolvedValue({
+      data: [{ name: "AGENTBREEDER_CLAUDE_BUILDER_KEY__u1" }],
+      meta: { page: 1, per_page: 50, total: 1 },
+      errors: [],
+    } as never);
+  });
+
+  it("renders streamed tokens incrementally then the done reply", async () => {
+    vi.spyOn(api.builders, "chatStream").mockImplementation(async (_m, onEvent) => {
+      onEvent("token", { text: "Hel" });
+      onEvent("token", { text: "lo" });
+      onEvent("done", { assistant_message: "Hello", agent_yaml: null, valid: false, errors: [] });
+    });
+
+    renderPanel();
+    fireEvent.change(await screen.findByTestId("chat-input"), { target: { value: "hi" } });
+    fireEvent.click(screen.getByTestId("send-btn"));
+
+    await waitFor(() => expect(screen.getByText("Hello")).toBeInTheDocument());
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dashboard && npx vitest run src/components/agent-wizard/ChatBuildPanel.test.tsx`
+Expected: FAIL — panel still calls `api.builders.chat` (mock for `chatStream` unused; no "Hello" appears as a streamed bubble).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `ChatBuildPanel.tsx`, replace the `chatMutation` (useMutation calling `api.builders.chat`) and `handleSend` body with a streaming send. Add a `streaming` text buffer state and render it as a live assistant bubble:
+
+```typescript
+  const [streaming, setStreaming] = useState<string | null>(null);
+  const [sending, setSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+
+  const sendStreaming = useCallback(
+    async (msgs: ChatBuildMessage[]) => {
+      setSending(true);
+      setStreaming("");
+      setSendError(null);
+      let acc = "";
+      try {
+        await api.builders.chatStream(msgs, (event, data) => {
+          if (event === "token") {
+            acc += (data as { text: string }).text;
+            setStreaming(acc);
+          } else if (event === "done") {
+            const result = data as ChatBuildResult;
+            setStreaming(null);
+            if (result.agent_yaml) {
+              setPendingSpec(result);
+              if (result.assistant_message) {
+                setEntries((prev) => [
+                  ...prev,
+                  { id: generateId(), role: "assistant", content: result.assistant_message },
+                ]);
+              }
+            } else {
+              setEntries((prev) => [
+                ...prev,
+                { id: generateId(), role: "assistant", content: result.assistant_message || acc },
+              ]);
+            }
+          } else if (event === "error") {
+            setSendError((data as { detail?: string }).detail ?? "Something went wrong.");
+          }
+        });
+      } catch (err) {
+        setSendError((err as Error).message || "Something went wrong.");
+      } finally {
+        setSending(false);
+        setStreaming(null);
+      }
+    },
+    [],
+  );
+```
+
+Update `handleSend` to call `void sendStreaming(buildHistory(trimmed))` instead of `chatMutation.mutate(...)`, and replace every `chatMutation.isPending` with `sending` and `chatMutation.isError`/`chatMutation.error` with `sendError`. Render the live streaming bubble below the message list:
+
+```tsx
+        {streaming !== null && (
+          <ChatBubble entry={{ id: "streaming", role: "assistant", content: streaming || "…" }} />
+        )}
+```
+
+Remove the now-unused `useMutation` import for chat (keep it if still used by `SpecReadyCard`/`KeyEntryGuard`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dashboard && npx vitest run src/components/agent-wizard/ChatBuildPanel.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/src/components/agent-wizard/ChatBuildPanel.tsx dashboard/src/components/agent-wizard/ChatBuildPanel.test.tsx
+git commit -m "feat(studio): stream interview tokens in ChatBuildPanel"
+```
+
+---
+
+## Task 5: Deploy-from-chat
+
+**Files:**
+- Modify: `dashboard/src/components/agent-wizard/ChatBuildPanel.tsx`
+- Test: `dashboard/src/components/agent-wizard/ChatBuildPanel.test.tsx` (add a case)
+
+The existing `SpecReadyCard` only offers "Create agent". Add a **Deploy** action: create the agent from YAML, trigger a `local` deploy, and tail logs via the existing deployment SSE stream (`/api/v1/deployments/{id}/stream` — note the `deployments` prefix, distinct from the `deploys` create route).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// add to ChatBuildPanel.test.tsx
+import { within } from "@testing-library/react";
+
+it("deploys the built agent and tails logs to the thread", async () => {
+  vi.spyOn(api.builders, "chatStream").mockImplementation(async (_m, onEvent) => {
+    onEvent("done", {
+      assistant_message: "",
+      agent_yaml: "name: my-agent\nversion: 1.0.0\n",
+      valid: true,
+      errors: [],
+    });
+  });
+  vi.spyOn(api.agents, "fromYaml").mockResolvedValue({
+    data: { id: "a1", name: "my-agent" }, meta: { page: 1, per_page: 1, total: 1 }, errors: [],
+  } as never);
+  vi.spyOn(api.deploys, "create").mockResolvedValue({
+    data: { id: "job1", status: "parsing" }, meta: { page: 1, per_page: 1, total: 1 }, errors: [],
+  } as never);
+  const streamSpy = vi
+    .spyOn(api.deploys, "streamLogs")
+    .mockImplementation(async (_id, onEvent) => {
+      onEvent("log", { level: "info", message: "Building image…" });
+      onEvent("complete", { endpoint_url: "http://localhost:8080" });
+    });
+
+  renderPanel();
+  fireEvent.change(await screen.findByTestId("chat-input"), { target: { value: "build it" } });
+  fireEvent.click(screen.getByTestId("send-btn"));
+
+  const card = await screen.findByTestId("spec-ready-card");
+  fireEvent.click(within(card).getByTestId("deploy-agent-btn"));
+
+  await waitFor(() => expect(streamSpy).toHaveBeenCalledWith("job1", expect.any(Function)));
+  await waitFor(() => expect(screen.getByText(/Building image/)).toBeInTheDocument());
+  await waitFor(() => expect(screen.getByText(/localhost:8080/)).toBeInTheDocument());
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dashboard && npx vitest run src/components/agent-wizard/ChatBuildPanel.test.tsx`
+Expected: FAIL — `api.deploys.streamLogs` undefined and no `deploy-agent-btn`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `streamLogs` to the `deploys` object in `dashboard/src/lib/api.ts`:
+
+```typescript
+    streamLogs: (id: string, onEvent: (event: string, data: unknown) => void) =>
+      streamSSE(`/deployments/${id}/stream`, { method: "GET" }, onEvent),
+```
+
+In `ChatBuildPanel.tsx`, extend `SpecReadyCard` with a Deploy button and inline log tail:
+
+```tsx
+  const [logs, setLogs] = useState<string[]>([]);
+  const [endpoint, setEndpoint] = useState<string | null>(null);
+  const [deploying, setDeploying] = useState(false);
+
+  async function handleDeploy() {
+    setDeploying(true);
+    setLogs([]);
+    setEndpoint(null);
+    try {
+      await api.agents.fromYaml(agentYaml);
+      const job = await api.deploys.create({ config_yaml: agentYaml, target: "local" });
+      await api.deploys.streamLogs(job.data.id, (event, data) => {
+        if (event === "log") {
+          setLogs((prev) => [...prev, (data as { message: string }).message]);
+        } else if (event === "complete") {
+          const url = (data as { endpoint_url?: string }).endpoint_url ?? null;
+          setEndpoint(url);
+        } else if (event === "error") {
+          setLogs((prev) => [...prev, `Error: ${(data as { detail?: string }).detail ?? "deploy failed"}`]);
+        }
+      });
+    } finally {
+      setDeploying(false);
+    }
+  }
+```
+
+Render (inside the valid branch of `SpecReadyCard`, below the existing "Create agent" button):
+
+```tsx
+      <Button
+        data-testid="deploy-agent-btn"
+        variant="secondary"
+        onClick={handleDeploy}
+        disabled={deploying}
+        className="w-full"
+      >
+        {deploying ? (
+          <><Loader2 className="mr-2 size-4 animate-spin" />Deploying…</>
+        ) : (
+          "Deploy now"
+        )}
+      </Button>
+      {logs.length > 0 && (
+        <pre className="rounded-lg bg-background border border-border px-3 py-2 text-[11px] max-h-40 overflow-y-auto">
+          {logs.join("\n")}
+        </pre>
+      )}
+      {endpoint && (
+        <a href={endpoint} target="_blank" rel="noopener noreferrer" className="text-xs underline text-green-600">
+          Agent live at {endpoint} — test it in the Playground
+        </a>
+      )}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dashboard && npx vitest run src/components/agent-wizard/ChatBuildPanel.test.tsx`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Verify the deployment stream path against the backend**
+
+Confirm the `DeployJob.id` returned by `POST /api/v1/deploys` is the same id accepted by `GET /api/v1/deployments/{id}/stream` (both should resolve through `app.state.deploy_job_service`). If the two routers use different id spaces, adjust `streamLogs` to the correct prefix. Run a local smoke deploy: `agentbreeder deploy --target local` and confirm logs stream.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/src/lib/api.ts dashboard/src/components/agent-wizard/ChatBuildPanel.tsx dashboard/src/components/agent-wizard/ChatBuildPanel.test.tsx
+git commit -m "feat(studio): deploy-from-chat with live log tail"
+```
+
+---
+
+## Task 6: Conversational front door on home
+
+**Files:**
+- Create: `dashboard/src/components/home/BuildFrontDoor.tsx`
+- Modify: `dashboard/src/pages/home.tsx`
+- Test: `dashboard/src/components/home/BuildFrontDoor.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// dashboard/src/components/home/BuildFrontDoor.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BuildFrontDoor } from "./BuildFrontDoor";
+
+describe("BuildFrontDoor", () => {
+  it("shows the prompt and example chips, and calls onStart with the chosen text", () => {
+    const onStart = vi.fn();
+    render(<BuildFrontDoor onStart={onStart} />);
+    expect(screen.getByText(/what do you want to build/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByText(/support agent/i));
+    expect(onStart).toHaveBeenCalledWith(expect.stringMatching(/support agent/i));
+  });
+
+  it("submits the freeform prompt", () => {
+    const onStart = vi.fn();
+    render(<BuildFrontDoor onStart={onStart} />);
+    fireEvent.change(screen.getByTestId("frontdoor-input"), { target: { value: "an invoice bot" } });
+    fireEvent.submit(screen.getByTestId("frontdoor-form"));
+    expect(onStart).toHaveBeenCalledWith("an invoice bot");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dashboard && npx vitest run src/components/home/BuildFrontDoor.test.tsx`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```tsx
+// dashboard/src/components/home/BuildFrontDoor.tsx
+import { useState } from "react";
+import { Sparkles, ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const EXAMPLES = [
+  "A support agent that reads our docs and Zendesk",
+  "A daily news digest agent emailed to the team",
+  "An invoice-processing agent that extracts line items",
+];
+
+export function BuildFrontDoor({ onStart }: { onStart: (prompt: string) => void }) {
+  const [value, setValue] = useState("");
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col items-center gap-6 py-12 text-center">
+      <div className="flex size-12 items-center justify-center rounded-full bg-primary/10">
+        <Sparkles className="size-6 text-primary" />
+      </div>
+      <h1 className="text-2xl font-semibold">What do you want to build today?</h1>
+      <p className="text-sm text-muted-foreground">
+        Describe your agent in plain language. I&apos;ll ask a few questions, generate a
+        ready-to-deploy <span className="font-mono">agent.yaml</span>, and ship it.
+      </p>
+      <form
+        data-testid="frontdoor-form"
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (value.trim()) onStart(value.trim());
+        }}
+        className="flex w-full items-center gap-2"
+      >
+        <input
+          data-testid="frontdoor-input"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="e.g. a customer-support agent for our SaaS"
+          className={cn(
+            "flex-1 rounded-lg border border-border bg-background px-4 py-3 text-sm",
+            "focus:outline-none focus:ring-2 focus:ring-primary/50",
+          )}
+        />
+        <Button type="submit" disabled={!value.trim()} size="icon" className="shrink-0">
+          <ArrowRight className="size-4" />
+        </Button>
+      </form>
+      <div className="flex flex-wrap justify-center gap-2">
+        {EXAMPLES.map((ex) => (
+          <button
+            key={ex}
+            type="button"
+            onClick={() => onStart(ex)}
+            className="rounded-full border border-border bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted"
+          >
+            {ex}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dashboard && npx vitest run src/components/home/BuildFrontDoor.test.tsx`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Wire into home.tsx**
+
+In `dashboard/src/pages/home.tsx`: when the workspace has **no agents yet**, render `<BuildFrontDoor onStart={(p) => navigate("/agents/new?prompt=" + encodeURIComponent(p) + "&mode=chat")} />` as the primary hero (above stats). Move `<GetStartedChecklist />` into a smaller secondary "Setup progress" rail (e.g. a right column or a collapsed card) rather than the main focus. Keep the checklist component itself unchanged. Then in `agent-wizard.tsx`, read the `prompt` query param and, when present with `mode=chat`, pre-seed the chat panel's first user message and auto-send.
+
+- [ ] **Step 6: Run the full frontend suite + typecheck**
+
+Run: `cd dashboard && npx vitest run && npm run typecheck`
+Expected: PASS, zero TS errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add dashboard/src/components/home/BuildFrontDoor.tsx dashboard/src/components/home/BuildFrontDoor.test.tsx dashboard/src/pages/home.tsx dashboard/src/pages/agent-wizard.tsx
+git commit -m "feat(studio): conversational front door on home empty-state"
+```
+
+---
+
+## Task 7: Docs + cross-repo sync
+
+**Files:**
+- Modify: `website/content/docs/quickstart.mdx`
+- Modify: `website/content/docs/how-to.mdx`
+
+- [ ] **Step 1: Update quickstart**
+
+Add a "Build from a conversation" section to `quickstart.mdx`: land in Studio → type what you want → answer 3–5 streamed questions → review the generated `agent.yaml` → click **Deploy now** and watch logs in the thread. Note it works locally and in cloud (cloud meters turns).
+
+- [ ] **Step 2: Update how-to**
+
+In `how-to.mdx`, add the conversational front door to the Studio walkthrough and cross-link to the BYO-key Settings → Secrets step.
+
+- [ ] **Step 3: Cloud sync check**
+
+The cloud proxies `/builders/chat`. Confirm whether `agentbreeder-cloud/api/routes/builders.py` needs a sibling `/cloud/builders/chat/stream` proxy for SSE. If yes, file a companion issue/PR in `agentbreeder-cloud` (SSE passthrough + per-turn metering) per the cross-repo sync rule. If the cloud proxy forwards arbitrary paths, verify streaming passes through unbuffered.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/content/docs/quickstart.mdx website/content/docs/how-to.mdx
+git commit -m "docs: conversational front door + deploy-from-chat (quickstart, how-to)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Backend:** `./venv/bin/pytest tests/unit/test_agent_chat_builder_stream.py tests/integration/test_builders_chat_stream.py -v` — all pass.
+- [ ] **Frontend:** `cd dashboard && npx vitest run && npm run typecheck && npm run lint` — all pass.
+- [ ] **Manual smoke:** run API + dashboard locally, connect a Claude key, type a prompt at the front door, confirm streamed interview → valid spec → "Deploy now" → live logs → endpoint link.
+- [ ] **Gate:** run `/gate` and let all gates pass before opening the Wave-1 PR (defer the PR until the full epic per the standing "defer PR until done" preference — or open a Wave-1 PR if shipping incrementally).
+
+---
+
+# Waves 2–4 (outline — each gets its own plan before implementation)
+
+**Wave 2 — Inline secrets / MCP / provider capture.** Add `setup_request` events to the builder driver (kind = secret|mcp|provider). Render inline cards in the thread (reuse `provider-catalog.tsx` + `ChatBuildPanel` key-entry pattern). On submit, call `/secrets`, `/providers`, or `/mcp-servers` (+ `/{id}/discover`); record the dependency by reference and re-validate the spec. Tests: driver emits setup_request when a required dep is missing; card submits to the right endpoint; spec re-validates.
+
+**Wave 3 — Eject-to-code (Claude + Codex) + Sandbox + LocalSandbox.** Introduce the server-side resumable `BuilderSession` (spec §6), the `Sandbox` protocol with `LocalSandbox`, and `CodingAgentEngine` with `ClaudeAgentEngine` (Claude Agent SDK) and `CodexEngine` (OpenAI Agents). Add `POST /builder/sessions/{id}/eject` (engine selector) streaming `file_change` events; artifact-panel Code tab with diffs. Eject may propose `agent.yaml` edits, always re-validated through governance. Tests: `FakeSandbox`, engine event parsing with mocked providers, golden transcripts per engine.
+
+**Wave 4 — CloudSandbox + metering + analytics.** Implement `CloudSandbox` (managed e2b-style microVM: egress allowlist, CPU/mem/time caps, auto-teardown, secrets-as-env). Add `/cloud/builder/sessions/*` proxy with turn + sandbox-minute metering against `QuotaCounter`. Ship the analytics funnel (spec §12) and a builder-funnel view. Tests: sandbox safety (egress blocked, caps enforced, teardown, secrets-not-on-disk), metering, end-to-end cloud build→deploy.

--- a/docs/superpowers/plans/2026-06-14-studio-conversational-builder-wave2.md
+++ b/docs/superpowers/plans/2026-06-14-studio-conversational-builder-wave2.md
@@ -1,0 +1,258 @@
+# Studio Conversational Builder — Wave 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:test-driven-development. Implement task-by-task, failing test first.
+> Branch: `feat/studio-conversational-builder` (continues Wave 1).
+> Spec: `docs/superpowers/specs/2026-06-14-studio-conversational-builder-design.md` §8, §13 (W2).
+
+**Goal:** Let the conversational builder collect the dependencies an agent needs —
+secrets, MCP servers, and model-provider keys — **inline in the thread**, never sending
+the user to a settings page. The dependency is recorded **by reference** in `agent.yaml`
+and the spec is re-validated through governance. Values never enter the spec or browser
+state.
+
+**Mechanism (locked):** Add a second Anthropic tool, `request_setup(kind, name, reason)`,
+to the interview. When the model calls it (instead of `submit_agent_spec`), the streaming
+driver emits a `setup_request` event and ends the turn. The frontend renders an inline
+`SetupCard`. On submit it calls the existing endpoint (`/secrets`, `/mcp-servers` +
+`/{id}/discover`, or a provider key → `/secrets`), then appends a confirmation user
+message and auto-continues the conversation. The model then references the dependency
+(`secrets:` / `mcp_servers:` / `tools:`) and calls `submit_agent_spec`, which is
+re-validated by `validate_config_yaml()`. This preserves the stateless,
+client-held-conversation contract from Wave 1 (no `BuilderSession` resource yet — that is
+still Wave 3).
+
+**Tech Stack:** Python 3.11 / FastAPI / `sse-starlette` / pytest · React 18 / TypeScript /
+TanStack Query / Vitest.
+
+---
+
+## File Structure
+
+**Backend**
+- Modify `engine/agent_chat_builder.py` — add `SetupRequest` dataclass; add
+  `setup_request` field to `ChatTurnResult`; add `REQUEST_SETUP_TOOL`; extend
+  `ChatStreamEvent` (`"setup_request"` type + `setup` field); handle the new tool in both
+  `run_chat_turn` and `run_chat_turn_stream`; update `_SYSTEM_PROMPT`.
+- Modify `api/routes/builders.py` — emit a `setup_request` SSE event in
+  `chat_build_stream`'s generator.
+- Test `tests/unit/test_agent_chat_builder_setup.py` — driver emits setup_request from the
+  tool; non-stream path sets the field; spec submission still wins when both appear.
+- Test `tests/integration/test_builders_chat_stream.py` — add a case asserting the
+  `event: setup_request` frame shape.
+
+**Frontend**
+- Modify `dashboard/src/lib/api.ts` — add `ChatBuildSetupRequest` type and a
+  `setup_request` field on `ChatBuildResult`.
+- Create `dashboard/src/components/agent-wizard/SetupCard.tsx` — inline card for
+  secret | mcp | provider; password/endpoint fields cleared after submit.
+- Create `dashboard/src/components/agent-wizard/SetupCard.test.tsx`.
+- Modify `dashboard/src/components/agent-wizard/ChatBuildPanel.tsx` — handle the
+  `setup_request` event, render `SetupCard`, continue the thread on completion.
+- Modify `dashboard/src/components/agent-wizard/ChatBuildPanel.test.tsx` — add a
+  setup-card flow case.
+
+**Docs**
+- Modify `website/content/docs/how-to.mdx` — document inline credential/MCP capture in the
+  chat builder.
+
+---
+
+## Task 1: Backend driver — `request_setup` tool + `SetupRequest`
+
+**Files:** Modify `engine/agent_chat_builder.py`; Test
+`tests/unit/test_agent_chat_builder_setup.py`.
+
+- [ ] **Step 1 — failing test** (`tests/unit/test_agent_chat_builder_setup.py`):
+  - `FakeStreamingProvider` scripts a `request_setup` tool call with
+    `{"kind":"mcp","name":"zendesk","reason":"read tickets"}`; assert the stream yields
+    exactly one `ChatStreamEvent(type="setup_request")` whose `setup.kind == "mcp"` /
+    `setup.name == "zendesk"`, followed by a `done` whose `result.setup_request` mirrors it
+    and `result.agent_yaml is None`.
+  - A second test: when a turn contains **both** a `submit_agent_spec` and a
+    `request_setup` call, the spec wins (no setup_request event; `done.result.valid`
+    reflects the spec). Belt-and-suspenders for model misbehaviour.
+  - Non-stream test: `run_chat_turn` with a fake non-stream provider whose
+    `result.tool_calls` is a single `request_setup` returns a `ChatTurnResult` with
+    `setup_request` set and `agent_yaml is None`.
+- [ ] **Step 2 — run, verify red.** `ImportError: SetupRequest`.
+- [ ] **Step 3 — implement:**
+  - Add dataclass:
+    ```python
+    @dataclass
+    class SetupRequest:
+        kind: Literal["secret", "mcp", "provider"]
+        name: str
+        reason: str = ""
+    ```
+  - Add `setup_request: SetupRequest | None = None` to `ChatTurnResult`.
+  - Extend `ChatStreamEvent`: `type: Literal["token", "setup_request", "done"]` and add
+    `setup: SetupRequest | None = None`.
+  - Add the tool:
+    ```python
+    REQUEST_SETUP_TOOL_NAME = "request_setup"
+    _REQUEST_SETUP_TOOL = ToolDefinition(
+        type="function",
+        function=ToolFunction(
+            name=REQUEST_SETUP_TOOL_NAME,
+            description=(
+                "Request that the user provide a dependency the agent needs before the "
+                "spec can be finished: an API key/secret, a model-provider key, or an MCP "
+                "server. Call this BEFORE submit_agent_spec when the agent requires a "
+                "credential or tool you cannot supply. After the user confirms it is "
+                "connected, reference it by name in the spec (secrets/mcp_servers/tools) "
+                "and then submit."
+            ),
+            parameters={
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "kind": {"type": "string", "enum": ["secret", "mcp", "provider"]},
+                    "name": {"type": "string"},
+                    "reason": {"type": "string"},
+                },
+                "required": ["kind", "name"],
+            },
+        ),
+    )
+    REQUEST_SETUP_TOOL: ToolDefinition = _REQUEST_SETUP_TOOL
+    ```
+  - Add `_parse_setup_request(arguments_json: str) -> SetupRequest | None` (lenient: bad
+    JSON / missing fields / bad kind → `None`, logged, so a malformed tool call degrades to
+    a plain reply rather than erroring).
+  - Pass `tools=[SUBMIT_TOOL, REQUEST_SETUP_TOOL]` in both drivers.
+  - In `run_chat_turn`: scan `result.tool_calls`; **submit wins**; else if a
+    `request_setup` call parses, return `ChatTurnResult(assistant_message=result.content or
+    "", setup_request=...)`.
+  - In `run_chat_turn_stream`: collect `submit_args` and `setup_args` across chunks. After
+    the loop: if `submit_args` → `_handle_spec_submission` → `done`. Elif `setup_args`
+    parses → yield `ChatStreamEvent(type="setup_request", setup=req)` then a `done` whose
+    result carries `setup_request=req` and `assistant_message="".join(text_parts)`. Else →
+    plain text `done`.
+- [ ] **Step 4 — run, verify green.**
+- [ ] **Step 5 — commit:** `feat(builder): request_setup tool + SetupRequest (inline deps)`.
+
+---
+
+## Task 2: SSE endpoint emits `setup_request`
+
+**Files:** Modify `api/routes/builders.py`; Test
+`tests/integration/test_builders_chat_stream.py` (add a case).
+
+- [ ] **Step 1 — failing test:** monkeypatch `run_chat_turn_stream` to yield a
+  `setup_request` event then `done`; POST to `/api/v1/builders/chat/stream`; assert
+  `event: setup_request` is in the body and its data JSON has `kind`/`name`.
+- [ ] **Step 2 — red** (event not emitted).
+- [ ] **Step 3 — implement:** in the generator, add
+  ```python
+  elif evt.type == "setup_request" and evt.setup is not None:
+      yield {"event": "setup_request", "data": json.dumps(asdict(evt.setup))}
+  ```
+  (`asdict` already imported.) The `done` branch already serialises the full result, whose
+  nested `setup_request` becomes a dict — fine.
+- [ ] **Step 4 — green.** Run `tests/integration -k builders`. Confirm still auth-gated.
+- [ ] **Step 5 — commit:** `feat(api): emit setup_request SSE event from chat/stream`.
+
+---
+
+## Task 3: Frontend types
+
+**Files:** Modify `dashboard/src/lib/api.ts`.
+
+- [ ] Add:
+  ```typescript
+  export interface ChatBuildSetupRequest {
+    kind: "secret" | "mcp" | "provider";
+    name: string;
+    reason?: string;
+  }
+  ```
+  and add `setup_request?: ChatBuildSetupRequest | null;` to the existing `ChatBuildResult`
+  interface. No runtime change; typecheck must stay clean. (Commit folded into Task 5.)
+
+---
+
+## Task 4: `SetupCard` inline component
+
+**Files:** Create `SetupCard.tsx` + `SetupCard.test.tsx`.
+
+- [ ] **Step 1 — failing test** (`SetupCard.test.tsx`):
+  - `secret` kind: renders the reason; a `type="password"` field; on submit calls
+    `api.secrets.create({ name, value })`, clears the field, and fires `onComplete` with a
+    confirmation string mentioning the name.
+  - `mcp` kind: renders endpoint + transport inputs; on submit calls
+    `api.mcpServers.create({ name, endpoint, transport })` then
+    `api.mcpServers.discover(id)`, then `onComplete` with a string mentioning the tool
+    count.
+  - `provider` kind: password field; on submit calls `api.secrets.create` with a
+    provider-key secret name (`${name}/api-key`, mirroring `provider-catalog.tsx`), then
+    `onComplete`.
+  - error path: rejected mutation surfaces an inline error and does NOT call `onComplete`.
+- [ ] **Step 2 — red** (module missing).
+- [ ] **Step 3 — implement** `SetupCard({ request, onComplete, onSkip })`:
+  - `request: ChatBuildSetupRequest`; `onComplete: (confirmation: string) => void`;
+    `onSkip: () => void`.
+  - Branch by `request.kind`; password inputs `autoComplete="off"`, cleared after submit;
+    never keep the value in state post-submit. Use `useMutation`. Show `Loader2` while
+    pending, inline `AlertCircle` error on failure.
+  - Confirmation strings (sent back into the thread as a user message):
+    - secret → `I've added the secret \`${name}\`.`
+    - provider → `I've added my ${name} API key.`
+    - mcp → `I've connected the MCP server '${name}' (${toolCount} tools discovered).`
+  - Reuse Tailwind patterns + `Button` from the existing panel; `data-testid="setup-card"`,
+    `setup-card-submit`, kind-specific input testids.
+- [ ] **Step 4 — green.**
+- [ ] **Step 5 — commit folded into Task 5.**
+
+---
+
+## Task 5: Wire `setup_request` into ChatBuildPanel
+
+**Files:** Modify `ChatBuildPanel.tsx` + `ChatBuildPanel.test.tsx`, `api.ts` (Task 3).
+
+- [ ] **Step 1 — failing test** (add to `ChatBuildPanel.test.tsx`): mock
+  `api.builders.chatStream` to emit a `setup_request` event (`kind:"secret"`,
+  `name:"ZENDESK_API_KEY"`) then `done` with no spec. Assert the `setup-card` renders.
+  Mock `api.secrets.create`; fill the password; submit; assert a second `chatStream` call
+  occurs whose history includes the confirmation user message.
+- [ ] **Step 2 — red.**
+- [ ] **Step 3 — implement:**
+  - Add `pendingSetup: ChatBuildSetupRequest | null` state. In `sendStreaming`'s event
+    handler, add `else if (event === "setup_request") setPendingSetup(data as
+    ChatBuildSetupRequest);`. Also read `result.setup_request` on `done` as a fallback.
+  - Render `<SetupCard>` (when `pendingSetup`) in the thread above the input. Its
+    `onComplete(confirmation)` pushes a user `ChatEntry` with the confirmation, clears
+    `pendingSetup`, and calls `sendStreaming(buildHistory(confirmation))` to continue.
+    `onSkip` clears `pendingSetup`.
+  - Ensure `buildHistory` includes the just-pushed confirmation (mirror the existing
+    `handleSend` ordering — append to `entries` then build from a local copy, or pass the
+    confirmation explicitly as the current input like `handleSend` does).
+- [ ] **Step 4 — green.** Run the full `ChatBuildPanel.test.tsx`.
+- [ ] **Step 5 — full suite + typecheck:** `cd dashboard && npx vitest run && npm run
+  typecheck && npm run lint`.
+- [ ] **Step 6 — commit:** `feat(studio): inline setup cards (secret/mcp/provider) in chat`.
+
+---
+
+## Task 6: Docs + cross-repo sync
+
+**Files:** Modify `website/content/docs/how-to.mdx`.
+
+- [ ] Add an "Inline setup" subsection to the chat-to-build walkthrough: when the agent
+  needs a credential, MCP server, or provider key, a secure card appears in the thread;
+  values go to the secrets backend (masked) and the spec records only references.
+- [ ] **Cloud sync check:** the cloud proxies `/builders/chat`. Confirm whether
+  `agentbreeder-cloud` needs a sibling change for the new `setup_request` SSE event (likely
+  pass-through if the proxy forwards arbitrary SSE frames). File a companion issue if not.
+- [ ] **Commit:** `docs: inline secrets/MCP/provider capture in chat builder`.
+
+---
+
+## Final verification
+
+- [ ] **Backend:** `./venv/bin/pytest tests/unit/test_agent_chat_builder_setup.py
+  tests/unit/test_agent_chat_builder_stream.py tests/integration/test_builders_chat_stream.py -v`.
+- [ ] **Frontend:** `cd dashboard && npx vitest run && npm run typecheck && npm run lint`.
+- [ ] **Governance check:** confirm the final spec contains only refs (no secret values);
+  `validate_config_yaml()` runs on every submit (unchanged from Wave 1).
+- [ ] **Gate:** run `/gate`. Defer the PR until the epic per the standing preference, or
+  open a Wave-2 increment.

--- a/docs/superpowers/plans/2026-06-14-studio-conversational-builder-wave3.md
+++ b/docs/superpowers/plans/2026-06-14-studio-conversational-builder-wave3.md
@@ -1,0 +1,2440 @@
+# Wave 3 — Eject-to-Code Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add server-side, resumable `BuilderSession` resource and an "eject to code" capability that lets the selected coding agent (Claude or Codex) write `agent.py` / `tools/` / tests into a sandbox, stream file diffs into the chat, and deploy from the same thread.
+
+**Architecture:** A pluggable `Sandbox` interface (`LocalSandbox` = temp dir + subprocess) holds the scaffold workspace. A single provider-loop `CodingAgentEngine` drives codegen over the existing `engine/providers/*.generate_stream()` abstraction with a `{write,read,list,exec}` tool surface bound to the sandbox — Claude vs Codex is a strategy choice of which provider+model the same loop uses (no vendor SDK deps, the security boundary stays in our code). A persisted `BuilderSession` (Postgres + in-process SSE event bus, mirroring the existing `deploy_event_bus`) ties together conversation history, the evolving `agent.yaml`, the sandbox workspace, the selected engine, and the deploy job. The frontend grows a two-pane build console with a **Code** artifact tab.
+
+**Tech Stack:** Python 3.11 / FastAPI / async SQLAlchemy / Alembic / sse-starlette · React 18 / TypeScript / Tailwind / Vitest · pytest
+
+**Decision (locked this session):** Coding-agent engine = **provider-loop over `generate_stream()`** (Option 1), not vendor SDKs and not CLI subprocess. Rationale: keeps the code-execution security surface in code we own + test, honors the provider abstraction and anti-lock-in rules, makes Claude↔Codex a one-line strategy swap.
+
+**Security rail (load-bearing):** `LocalSandbox` executes code on the host running Studio. That is acceptable **only** in local single-user mode. A new env gate `AGENTBREEDER_SANDBOX` (`local` default | `cloud` | `disabled`) controls which sandbox the server may construct. In cloud mode, `LocalSandbox` construction raises — only `CloudSandbox` (Wave 4) is allowed. This prevents the multi-tenant cloud from ever running user code in-process.
+
+---
+
+## Part overview
+
+| Part | Scope | Independently testable milestone |
+|---|---|---|
+| **A** | `Sandbox` interface + `LocalSandbox` + `FakeSandbox` test double | Sandbox unit tests green; path-containment + timeout + snapshot proven |
+| **B** | `CodingAgentEngine` protocol + provider-loop + Claude/Codex strategies | Coding loop unit tests green against a fake provider + `FakeSandbox` |
+| **C** | `BuilderSession` model + migration + service + §6 API routes + SSE | Integration tests for create/get/messages/eject/deploy green |
+| **D** | Frontend two-pane build console + Code artifact tab + eject UI + client | Vitest green; `tsc` clean |
+| **E** | Cross-repo (cloud proxy) + docs sync + model-e2e gated test + analytics events | Cloud passthrough test green; docs updated in same commit |
+
+Parts A→C are sequential (C depends on A+B). D depends on C's API contract. E closes out cross-repo + docs. Commit after every task.
+
+---
+
+## PART A — Sandbox interface + LocalSandbox
+
+**File structure:**
+- Create: `engine/sandbox/__init__.py`
+- Create: `engine/sandbox/base.py` — `ExecResult`, `Sandbox` protocol, `SandboxDisabledError`, `select_sandbox_mode()`
+- Create: `engine/sandbox/local.py` — `LocalSandbox`
+- Create: `tests/unit/test_sandbox_local.py`
+- Create: `tests/unit/fakes/fake_sandbox.py` — `FakeSandbox` reused by Part B/C tests
+
+### Task A1: Sandbox interface + ExecResult + mode gate
+
+**Files:**
+- Create: `engine/sandbox/__init__.py`
+- Create: `engine/sandbox/base.py`
+- Test: `tests/unit/test_sandbox_base.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_sandbox_base.py
+import os
+import pytest
+from engine.sandbox.base import (
+    ExecResult,
+    SandboxDisabledError,
+    select_sandbox_mode,
+)
+
+
+def test_exec_result_defaults():
+    r = ExecResult(stdout="hi", stderr="", exit_code=0)
+    assert r.timed_out is False
+    assert r.ok is True
+
+
+def test_exec_result_nonzero_not_ok():
+    assert ExecResult(stdout="", stderr="boom", exit_code=1).ok is False
+
+
+def test_select_sandbox_mode_defaults_local(monkeypatch):
+    monkeypatch.delenv("AGENTBREEDER_SANDBOX", raising=False)
+    assert select_sandbox_mode() == "local"
+
+
+def test_select_sandbox_mode_reads_env(monkeypatch):
+    monkeypatch.setenv("AGENTBREEDER_SANDBOX", "cloud")
+    assert select_sandbox_mode() == "cloud"
+
+
+def test_select_sandbox_mode_rejects_unknown(monkeypatch):
+    monkeypatch.setenv("AGENTBREEDER_SANDBOX", "bogus")
+    with pytest.raises(SandboxDisabledError):
+        select_sandbox_mode()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/unit/test_sandbox_base.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'engine.sandbox'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# engine/sandbox/__init__.py
+"""Pluggable sandbox interface for the conversational builder's eject-to-code flow."""
+```
+
+```python
+# engine/sandbox/base.py
+"""Sandbox interface — a pluggable scaffold workspace for the coding agent.
+
+LocalSandbox runs on the host (local single-user Studio only). CloudSandbox
+(Wave 4) runs in a managed microVM. The AGENTBREEDER_SANDBOX env gate decides
+which the server is permitted to construct so the multi-tenant cloud can never
+run user code in-process.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Literal, Protocol, runtime_checkable
+
+SandboxMode = Literal["local", "cloud", "disabled"]
+_VALID_MODES: frozenset[str] = frozenset({"local", "cloud", "disabled"})
+
+
+class SandboxDisabledError(RuntimeError):
+    """Raised when a sandbox is requested but disallowed by configuration."""
+
+
+@dataclass
+class ExecResult:
+    """Result of running a command inside a sandbox."""
+
+    stdout: str
+    stderr: str
+    exit_code: int
+    timed_out: bool = False
+
+    @property
+    def ok(self) -> bool:
+        return self.exit_code == 0 and not self.timed_out
+
+
+def select_sandbox_mode() -> SandboxMode:
+    """Return the configured sandbox mode (defaults to ``local``).
+
+    Raises SandboxDisabledError on an unrecognised value rather than silently
+    falling back, so a misconfigured cloud deploy fails closed.
+    """
+    raw = os.environ.get("AGENTBREEDER_SANDBOX", "local").strip().lower()
+    if raw not in _VALID_MODES:
+        raise SandboxDisabledError(
+            f"AGENTBREEDER_SANDBOX={raw!r} is not one of {sorted(_VALID_MODES)}"
+        )
+    return raw  # type: ignore[return-value]
+
+
+@runtime_checkable
+class Sandbox(Protocol):
+    """A scaffold workspace the coding agent reads from and writes into."""
+
+    async def write(self, path: str, content: str) -> None: ...
+    async def read(self, path: str) -> str: ...
+    async def list(self, directory: str = ".") -> list[str]: ...
+    async def exec(self, cmd: list[str], timeout: float = 30.0) -> ExecResult: ...
+    async def snapshot(self) -> bytes: ...
+    async def close(self) -> None: ...
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/unit/test_sandbox_base.py -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/sandbox/__init__.py engine/sandbox/base.py tests/unit/test_sandbox_base.py
+git commit -m "feat(builder): add Sandbox interface + ExecResult + mode gate (W3)"
+```
+
+### Task A2: LocalSandbox — write/read/list with path containment
+
+**Files:**
+- Create: `engine/sandbox/local.py`
+- Test: `tests/unit/test_sandbox_local.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_sandbox_local.py
+import pytest
+from engine.sandbox.local import LocalSandbox
+
+
+@pytest.mark.asyncio
+async def test_write_then_read_roundtrip():
+    sb = LocalSandbox()
+    try:
+        await sb.write("agent.py", "print('hi')\n")
+        assert await sb.read("agent.py") == "print('hi')\n"
+    finally:
+        await sb.close()
+
+
+@pytest.mark.asyncio
+async def test_write_creates_nested_dirs():
+    sb = LocalSandbox()
+    try:
+        await sb.write("tools/search.py", "x = 1\n")
+        assert "tools/search.py" in await sb.list(".")
+    finally:
+        await sb.close()
+
+
+@pytest.mark.asyncio
+async def test_read_missing_raises_filenotfound():
+    sb = LocalSandbox()
+    try:
+        with pytest.raises(FileNotFoundError):
+            await sb.read("nope.py")
+    finally:
+        await sb.close()
+
+
+@pytest.mark.asyncio
+async def test_path_traversal_is_rejected():
+    sb = LocalSandbox()
+    try:
+        with pytest.raises(ValueError):
+            await sb.write("../escape.py", "danger")
+        with pytest.raises(ValueError):
+            await sb.read("/etc/passwd")
+    finally:
+        await sb.close()
+
+
+@pytest.mark.asyncio
+async def test_close_removes_workspace():
+    sb = LocalSandbox()
+    root = sb.root
+    await sb.write("a.txt", "1")
+    await sb.close()
+    assert not root.exists()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/unit/test_sandbox_local.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'engine.sandbox.local'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# engine/sandbox/local.py
+"""LocalSandbox — temp-dir + subprocess scaffold workspace for local Studio.
+
+SECURITY: runs commands on the host. Only constructed when AGENTBREEDER_SANDBOX
+is 'local'. The server guards construction (see api/services/builder_session_service).
+All paths are contained within the workspace root; absolute paths and '..' escapes
+are rejected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+
+from engine.sandbox.base import ExecResult
+
+logger = logging.getLogger(__name__)
+
+_MAX_EXEC_TIMEOUT = 120.0
+_MAX_FILE_BYTES = 1_000_000  # 1 MB per file cap
+
+
+class LocalSandbox:
+    """In-process sandbox backed by a temporary directory."""
+
+    def __init__(self, prefix: str = "agentbreeder-builder-") -> None:
+        self.root: Path = Path(tempfile.mkdtemp(prefix=prefix)).resolve()
+
+    def _resolve(self, path: str) -> Path:
+        """Resolve ``path`` strictly inside the workspace root."""
+        if path.startswith("/") or path.startswith("\\"):
+            raise ValueError(f"absolute paths are not allowed: {path!r}")
+        candidate = (self.root / path).resolve()
+        if candidate != self.root and self.root not in candidate.parents:
+            raise ValueError(f"path escapes the sandbox workspace: {path!r}")
+        return candidate
+
+    async def write(self, path: str, content: str) -> None:
+        if len(content.encode("utf-8")) > _MAX_FILE_BYTES:
+            raise ValueError(f"file exceeds {_MAX_FILE_BYTES} byte cap: {path!r}")
+        target = self._resolve(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+
+    async def read(self, path: str) -> str:
+        target = self._resolve(path)
+        if not target.is_file():
+            raise FileNotFoundError(path)
+        return target.read_text(encoding="utf-8")
+
+    async def list(self, directory: str = ".") -> list[str]:
+        base = self._resolve(directory)
+        if not base.exists():
+            return []
+        return sorted(
+            str(p.relative_to(self.root)) for p in base.rglob("*") if p.is_file()
+        )
+
+    async def exec(self, cmd: list[str], timeout: float = 30.0) -> ExecResult:
+        timeout = min(timeout, _MAX_EXEC_TIMEOUT)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                cwd=str(self.root),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError as exc:
+            return ExecResult(stdout="", stderr=str(exc), exit_code=127)
+        try:
+            out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return ExecResult(stdout="", stderr="timed out", exit_code=124, timed_out=True)
+        return ExecResult(
+            stdout=out.decode("utf-8", "replace"),
+            stderr=err.decode("utf-8", "replace"),
+            exit_code=proc.returncode if proc.returncode is not None else -1,
+        )
+
+    async def snapshot(self) -> bytes:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            for path in sorted(self.root.rglob("*")):
+                if path.is_file():
+                    zf.write(path, arcname=str(path.relative_to(self.root)))
+        return buf.getvalue()
+
+    async def close(self) -> None:
+        shutil.rmtree(self.root, ignore_errors=True)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/unit/test_sandbox_local.py -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/sandbox/local.py tests/unit/test_sandbox_local.py
+git commit -m "feat(builder): LocalSandbox with path containment + caps (W3)"
+```
+
+### Task A3: LocalSandbox exec/snapshot + FakeSandbox test double
+
+**Files:**
+- Create: `tests/unit/fakes/__init__.py`
+- Create: `tests/unit/fakes/fake_sandbox.py`
+- Modify: `tests/unit/test_sandbox_local.py` (add exec + snapshot tests)
+
+- [ ] **Step 1: Write the failing tests** (append to `tests/unit/test_sandbox_local.py`)
+
+```python
+@pytest.mark.asyncio
+async def test_exec_runs_and_captures_stdout():
+    sb = LocalSandbox()
+    try:
+        await sb.write("hello.py", "print('from sandbox')\n")
+        res = await sb.exec(["python", "hello.py"], timeout=10)
+        assert res.ok
+        assert "from sandbox" in res.stdout
+    finally:
+        await sb.close()
+
+
+@pytest.mark.asyncio
+async def test_exec_timeout_is_flagged():
+    sb = LocalSandbox()
+    try:
+        res = await sb.exec(["python", "-c", "import time; time.sleep(5)"], timeout=0.5)
+        assert res.timed_out is True
+        assert res.exit_code == 124
+    finally:
+        await sb.close()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_contains_written_files():
+    import io, zipfile
+    sb = LocalSandbox()
+    try:
+        await sb.write("agent.py", "x = 1\n")
+        await sb.write("tools/t.py", "y = 2\n")
+        data = await sb.snapshot()
+        names = set(zipfile.ZipFile(io.BytesIO(data)).namelist())
+        assert {"agent.py", "tools/t.py"} <= names
+    finally:
+        await sb.close()
+```
+
+And the FakeSandbox double:
+
+```python
+# tests/unit/fakes/__init__.py
+```
+
+```python
+# tests/unit/fakes/fake_sandbox.py
+"""In-memory Sandbox double for engine + service tests (no subprocess)."""
+
+from __future__ import annotations
+
+from engine.sandbox.base import ExecResult
+
+
+class FakeSandbox:
+    """Deterministic in-memory sandbox. exec() returns scripted results."""
+
+    def __init__(self) -> None:
+        self.files: dict[str, str] = {}
+        self.exec_calls: list[list[str]] = []
+        self.exec_results: dict[str, ExecResult] = {}
+        self.closed = False
+
+    async def write(self, path: str, content: str) -> None:
+        self.files[path] = content
+
+    async def read(self, path: str) -> str:
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        return self.files[path]
+
+    async def list(self, directory: str = ".") -> list[str]:
+        return sorted(self.files)
+
+    async def exec(self, cmd: list[str], timeout: float = 30.0) -> ExecResult:
+        self.exec_calls.append(cmd)
+        key = " ".join(cmd)
+        return self.exec_results.get(key, ExecResult(stdout="", stderr="", exit_code=0))
+
+    async def snapshot(self) -> bytes:
+        return repr(self.files).encode("utf-8")
+
+    async def close(self) -> None:
+        self.closed = True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/unit/test_sandbox_local.py -k "exec or snapshot" -v`
+Expected: PASS for the new LocalSandbox tests (LocalSandbox already implements exec/snapshot). If `python` is not on PATH in CI, the exec test will need `sys.executable` — if it FAILS on command-not-found, change `["python", ...]` to `[sys.executable, ...]` and add `import sys`.
+
+- [ ] **Step 3: (only if exec test failed on PATH)** swap `"python"` → `sys.executable` in the two exec tests.
+
+- [ ] **Step 4: Run full Part A suite**
+
+Run: `pytest tests/unit/test_sandbox_base.py tests/unit/test_sandbox_local.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/fakes/ tests/unit/test_sandbox_local.py
+git commit -m "test(builder): LocalSandbox exec/snapshot tests + FakeSandbox double (W3)"
+```
+
+---
+
+## PART B — CodingAgentEngine (provider-loop) + Claude/Codex strategies
+
+**File structure:**
+- Modify: `engine/providers/anthropic_provider.py` — `_build_payload` tool round-trip (Task B0)
+- Modify: `engine/providers/openai_provider.py` — `_build_payload` tool round-trip (Task B0)
+- Create: `engine/coding_agent/__init__.py`
+- Create: `engine/coding_agent/base.py` — `AgentEvent`, `AgentBounds`, `CodingAgentEngine` protocol, `CODING_TOOLS`
+- Create: `engine/coding_agent/loop.py` — `run_coding_loop()` (the shared driver)
+- Create: `engine/coding_agent/engines.py` — `ClaudeAgentEngine`, `CodexEngine`, `engine_for(name)`
+- Create: `tests/unit/test_coding_loop.py`
+- Create: `tests/unit/fakes/fake_provider.py` — scripted streaming provider double
+
+### Task B0: Provider tool-message round-trip (foundational — spiked + confirmed required)
+
+**Why first:** The coding loop (Task B2) feeds tool results back as OpenAI-format messages —
+an assistant message carrying `tool_calls` (our `ToolCall` shape: `function_name` /
+`function_arguments`) followed by `{"role": "tool", "tool_call_id", "content"}`. A spike on
+2026-06-14 confirmed **neither** provider's `_build_payload` handles these today:
+- `anthropic_provider._build_payload` (lines 253-259) copies only `role` + `content` (string),
+  dropping `tool_calls` and never emitting Anthropic `tool_use` / `tool_result` blocks.
+- `openai_provider._build_payload` (lines 166-168) passes messages verbatim, but our `ToolCall`
+  shape (`function_name`/`function_arguments`) ≠ OpenAI's wire shape (`function.name`/`.arguments`).
+
+Without this task the loop's unit tests still pass (FakeProvider), but Part C integration and
+the E3 live e2e fail. Build it first.
+
+**Files:**
+- Modify: `engine/providers/anthropic_provider.py` (`_build_payload`)
+- Modify: `engine/providers/openai_provider.py` (`_build_payload`)
+- Test: `tests/unit/test_provider_tool_roundtrip.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_provider_tool_roundtrip.py
+import json
+from engine.providers.anthropic_provider import AnthropicProvider
+from engine.providers.openai_provider import OpenAIProvider
+from engine.providers.models import ProviderConfig, ProviderType
+
+
+def _messages():
+    # assistant turn with a tool call, then a tool result, OpenAI-format (loop output)
+    return [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "build it"},
+        {
+            "role": "assistant",
+            "content": "Creating agent.py",
+            "tool_calls": [{
+                "id": "call_1", "type": "function",
+                "function_name": "write_file",
+                "function_arguments": json.dumps({"path": "agent.py", "content": "x=1\n"}),
+            }],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "wrote agent.py (4 bytes)"},
+    ]
+
+
+def test_anthropic_builds_tool_use_and_tool_result_blocks():
+    p = AnthropicProvider(ProviderConfig(provider_type=ProviderType.anthropic, api_key="sk-x"))
+    payload = p._build_payload(_messages(), "claude-sonnet-4-6", None, 1024, None)
+    msgs = payload["messages"]
+    # assistant turn carries a tool_use block
+    asst = next(m for m in msgs if m["role"] == "assistant")
+    tu = [b for b in asst["content"] if isinstance(b, dict) and b.get("type") == "tool_use"]
+    assert tu and tu[0]["id"] == "call_1" and tu[0]["name"] == "write_file"
+    assert tu[0]["input"] == {"path": "agent.py", "content": "x=1\n"}
+    # tool result becomes a user turn with a tool_result block referencing the id
+    tr_turns = [m for m in msgs if m["role"] == "user"
+                and isinstance(m["content"], list)
+                and any(b.get("type") == "tool_result" for b in m["content"])]
+    assert tr_turns
+    block = next(b for b in tr_turns[-1]["content"] if b.get("type") == "tool_result")
+    assert block["tool_use_id"] == "call_1"
+
+
+def test_openai_translates_toolcall_shape():
+    p = OpenAIProvider(ProviderConfig(provider_type=ProviderType.openai, api_key="sk-x"))
+    payload = p._build_payload(_messages(), "gpt-4o", None, None, None, False)
+    asst = next(m for m in payload["messages"] if m["role"] == "assistant")
+    fn = asst["tool_calls"][0]["function"]
+    assert fn["name"] == "write_file"
+    assert json.loads(fn["arguments"])["path"] == "agent.py"
+    tool_msg = next(m for m in payload["messages"] if m["role"] == "tool")
+    assert tool_msg["tool_call_id"] == "call_1"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/unit/test_provider_tool_roundtrip.py -v`
+Expected: FAIL — assistant content is a plain string; no `tool_use`/`tool_result` blocks.
+
+- [ ] **Step 3: Implement the Anthropic translation** — replace the message loop in
+`anthropic_provider._build_payload` (currently lines 252-259) with tool-aware translation.
+Consecutive `role="tool"` messages must be merged into a single user turn.
+
+```python
+        system_content: str | None = None
+        non_system: list[dict[str, Any]] = []
+        pending_tool_results: list[dict[str, Any]] = []
+
+        def _flush_tool_results() -> None:
+            if pending_tool_results:
+                non_system.append({"role": "user", "content": list(pending_tool_results)})
+                pending_tool_results.clear()
+
+        for msg in messages:
+            role = msg.get("role", "user")
+            if role == "system":
+                system_content = msg.get("content", "")
+                continue
+            if role == "tool":
+                pending_tool_results.append({
+                    "type": "tool_result",
+                    "tool_use_id": msg.get("tool_call_id", ""),
+                    "content": msg.get("content", ""),
+                })
+                continue
+            # any non-tool message flushes buffered tool_results first
+            _flush_tool_results()
+            if role == "assistant" and msg.get("tool_calls"):
+                blocks: list[dict[str, Any]] = []
+                if msg.get("content"):
+                    blocks.append({"type": "text", "text": msg["content"]})
+                for tc in msg["tool_calls"]:
+                    name = tc.get("function_name") or tc.get("function", {}).get("name", "")
+                    raw = tc.get("function_arguments") or tc.get("function", {}).get("arguments", "{}")
+                    try:
+                        parsed = json.loads(raw) if isinstance(raw, str) else raw
+                    except json.JSONDecodeError:
+                        parsed = {}
+                    blocks.append({
+                        "type": "tool_use", "id": tc.get("id", ""),
+                        "name": name, "input": parsed,
+                    })
+                non_system.append({"role": "assistant", "content": blocks})
+            else:
+                non_system.append({"role": role, "content": msg.get("content", "")})
+        _flush_tool_results()
+```
+
+- [ ] **Step 4: Implement the OpenAI translation** — in `openai_provider._build_payload`, normalise
+each message before assigning to `payload["messages"]` (replace the `"messages": messages` line):
+
+```python
+        norm_messages: list[dict[str, Any]] = []
+        for msg in messages:
+            if msg.get("role") == "assistant" and msg.get("tool_calls"):
+                norm_messages.append({
+                    "role": "assistant",
+                    "content": msg.get("content") or None,
+                    "tool_calls": [
+                        {
+                            "id": tc.get("id", ""),
+                            "type": "function",
+                            "function": {
+                                "name": tc.get("function_name") or tc.get("function", {}).get("name", ""),
+                                "arguments": tc.get("function_arguments")
+                                or tc.get("function", {}).get("arguments", "{}"),
+                            },
+                        }
+                        for tc in msg["tool_calls"]
+                    ],
+                })
+            else:
+                norm_messages.append(dict(msg))
+        payload: dict[str, Any] = {"model": model, "messages": norm_messages}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pytest tests/unit/test_provider_tool_roundtrip.py -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 6: Run the existing provider suites to confirm no regression** (plain text turns must still work)
+
+Run: `pytest tests/unit/ -k "anthropic or openai or provider" -v`
+Expected: PASS (no regressions — non-tool messages take the unchanged `else` branch)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add engine/providers/anthropic_provider.py engine/providers/openai_provider.py tests/unit/test_provider_tool_roundtrip.py
+git commit -m "feat(providers): tool-message round-trip for multi-turn tool loops (W3 B0)"
+```
+
+### Task B1: AgentEvent + tool surface + engine protocol
+
+**Files:**
+- Create: `engine/coding_agent/__init__.py`
+- Create: `engine/coding_agent/base.py`
+- Test: `tests/unit/test_coding_agent_base.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_coding_agent_base.py
+from engine.coding_agent.base import AgentEvent, AgentBounds, CODING_TOOLS, TOOL_NAMES
+
+
+def test_agent_event_token_defaults():
+    e = AgentEvent(type="token", text="hi")
+    assert e.path == "" and e.diff == "" and e.error == ""
+
+
+def test_coding_tools_cover_fs_surface():
+    assert TOOL_NAMES == {"write_file", "read_file", "list_files", "run_command"}
+    # every tool is an OpenAI-format ToolDefinition
+    assert all(t.function.name in TOOL_NAMES for t in CODING_TOOLS)
+
+
+def test_bounds_defaults_are_sane():
+    b = AgentBounds()
+    assert b.max_turns >= 1 and b.wall_clock_s > 0 and b.max_tokens > 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/unit/test_coding_agent_base.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'engine.coding_agent'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# engine/coding_agent/__init__.py
+"""Provider-loop coding agent for the builder's eject-to-code flow."""
+```
+
+```python
+# engine/coding_agent/base.py
+"""Coding-agent contracts: events, bounds, the engine protocol, and the
+sandbox-scoped tool surface (write/read/list/exec) shared by all engines."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+from engine.providers.models import ToolDefinition, ToolFunction
+from engine.sandbox.base import Sandbox
+
+AgentEventType = Literal["token", "tool_call", "file_change", "done", "error"]
+
+
+@dataclass
+class AgentEvent:
+    """One event emitted by a coding-agent run."""
+
+    type: AgentEventType
+    text: str = ""          # token text / done summary
+    tool_name: str = ""     # for tool_call
+    path: str = ""          # for file_change
+    diff: str = ""          # unified diff for file_change
+    error: str = ""         # for error
+
+
+@dataclass
+class AgentBounds:
+    """Hard bounds on a coding-agent run."""
+
+    max_turns: int = 12
+    max_tokens: int = 200_000
+    wall_clock_s: float = 180.0
+
+
+def _tool(name: str, description: str, params: dict) -> ToolDefinition:
+    return ToolDefinition(
+        type="function",
+        function=ToolFunction(name=name, description=description, parameters=params),
+    )
+
+
+CODING_TOOLS: list[ToolDefinition] = [
+    _tool(
+        "write_file",
+        "Create or overwrite a file in the agent project workspace.",
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "path": {"type": "string", "description": "Workspace-relative path."},
+                "content": {"type": "string", "description": "Full file contents."},
+            },
+            "required": ["path", "content"],
+        },
+    ),
+    _tool(
+        "read_file",
+        "Read a file from the workspace.",
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+    ),
+    _tool(
+        "list_files",
+        "List files in the workspace (recursively).",
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {"directory": {"type": "string", "default": "."}},
+        },
+    ),
+    _tool(
+        "run_command",
+        "Run a shell command in the workspace (e.g. run tests). Bounded by a timeout.",
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "cmd": {"type": "array", "items": {"type": "string"}},
+                "timeout": {"type": "number", "default": 30},
+            },
+            "required": ["cmd"],
+        },
+    ),
+]
+
+TOOL_NAMES: set[str] = {t.function.name for t in CODING_TOOLS}
+
+
+class CodingAgentEngine(Protocol):
+    """Strategy: which provider+model+system-prompt drives the shared loop."""
+
+    name: str
+
+    def run(
+        self,
+        instruction: str,
+        history: list[dict[str, str]],
+        sandbox: Sandbox,
+        bounds: AgentBounds | None = None,
+    ) -> AsyncIterator[AgentEvent]: ...
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/unit/test_coding_agent_base.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/coding_agent/__init__.py engine/coding_agent/base.py tests/unit/test_coding_agent_base.py
+git commit -m "feat(builder): coding-agent events, bounds, tool surface (W3)"
+```
+
+### Task B2: The provider-loop driver `run_coding_loop()`
+
+**Files:**
+- Create: `engine/coding_agent/loop.py`
+- Create: `tests/unit/fakes/fake_provider.py`
+- Test: `tests/unit/test_coding_loop.py`
+
+- [ ] **Step 1: Write the FakeProvider double**
+
+```python
+# tests/unit/fakes/fake_provider.py
+"""Scripted streaming provider double.
+
+Each entry in ``script`` is a list of StreamChunk objects representing one
+generate_stream() turn. Successive generate_stream() calls pop the next turn.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+from engine.providers.models import StreamChunk, ToolCall
+
+
+class FakeProvider:
+    def __init__(self, script: list[list[StreamChunk]]) -> None:
+        self._script = list(script)
+        self.calls: list[list[dict]] = []
+        self.closed = False
+
+    async def generate_stream(self, messages, model=None, temperature=None,
+                              max_tokens=None, tools=None) -> AsyncIterator[StreamChunk]:
+        self.calls.append(list(messages))
+        turn = self._script.pop(0) if self._script else []
+        for chunk in turn:
+            yield chunk
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def text(s: str) -> StreamChunk:
+    return StreamChunk(content=s)
+
+
+def call(tool_id: str, name: str, args_json: str) -> StreamChunk:
+    return StreamChunk(
+        tool_calls=[ToolCall(id=tool_id, function_name=name, function_arguments=args_json)]
+    )
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# tests/unit/test_coding_loop.py
+import json
+import pytest
+
+from engine.coding_agent.base import AgentBounds
+from engine.coding_agent.loop import run_coding_loop
+from tests.unit.fakes.fake_provider import FakeProvider, text, call
+from tests.unit.fakes.fake_sandbox import FakeSandbox
+
+
+@pytest.mark.asyncio
+async def test_loop_writes_file_and_emits_diff():
+    sandbox = FakeSandbox()
+    provider = FakeProvider([
+        # turn 1: model narrates then calls write_file
+        [text("Creating agent.py"),
+         call("c1", "write_file", json.dumps({"path": "agent.py", "content": "print(1)\n"}))],
+        # turn 2: model finishes (no tool calls)
+        [text("Done.")],
+    ])
+
+    events = [e async for e in run_coding_loop(
+        provider=provider, model="m", system_prompt="sys",
+        instruction="build it", history=[], sandbox=sandbox,
+        bounds=AgentBounds(max_turns=5),
+    )]
+
+    types = [e.type for e in events]
+    assert "token" in types
+    assert "file_change" in types
+    assert types[-1] == "done"
+    fc = next(e for e in events if e.type == "file_change")
+    assert fc.path == "agent.py"
+    assert "+print(1)" in fc.diff
+    assert sandbox.files["agent.py"] == "print(1)\n"
+
+
+@pytest.mark.asyncio
+async def test_loop_respects_max_turns():
+    sandbox = FakeSandbox()
+    # every turn calls a tool → never terminates on its own
+    provider = FakeProvider([
+        [call(f"c{i}", "list_files", "{}")] for i in range(20)
+    ])
+    events = [e async for e in run_coding_loop(
+        provider=provider, model="m", system_prompt="s",
+        instruction="x", history=[], sandbox=sandbox,
+        bounds=AgentBounds(max_turns=3),
+    )]
+    # 3 turns then a forced done
+    assert events[-1].type == "done"
+    assert len([e for e in events if e.type == "tool_call"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_loop_run_command_feeds_result_back():
+    sandbox = FakeSandbox()
+    provider = FakeProvider([
+        [call("c1", "run_command", json.dumps({"cmd": ["pytest"], "timeout": 5}))],
+        [text("tests pass")],
+    ])
+    events = [e async for e in run_coding_loop(
+        provider=provider, model="m", system_prompt="s",
+        instruction="run tests", history=[], sandbox=sandbox,
+    )]
+    assert sandbox.exec_calls == [["pytest"]]
+    assert events[-1].type == "done"
+    # the tool result must have been appended to the messages of turn 2
+    assert any(m.get("role") == "tool" for m in provider.calls[1])
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pytest tests/unit/test_coding_loop.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'engine.coding_agent.loop'`
+
+- [ ] **Step 4: Write minimal implementation**
+
+```python
+# engine/coding_agent/loop.py
+"""The shared provider-loop driver.
+
+Drives one ``generate_stream()`` turn at a time, executing the model's
+write/read/list/exec tool calls against the sandbox and feeding the results
+back as OpenAI-format tool messages (role="tool", tool_call_id=...), which the
+provider abstraction normalises per backend. Bounded by AgentBounds.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import logging
+import time
+from collections.abc import AsyncIterator
+
+from engine.coding_agent.base import (
+    CODING_TOOLS,
+    TOOL_NAMES,
+    AgentBounds,
+    AgentEvent,
+)
+from engine.providers.models import ToolCall
+from engine.sandbox.base import Sandbox
+
+logger = logging.getLogger(__name__)
+
+
+def _unified_diff(path: str, old: str, new: str) -> str:
+    return "".join(
+        difflib.unified_diff(
+            old.splitlines(keepends=True),
+            new.splitlines(keepends=True),
+            fromfile=f"a/{path}",
+            tofile=f"b/{path}",
+        )
+    )
+
+
+async def _apply_tool(sandbox: Sandbox, tc: ToolCall) -> tuple[str, AgentEvent | None]:
+    """Execute one tool call. Returns (result_text_for_model, optional file_change event)."""
+    try:
+        args = json.loads(tc.function_arguments or "{}")
+    except json.JSONDecodeError:
+        return (f"ERROR: malformed arguments for {tc.function_name}", None)
+
+    name = tc.function_name
+    if name == "write_file":
+        path, content = args.get("path", ""), args.get("content", "")
+        try:
+            old = await sandbox.read(path)
+        except FileNotFoundError:
+            old = ""
+        await sandbox.write(path, content)
+        diff = _unified_diff(path, old, content)
+        return (f"wrote {path} ({len(content)} bytes)",
+                AgentEvent(type="file_change", path=path, diff=diff))
+    if name == "read_file":
+        try:
+            return (await sandbox.read(args.get("path", "")), None)
+        except FileNotFoundError:
+            return (f"ERROR: file not found: {args.get('path')}", None)
+    if name == "list_files":
+        files = await sandbox.list(args.get("directory", "."))
+        return ("\n".join(files), None)
+    if name == "run_command":
+        res = await sandbox.exec(args.get("cmd", []), timeout=float(args.get("timeout", 30)))
+        body = f"exit={res.exit_code} timed_out={res.timed_out}\n{res.stdout}\n{res.stderr}"
+        return (body, None)
+    return (f"ERROR: unknown tool {name}", None)
+
+
+async def run_coding_loop(
+    *,
+    provider,
+    model: str,
+    system_prompt: str,
+    instruction: str,
+    history: list[dict[str, str]],
+    sandbox: Sandbox,
+    bounds: AgentBounds | None = None,
+) -> AsyncIterator[AgentEvent]:
+    """Run the coding agent until it stops calling tools or a bound trips."""
+    bounds = bounds or AgentBounds()
+    started = time.monotonic()
+    tokens_seen = 0
+
+    messages: list[dict] = [{"role": "system", "content": system_prompt}]
+    messages.extend(history)
+    messages.append({"role": "user", "content": instruction})
+
+    for _turn in range(bounds.max_turns):
+        if time.monotonic() - started > bounds.wall_clock_s:
+            yield AgentEvent(type="done", text="stopped: wall-clock bound reached")
+            return
+
+        text_parts: list[str] = []
+        tool_calls: list[ToolCall] = []
+        async for chunk in provider.generate_stream(
+            messages, model=model, tools=CODING_TOOLS
+        ):
+            if chunk.content:
+                text_parts.append(chunk.content)
+                tokens_seen += len(chunk.content)
+                yield AgentEvent(type="token", text=chunk.content)
+            if chunk.tool_calls:
+                tool_calls.extend(chunk.tool_calls)
+
+        # No tool calls → the agent is done.
+        if not tool_calls:
+            yield AgentEvent(type="done", text="".join(text_parts))
+            return
+
+        # Record the assistant turn (text + the tool_use calls).
+        messages.append({
+            "role": "assistant",
+            "content": "".join(text_parts),
+            "tool_calls": [tc.model_dump() for tc in tool_calls],
+        })
+
+        for tc in tool_calls:
+            if tc.function_name not in TOOL_NAMES:
+                result = f"ERROR: tool {tc.function_name} is not available"
+                fc = None
+            else:
+                yield AgentEvent(type="tool_call", tool_name=tc.function_name)
+                result, fc = await _apply_tool(sandbox, tc)
+            if fc is not None:
+                yield fc
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tc.id,
+                "content": result[:20_000],
+            })
+
+        if tokens_seen > bounds.max_tokens:
+            yield AgentEvent(type="done", text="stopped: token bound reached")
+            return
+
+    yield AgentEvent(type="done", text="stopped: max turns reached")
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pytest tests/unit/test_coding_loop.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add engine/coding_agent/loop.py tests/unit/fakes/fake_provider.py tests/unit/test_coding_loop.py
+git commit -m "feat(builder): provider-loop coding driver with bounds + diffs (W3)"
+```
+
+### Task B3: Claude + Codex engine strategies + `engine_for()`
+
+**Files:**
+- Create: `engine/coding_agent/engines.py`
+- Test: `tests/unit/test_coding_engines.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_coding_engines.py
+import pytest
+from engine.coding_agent.engines import engine_for, ClaudeAgentEngine, CodexEngine
+from tests.unit.fakes.fake_provider import FakeProvider, text
+from tests.unit.fakes.fake_sandbox import FakeSandbox
+
+
+def test_engine_for_claude():
+    e = engine_for("claude", provider=FakeProvider([]))
+    assert isinstance(e, ClaudeAgentEngine)
+    assert e.name == "claude"
+
+
+def test_engine_for_codex():
+    e = engine_for("codex", provider=FakeProvider([]))
+    assert isinstance(e, CodexEngine)
+    assert e.name == "codex"
+
+
+def test_engine_for_unknown_raises():
+    with pytest.raises(ValueError):
+        engine_for("bard", provider=FakeProvider([]))
+
+
+@pytest.mark.asyncio
+async def test_engine_run_streams_done():
+    provider = FakeProvider([[text("hi")]])
+    engine = engine_for("claude", provider=provider)
+    events = [e async for e in engine.run("build", [], FakeSandbox())]
+    assert events[-1].type == "done"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/unit/test_coding_engines.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'engine.coding_agent.engines'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# engine/coding_agent/engines.py
+"""Claude / Codex coding-agent strategies over the shared provider loop.
+
+Each engine is a thin strategy: it owns the model id + system prompt and hands
+an injected provider to run_coding_loop(). The provider is constructed by the
+API layer from the BYO key in the secrets backend (never here)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+from engine.coding_agent.base import AgentBounds, AgentEvent
+from engine.coding_agent.loop import run_coding_loop
+from engine.sandbox.base import Sandbox
+
+_CODING_SYSTEM_PROMPT = """\
+You are AgentBreeder's coding agent. You are ejecting a validated agent.yaml into
+real code. Write agent.py, any tools/ modules, and tests into the workspace using
+the provided tools. Keep the code framework-correct for the chosen framework, runnable,
+and covered by at least one test. Use write_file to create files, run_command to run
+tests, and stop when the project is complete. Never print secrets."""
+
+
+class _BaseEngine:
+    name: str = ""
+    model: str = ""
+
+    def __init__(self, provider) -> None:
+        self._provider = provider
+
+    def run(
+        self,
+        instruction: str,
+        history: list[dict[str, str]],
+        sandbox: Sandbox,
+        bounds: AgentBounds | None = None,
+    ) -> AsyncIterator[AgentEvent]:
+        return run_coding_loop(
+            provider=self._provider,
+            model=self.model,
+            system_prompt=_CODING_SYSTEM_PROMPT,
+            instruction=instruction,
+            history=history,
+            sandbox=sandbox,
+            bounds=bounds,
+        )
+
+
+class ClaudeAgentEngine(_BaseEngine):
+    name = "claude"
+    model = "claude-sonnet-4-6"
+
+
+class CodexEngine(_BaseEngine):
+    name = "codex"
+    model = "gpt-4o"
+
+
+def engine_for(name: str, *, provider) -> _BaseEngine:
+    if name == "claude":
+        return ClaudeAgentEngine(provider)
+    if name == "codex":
+        return CodexEngine(provider)
+    raise ValueError(f"unknown coding engine: {name!r} (expected 'claude' or 'codex')")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/unit/test_coding_engines.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Run full Part B suite + commit**
+
+Run: `pytest tests/unit/test_coding_agent_base.py tests/unit/test_coding_loop.py tests/unit/test_coding_engines.py -v`
+Expected: PASS (all)
+
+```bash
+git add engine/coding_agent/engines.py tests/unit/test_coding_engines.py
+git commit -m "feat(builder): Claude + Codex coding-engine strategies (W3)"
+```
+
+---
+
+## PART C — BuilderSession model + service + §6 API
+
+> **TEST-INFRA CORRECTION (discovered 2026-06-14, supersedes the test snippets below):**
+> The integration conftest (`tests/integration/conftest.py`) mocks **auth only** via autouse
+> (injects an admin with `team="engineering"`); there is **no `async_client` / `auth_headers` /
+> `other_team_headers` / `fake_builder_key` fixture and no DB-session override**. The harness uses
+> the **synchronous** `fastapi.testclient.TestClient`. Postgres is NOT available in this dev env.
+> Therefore Part C integration tests MUST follow the repo's established no-DB pattern:
+> - `@pytest.fixture def client() -> TestClient: return TestClient(app)` (per-file, like `test_builders_chat_stream.py`).
+> - Override the DB dep: `from api.database import get_db; app.dependency_overrides[get_db] = lambda: AsyncMock()` (set in a fixture, popped in teardown) — the real DB is never hit.
+> - `@patch`/`monkeypatch` the `BuilderSessionService` methods (`create`/`get`/`list_for_team`/`run_interview_turn`/`run_eject`/`save_state`) to return fakes, asserting route wiring + SSE framing (NOT real persistence). Mirror `_override_db_dep()` + `@patch("api.routes.agentops.FleetService...")` in `tests/unit/test_api_routes_coverage_boost.py`.
+> - BYO key: monkeypatch `get_workspace_backend` to a fake backend (as `test_builders_chat_stream.py` does), not a `fake_builder_key` fixture.
+> - Team-scoping 404: simulate by having the patched `service.get` return `None` (the autouse user is always team `engineering`; there is no real second tenant).
+> - `SessionEventBus` is tested directly (real, no DB).
+> The production `BuilderSessionService(db, bus)` design (DB-backed) is UNCHANGED; only the test approach is corrected. Migration apply (`alembic upgrade head`) is deferred to a DB-enabled run (note it; don't block).
+
+**File structure:**
+- Modify: `api/models/database.py` — add `BuilderSession` table
+- Create: `alembic/versions/0NN_add_builder_sessions.py` — migration (NN = next number)
+- Modify: `api/models/schemas.py` — request/response Pydantic models
+- Create: `api/services/builder_session_service.py` — CRUD + event bus + orchestration
+- Create: `api/routes/builder_sessions.py` — §6 endpoints
+- Modify: `api/main.py` — register router
+- Create: `tests/integration/test_builder_sessions.py`
+
+### Task C1: BuilderSession DB model + migration
+
+**Files:**
+- Modify: `api/models/database.py` (add after `DeployJob`, ~line 163)
+- Create: `alembic/versions/0NN_add_builder_sessions.py`
+
+- [ ] **Step 1: Determine the next migration number**
+
+Run: `ls alembic/versions/ | grep -oE '^[0-9]+' | sort -n | tail -1`
+Use `next = that + 1`, zero-padded to 3 digits (the explorer saw `022` as latest, so likely `023`). Substitute for `0NN` below and set `down_revision` to the latest existing revision id.
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# tests/integration/test_builder_sessions.py  (model import smoke first)
+def test_builder_session_model_importable():
+    from api.models.database import BuilderSession
+    assert BuilderSession.__tablename__ == "builder_sessions"
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pytest tests/integration/test_builder_sessions.py::test_builder_session_model_importable -v`
+Expected: FAIL — `ImportError: cannot import name 'BuilderSession'`
+
+- [ ] **Step 4: Add the model** (in `api/models/database.py`, after the `DeployJob` class)
+
+```python
+class BuilderSession(Base):
+    """A resumable conversational-builder session (Wave 3)."""
+
+    __tablename__ = "builder_sessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    team: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    engine: Mapped[str] = mapped_column(String(20), default="claude", nullable=False)
+    # state JSON: {history: [...], agent_yaml: str|None, files: {path: content},
+    #              deploy_job_id: str|None, satisfied: [...refs]}
+    state: Mapped[dict] = mapped_column(JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+```
+
+- [ ] **Step 5: Write the migration**
+
+```python
+# alembic/versions/0NN_add_builder_sessions.py
+"""add builder_sessions
+
+Revision ID: 0NN
+Revises: <latest>
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0NN"
+down_revision = "<latest>"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "builder_sessions",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("team", sa.String(100), nullable=False),
+        sa.Column("user_id", UUID(as_uuid=True),
+                  sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("engine", sa.String(20), nullable=False, server_default="claude"),
+        sa.Column("state", sa.JSON, server_default="{}"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("ix_builder_sessions_team", "builder_sessions", ["team"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_builder_sessions_team", table_name="builder_sessions")
+    op.drop_table("builder_sessions")
+```
+
+- [ ] **Step 6: Run test + apply migration**
+
+Run: `pytest tests/integration/test_builder_sessions.py::test_builder_session_model_importable -v` → PASS
+Run: `alembic upgrade head` → applies cleanly (requires local Postgres up).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/models/database.py alembic/versions/0NN_add_builder_sessions.py tests/integration/test_builder_sessions.py
+git commit -m "feat(builder): BuilderSession table + migration (W3)"
+```
+
+### Task C2: Session service — CRUD + event bus
+
+**Files:**
+- Modify: `api/models/schemas.py` — add response models
+- Create: `api/services/builder_session_service.py`
+- Test: `tests/integration/test_builder_sessions.py` (add service tests)
+
+- [ ] **Step 1: Add Pydantic schemas** (`api/models/schemas.py`, near `DeployJobResponse`)
+
+```python
+class BuilderSessionResponse(BaseModel):
+    id: str
+    team: str
+    engine: str
+    agent_yaml: str | None = None
+    files: dict[str, str] = Field(default_factory=dict)
+    deploy_job_id: str | None = None
+    history: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class BuilderSessionCreateRequest(BaseModel):
+    engine: str = "claude"  # "claude" | "codex"
+
+
+class BuilderEjectRequest(BaseModel):
+    instruction: str = Field(..., min_length=1, max_length=4000)
+    engine: str | None = None  # override session engine for this run
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# tests/integration/test_builder_sessions.py  (append)
+import pytest
+from api.services.builder_session_service import BuilderSessionService, SessionEventBus
+
+
+@pytest.mark.asyncio
+async def test_event_bus_publish_subscribe():
+    bus = SessionEventBus()
+    async with bus.subscribe("s1") as q:
+        await bus.publish("s1", {"event": "token", "data": "{}"})
+        evt = await q.get()
+        assert evt["event"] == "token"
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pytest tests/integration/test_builder_sessions.py::test_event_bus_publish_subscribe -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'api.services.builder_session_service'`
+
+- [ ] **Step 4: Write minimal implementation**
+
+```python
+# api/services/builder_session_service.py
+"""BuilderSession persistence, the per-session SSE event bus, and orchestration
+of interview / eject / deploy turns. Mirrors the deploy_event_bus pattern.
+
+Governance: the coding agent writes into a sandbox; nothing is auto-deployed.
+Deploy still flows through the existing /deploys pipeline (Parse → RBAC →
+Resolve → Build → Provision → Deploy → Health → Register)."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.models.database import BuilderSession
+
+logger = logging.getLogger(__name__)
+
+
+class SessionEventBus:
+    """In-process pub/sub keyed by session id (swap for Redis in cloud, W4)."""
+
+    def __init__(self) -> None:
+        self._subs: dict[str, set[asyncio.Queue]] = {}
+
+    @contextlib.asynccontextmanager
+    async def subscribe(self, sid: str) -> AsyncIterator[asyncio.Queue]:
+        q: asyncio.Queue = asyncio.Queue()
+        self._subs.setdefault(sid, set()).add(q)
+        try:
+            yield q
+        finally:
+            self._subs.get(sid, set()).discard(q)
+
+    async def publish(self, sid: str, event: dict[str, str]) -> None:
+        for q in list(self._subs.get(sid, set())):
+            await q.put(event)
+
+
+class BuilderSessionService:
+    def __init__(self, db: AsyncSession, bus: SessionEventBus) -> None:
+        self._db = db
+        self._bus = bus
+
+    async def create(self, *, team: str, user_id: uuid.UUID, engine: str) -> BuilderSession:
+        sess = BuilderSession(
+            team=team, user_id=user_id, engine=engine,
+            state={"history": [], "agent_yaml": None, "files": {},
+                   "deploy_job_id": None, "satisfied": []},
+        )
+        self._db.add(sess)
+        await self._db.flush()
+        return sess
+
+    async def get(self, sid: uuid.UUID, *, team: str) -> BuilderSession | None:
+        row = await self._db.get(BuilderSession, sid)
+        if row is None or row.team != team:
+            return None
+        return row
+
+    async def list_for_team(self, team: str) -> list[BuilderSession]:
+        res = await self._db.execute(
+            select(BuilderSession).where(BuilderSession.team == team)
+        )
+        return list(res.scalars().all())
+
+    async def save_state(self, sess: BuilderSession, state: dict[str, Any]) -> None:
+        sess.state = state
+        await self._db.flush()
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pytest tests/integration/test_builder_sessions.py::test_event_bus_publish_subscribe -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/models/schemas.py api/services/builder_session_service.py tests/integration/test_builder_sessions.py
+git commit -m "feat(builder): BuilderSession service + SSE event bus (W3)"
+```
+
+### Task C3: §6 routes — create / get / list
+
+**Files:**
+- Create: `api/routes/builder_sessions.py`
+- Modify: `api/main.py` (register router + attach bus to `app.state`)
+- Test: `tests/integration/test_builder_sessions.py`
+
+- [ ] **Step 1: Write the failing test** (uses the existing integration test client + auth fixtures — mirror the auth/team fixtures already used in `tests/integration/test_deploys.py`)
+
+```python
+# tests/integration/test_builder_sessions.py  (append)
+@pytest.mark.asyncio
+async def test_create_and_get_session(async_client, auth_headers):
+    r = await async_client.post("/api/v1/builder/sessions",
+                                json={"engine": "claude"}, headers=auth_headers)
+    assert r.status_code == 200
+    sid = r.json()["data"]["id"]
+    g = await async_client.get(f"/api/v1/builder/sessions/{sid}", headers=auth_headers)
+    assert g.status_code == 200
+    assert g.json()["data"]["engine"] == "claude"
+
+
+@pytest.mark.asyncio
+async def test_get_other_teams_session_404(async_client, auth_headers, other_team_headers):
+    r = await async_client.post("/api/v1/builder/sessions",
+                                json={"engine": "claude"}, headers=auth_headers)
+    sid = r.json()["data"]["id"]
+    g = await async_client.get(f"/api/v1/builder/sessions/{sid}", headers=other_team_headers)
+    assert g.status_code == 404
+```
+
+> If `async_client`/`auth_headers`/`other_team_headers` fixtures don't exist by those names, reuse whatever `tests/integration/test_deploys.py` and `tests/integration/test_builders*.py` use (same conftest). Match the existing fixture names — do not invent new ones.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/integration/test_builder_sessions.py -k "create_and_get or other_teams" -v`
+Expected: FAIL — 404 (route not registered)
+
+- [ ] **Step 3: Write the router**
+
+```python
+# api/routes/builder_sessions.py
+"""BuilderSession API (Wave 3, spec §6).
+
+POST   /api/v1/builder/sessions                  create
+GET    /api/v1/builder/sessions                  list (team-scoped)
+GET    /api/v1/builder/sessions/{id}             get state
+POST   /api/v1/builder/sessions/{id}/messages    interview turn (SSE)
+POST   /api/v1/builder/sessions/{id}/eject       eject-to-code (SSE)
+GET    /api/v1/builder/sessions/{id}/stream      SSE for all session events
+POST   /api/v1/builder/sessions/{id}/deploy      deploy from current spec
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.auth import get_current_user
+from api.database import get_db
+from api.models.database import User
+from api.models.schemas import (
+    ApiResponse,
+    BuilderSessionCreateRequest,
+    BuilderSessionResponse,
+)
+from api.services.builder_session_service import BuilderSessionService, SessionEventBus
+
+router = APIRouter(prefix="/api/v1/builder/sessions", tags=["builder-sessions"])
+
+
+def _bus(request: Request) -> SessionEventBus:
+    return request.app.state.builder_event_bus
+
+
+def _to_response(sess) -> BuilderSessionResponse:
+    st = sess.state or {}
+    return BuilderSessionResponse(
+        id=str(sess.id), team=sess.team, engine=sess.engine,
+        agent_yaml=st.get("agent_yaml"), files=st.get("files", {}),
+        deploy_job_id=st.get("deploy_job_id"), history=st.get("history", []),
+    )
+
+
+@router.post("", response_model=ApiResponse[BuilderSessionResponse])
+async def create_session(
+    body: BuilderSessionCreateRequest,
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ApiResponse[BuilderSessionResponse]:
+    if body.engine not in ("claude", "codex"):
+        raise HTTPException(400, "engine must be 'claude' or 'codex'")
+    svc = BuilderSessionService(db, _bus(request))
+    sess = await svc.create(team=user.team, user_id=user.id, engine=body.engine)
+    return ApiResponse(data=_to_response(sess))
+
+
+@router.get("", response_model=ApiResponse[list[BuilderSessionResponse]])
+async def list_sessions(
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ApiResponse[list[BuilderSessionResponse]]:
+    svc = BuilderSessionService(db, _bus(request))
+    rows = await svc.list_for_team(user.team)
+    return ApiResponse(data=[_to_response(s) for s in rows])
+
+
+@router.get("/{session_id}", response_model=ApiResponse[BuilderSessionResponse])
+async def get_session(
+    session_id: uuid.UUID,
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ApiResponse[BuilderSessionResponse]:
+    svc = BuilderSessionService(db, _bus(request))
+    sess = await svc.get(session_id, team=user.team)
+    if sess is None:
+        raise HTTPException(404, "Builder session not found")
+    return ApiResponse(data=_to_response(sess))
+```
+
+- [ ] **Step 4: Register router + bus** (`api/main.py` — follow the existing `include_router` block and the `app.state.deploy_event_bus` assignment)
+
+```python
+from api.routes import builder_sessions
+from api.services.builder_session_service import SessionEventBus
+# ... where other routers are included:
+app.include_router(builder_sessions.router)
+# ... where deploy_event_bus is set on app.state (startup):
+app.state.builder_event_bus = SessionEventBus()
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pytest tests/integration/test_builder_sessions.py -k "create_and_get or other_teams" -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/routes/builder_sessions.py api/main.py tests/integration/test_builder_sessions.py
+git commit -m "feat(builder): BuilderSession create/get/list routes (W3 §6)"
+```
+
+### Task C4: `/messages` interview turn over the session (SSE)
+
+**Files:**
+- Modify: `api/routes/builder_sessions.py` (add `/messages`)
+- Modify: `api/services/builder_session_service.py` (add `run_interview_turn`)
+- Test: `tests/integration/test_builder_sessions.py`
+
+This reuses `run_chat_turn_stream` (the W1 engine) but persists history into the session and re-emits events onto the session bus. The BYO key is read via the existing `_builder_key_name` + `get_workspace_backend()` pattern.
+
+- [ ] **Step 1: Write the failing test** (mock the provider so no network — patch `run_chat_turn_stream` to a scripted async generator, mirroring `tests/integration/test_builders_chat_stream.py`)
+
+```python
+# tests/integration/test_builder_sessions.py  (append)
+@pytest.mark.asyncio
+async def test_messages_turn_persists_history(async_client, auth_headers, monkeypatch, fake_builder_key):
+    from engine.agent_chat_builder import ChatStreamEvent, ChatTurnResult
+
+    async def fake_stream(provider, history):
+        yield ChatStreamEvent(type="token", text="Hello")
+        yield ChatStreamEvent(type="done",
+            result=ChatTurnResult(assistant_message="Hello", agent_yaml=None, valid=False))
+
+    monkeypatch.setattr("api.services.builder_session_service.run_chat_turn_stream", fake_stream)
+
+    sid = (await async_client.post("/api/v1/builder/sessions",
+            json={"engine": "claude"}, headers=auth_headers)).json()["data"]["id"]
+    r = await async_client.post(f"/api/v1/builder/sessions/{sid}/messages",
+            json={"content": "build a support agent"}, headers=auth_headers)
+    assert r.status_code == 200
+    body = r.text
+    assert "event: token" in body and "event: done" in body
+
+    g = await async_client.get(f"/api/v1/builder/sessions/{sid}", headers=auth_headers)
+    hist = g.json()["data"]["history"]
+    assert hist[0]["role"] == "user"
+    assert hist[-1]["role"] == "assistant"
+```
+
+> `fake_builder_key` fixture: seed the workspace secrets backend with `AGENTBREEDER_CLAUDE_BUILDER_KEY__{user.id}` = `"sk-test"`. If such a fixture exists in the builders-chat tests, reuse it; otherwise add it to the integration conftest.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/integration/test_builder_sessions.py::test_messages_turn_persists_history -v`
+Expected: FAIL — 405/404 (no `/messages` route)
+
+- [ ] **Step 3: Add service method** (`builder_session_service.py`)
+
+```python
+from dataclasses import asdict
+
+from engine.agent_chat_builder import run_chat_turn_stream
+
+
+class BuilderSessionService:
+    # ... existing ...
+
+    async def run_interview_turn(self, sess, provider, user_text: str):
+        """Async-generate SSE frames for one interview turn; persists history."""
+        state = dict(sess.state or {})
+        history = list(state.get("history", []))
+        history.append({"role": "user", "content": user_text})
+
+        assistant_text = ""
+        async for evt in run_chat_turn_stream(provider, history):
+            if evt.type == "token":
+                assistant_text += evt.text
+                yield {"event": "token", "data": _json({"text": evt.text})}
+            elif evt.type == "setup_request" and evt.setup is not None:
+                yield {"event": "setup_request", "data": _json(asdict(evt.setup))}
+            elif evt.type == "done" and evt.result is not None:
+                r = evt.result
+                if r.agent_yaml:
+                    state["agent_yaml"] = r.agent_yaml
+                    yield {"event": "spec_update", "data": _json(
+                        {"agent_yaml": r.agent_yaml, "valid": r.valid, "errors": r.errors})}
+                history.append({"role": "assistant", "content": r.assistant_message})
+                yield {"event": "done", "data": _json(asdict(r))}
+
+        state["history"] = history
+        await self.save_state(sess, state)
+```
+
+Add a tiny json helper at module top:
+
+```python
+import json as _jsonlib
+def _json(obj) -> str:
+    return _jsonlib.dumps(obj)
+```
+
+- [ ] **Step 4: Add the route** (`builder_sessions.py`)
+
+```python
+import json
+from collections.abc import AsyncGenerator
+from dataclasses import asdict
+
+from sse_starlette.sse import EventSourceResponse
+
+from api.models.schemas import BuilderMessageRequest  # add this schema (content: str)
+from api.routes.builders import _builder_key_name, _no_key_detail
+from engine.providers.anthropic_provider import AnthropicProvider
+from engine.providers.models import ProviderConfig, ProviderType
+from engine.secrets.factory import get_workspace_backend
+
+
+@router.post("/{session_id}/messages")
+async def post_message(
+    session_id: uuid.UUID,
+    body: BuilderMessageRequest,
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> EventSourceResponse:
+    svc = BuilderSessionService(db, _bus(request))
+    sess = await svc.get(session_id, team=user.team)
+    if sess is None:
+        raise HTTPException(404, "Builder session not found")
+
+    secret_name = _builder_key_name(user)
+    backend, _ws = get_workspace_backend()
+    api_key = await backend.get(secret_name)
+    if not api_key:
+        raise HTTPException(400, _no_key_detail(secret_name))
+
+    async def generator() -> AsyncGenerator[dict, None]:
+        provider = AnthropicProvider(
+            ProviderConfig(provider_type=ProviderType.anthropic, api_key=api_key))
+        try:
+            async for frame in svc.run_interview_turn(sess, provider, body.content):
+                yield frame
+        finally:
+            await provider.close()
+
+    return EventSourceResponse(generator())
+```
+
+Add `BuilderMessageRequest` to `schemas.py`:
+
+```python
+class BuilderMessageRequest(BaseModel):
+    content: str = Field(..., min_length=1, max_length=10_000)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pytest tests/integration/test_builder_sessions.py::test_messages_turn_persists_history -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/routes/builder_sessions.py api/services/builder_session_service.py api/models/schemas.py tests/integration/test_builder_sessions.py
+git commit -m "feat(builder): session /messages interview turn with persisted history (W3 §6)"
+```
+
+### Task C5: `/eject` — coding-agent run streaming file diffs
+
+**Files:**
+- Modify: `api/routes/builder_sessions.py` (add `/eject`)
+- Modify: `api/services/builder_session_service.py` (add `run_eject` + sandbox gating)
+- Test: `tests/integration/test_builder_sessions.py`
+
+- [ ] **Step 1: Write the failing test** (mock `engine_for` to return a fake engine emitting file_change + done; assert files persist into session state)
+
+```python
+# tests/integration/test_builder_sessions.py  (append)
+@pytest.mark.asyncio
+async def test_eject_persists_generated_files(async_client, auth_headers, monkeypatch, fake_builder_key):
+    from engine.coding_agent.base import AgentEvent
+
+    class FakeEngine:
+        name = "claude"
+        async def run(self, instruction, history, sandbox, bounds=None):
+            await sandbox.write("agent.py", "print('hi')\n")
+            yield AgentEvent(type="file_change", path="agent.py", diff="+print('hi')")
+            yield AgentEvent(type="done", text="done")
+
+    monkeypatch.setattr(
+        "api.services.builder_session_service.engine_for",
+        lambda name, provider: FakeEngine())
+
+    sid = (await async_client.post("/api/v1/builder/sessions",
+            json={"engine": "claude"}, headers=auth_headers)).json()["data"]["id"]
+    r = await async_client.post(f"/api/v1/builder/sessions/{sid}/eject",
+            json={"instruction": "add a custom tool"}, headers=auth_headers)
+    assert r.status_code == 200
+    assert "event: file_change" in r.text
+
+    files = (await async_client.get(f"/api/v1/builder/sessions/{sid}",
+             headers=auth_headers)).json()["data"]["files"]
+    assert files["agent.py"] == "print('hi')\n"
+
+
+@pytest.mark.asyncio
+async def test_eject_blocked_when_sandbox_cloud(async_client, auth_headers, monkeypatch, fake_builder_key):
+    monkeypatch.setenv("AGENTBREEDER_SANDBOX", "cloud")
+    sid = (await async_client.post("/api/v1/builder/sessions",
+            json={"engine": "claude"}, headers=auth_headers)).json()["data"]["id"]
+    r = await async_client.post(f"/api/v1/builder/sessions/{sid}/eject",
+            json={"instruction": "x"}, headers=auth_headers)
+    # cloud sandbox not available until W4 → 409
+    assert r.status_code == 409
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/integration/test_builder_sessions.py -k eject -v`
+Expected: FAIL — no `/eject` route
+
+- [ ] **Step 3: Add service method** (`builder_session_service.py`)
+
+```python
+from engine.coding_agent.engines import engine_for
+from engine.sandbox.base import select_sandbox_mode
+from engine.sandbox.local import LocalSandbox
+
+
+class CloudSandboxUnavailable(RuntimeError):
+    """Raised when cloud sandbox is selected but not yet available (pre-W4)."""
+
+
+def _make_sandbox():
+    mode = select_sandbox_mode()
+    if mode == "local":
+        return LocalSandbox()
+    if mode == "cloud":
+        raise CloudSandboxUnavailable("CloudSandbox is not available yet (Wave 4)")
+    raise CloudSandboxUnavailable("Sandbox is disabled (AGENTBREEDER_SANDBOX=disabled)")
+
+
+class BuilderSessionService:
+    # ... existing ...
+
+    async def run_eject(self, sess, provider, instruction: str, engine_name: str):
+        """Run the coding agent in a sandbox; stream events; persist files."""
+        sandbox = _make_sandbox()
+        state = dict(sess.state or {})
+        # seed the sandbox with files already generated this session
+        for path, content in (state.get("files") or {}).items():
+            await sandbox.write(path, content)
+        if state.get("agent_yaml"):
+            await sandbox.write("agent.yaml", state["agent_yaml"])
+
+        engine = engine_for(engine_name, provider=provider)
+        try:
+            async for evt in engine.run(instruction, state.get("history", []), sandbox):
+                if evt.type == "token":
+                    yield {"event": "token", "data": _json({"text": evt.text})}
+                elif evt.type == "tool_call":
+                    yield {"event": "tool_call", "data": _json({"tool": evt.tool_name})}
+                elif evt.type == "file_change":
+                    yield {"event": "file_change",
+                           "data": _json({"path": evt.path, "diff": evt.diff})}
+                elif evt.type == "done":
+                    yield {"event": "complete", "data": _json({"summary": evt.text})}
+                elif evt.type == "error":
+                    yield {"event": "error", "data": _json({"detail": evt.error})}
+            # snapshot the workspace back into session state
+            state["files"] = {p: await sandbox.read(p) for p in await sandbox.list(".")}
+            await self.save_state(sess, state)
+        finally:
+            await sandbox.close()
+```
+
+- [ ] **Step 4: Add the route** (`builder_sessions.py`)
+
+```python
+from api.models.schemas import BuilderEjectRequest
+from api.services.builder_session_service import CloudSandboxUnavailable
+
+
+@router.post("/{session_id}/eject")
+async def eject_to_code(
+    session_id: uuid.UUID,
+    body: BuilderEjectRequest,
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> EventSourceResponse:
+    svc = BuilderSessionService(db, _bus(request))
+    sess = await svc.get(session_id, team=user.team)
+    if sess is None:
+        raise HTTPException(404, "Builder session not found")
+
+    engine_name = body.engine or sess.engine
+    if engine_name not in ("claude", "codex"):
+        raise HTTPException(400, "engine must be 'claude' or 'codex'")
+
+    # Fail fast on sandbox availability before opening the stream.
+    try:
+        from engine.sandbox.base import select_sandbox_mode
+        if select_sandbox_mode() != "local":
+            raise CloudSandboxUnavailable()
+    except CloudSandboxUnavailable:
+        raise HTTPException(409, "Code generation requires local sandbox mode (cloud sandbox lands in Wave 4).")
+
+    secret_name = _builder_key_name(user)
+    backend, _ws = get_workspace_backend()
+    api_key = await backend.get(secret_name)
+    if not api_key:
+        raise HTTPException(400, _no_key_detail(secret_name))
+
+    async def generator():
+        provider = AnthropicProvider(
+            ProviderConfig(provider_type=ProviderType.anthropic, api_key=api_key))
+        try:
+            async for frame in svc.run_eject(sess, provider, body.instruction, engine_name):
+                yield frame
+        finally:
+            await provider.close()
+
+    return EventSourceResponse(generator())
+```
+
+> NOTE (Codex parity): the `/eject` route above constructs an `AnthropicProvider`. For `engine="codex"`, construct an `OpenAIProvider` from the user's OpenAI key secret instead. Add a `_provider_for_engine(engine_name, user)` helper that returns the right provider + the right BYO-key secret name (`AGENTBREEDER_CLAUDE_BUILDER_KEY__{id}` for claude, an `AGENTBREEDER_CODEX_BUILDER_KEY__{id}` for codex). Implement it now so Codex isn't a stub — mirror `_builder_key_name`.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pytest tests/integration/test_builder_sessions.py -k eject -v`
+Expected: PASS (both tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/routes/builder_sessions.py api/services/builder_session_service.py api/models/schemas.py tests/integration/test_builder_sessions.py
+git commit -m "feat(builder): /eject coding-agent run with sandbox gating (W3 §6)"
+```
+
+### Task C6: `/deploy` from session + `/stream` aggregate SSE
+
+**Files:**
+- Modify: `api/routes/builder_sessions.py`
+- Test: `tests/integration/test_builder_sessions.py`
+
+- [ ] **Step 1: Write the failing test** (deploy reuses the existing deploy pipeline by POSTing the session's `agent_yaml`; mock `DeployJobService` create to return a fake job id, mirroring `tests/integration/test_deploys.py` mocking)
+
+```python
+# tests/integration/test_builder_sessions.py  (append)
+@pytest.mark.asyncio
+async def test_deploy_from_session_uses_pipeline(async_client, auth_headers, monkeypatch):
+    # seed a session with a valid agent_yaml directly via the service
+    sid = (await async_client.post("/api/v1/builder/sessions",
+            json={"engine": "claude"}, headers=auth_headers)).json()["data"]["id"]
+    # patch get to inject agent_yaml, and patch deploy creation
+    import api.routes.builder_sessions as mod
+
+    async def fake_create_deploy_from_yaml(yaml_content, team, user, db, bus):
+        return "job-123"
+    monkeypatch.setattr(mod, "_create_deploy_from_yaml", fake_create_deploy_from_yaml)
+    monkeypatch.setattr(mod.BuilderSessionService, "get",
+        lambda self, sid_, team: _fake_session_with_yaml(sid_, team))
+
+    r = await async_client.post(f"/api/v1/builder/sessions/{sid}/deploy", headers=auth_headers)
+    assert r.status_code == 200
+    assert r.json()["data"]["deploy_job_id"] == "job-123"
+
+
+@pytest.mark.asyncio
+async def test_deploy_without_spec_400(async_client, auth_headers):
+    sid = (await async_client.post("/api/v1/builder/sessions",
+            json={"engine": "claude"}, headers=auth_headers)).json()["data"]["id"]
+    r = await async_client.post(f"/api/v1/builder/sessions/{sid}/deploy", headers=auth_headers)
+    assert r.status_code == 400  # no agent_yaml yet
+```
+
+> The mocking shape here is illustrative — match the actual `DeployJobService` constructor + create signature used in `api/routes/deploys.py::create_deploy`. The real route should call the same service the deploys route uses (do NOT duplicate pipeline logic — reuse `DeployJobService`). Adjust the test's monkeypatch targets to the real symbols.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/integration/test_builder_sessions.py -k "deploy_from_session or deploy_without_spec" -v`
+Expected: FAIL — no `/deploy` route
+
+- [ ] **Step 3: Add `/deploy` + `/stream` routes** (reuse `DeployJobService` exactly as `deploys.py` does — RBAC, team resolution, audit, registry are all preserved by going through it)
+
+```python
+@router.post("/{session_id}/deploy", response_model=ApiResponse[BuilderSessionResponse])
+async def deploy_from_session(
+    session_id: uuid.UUID,
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ApiResponse[BuilderSessionResponse]:
+    svc = BuilderSessionService(db, _bus(request))
+    sess = await svc.get(session_id, team=user.team)
+    if sess is None:
+        raise HTTPException(404, "Builder session not found")
+    agent_yaml = (sess.state or {}).get("agent_yaml")
+    if not agent_yaml:
+        raise HTTPException(400, "Session has no validated agent.yaml to deploy yet.")
+
+    # Reuse the exact deploy entrypoint the /deploys route uses so the full
+    # governance pipeline (RBAC, team check, audit, registry) is preserved.
+    from api.models.schemas import DeployRequest
+    from api.routes.deploys import _resolve_deploy_team
+    from api.services.deploy_service import DeployJobService
+
+    body = DeployRequest(config_yaml=agent_yaml, target="local")
+    team, agent = await _resolve_deploy_team(body, db)
+    # enforce_team_role(user, team, "deployer") — call the same guard deploys.py calls
+    deploy_svc = DeployJobService(db, request.app.state.deploy_event_bus)
+    job = await deploy_svc.create(body, team=team, agent=agent, user=user)
+
+    state = dict(sess.state or {})
+    state["deploy_job_id"] = str(job.id)
+    await svc.save_state(sess, state)
+    return ApiResponse(data=_to_response(sess))
+
+
+@router.get("/{session_id}/stream")
+async def stream_session(
+    session_id: uuid.UUID,
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> EventSourceResponse:
+    svc = BuilderSessionService(db, _bus(request))
+    sess = await svc.get(session_id, team=user.team)
+    if sess is None:
+        raise HTTPException(404, "Builder session not found")
+    bus = _bus(request)
+
+    async def generator():
+        import asyncio
+        async with bus.subscribe(str(session_id)) as queue:
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    evt = await asyncio.wait_for(queue.get(), timeout=15)
+                except TimeoutError:
+                    yield {"event": "ping", "data": ""}
+                    continue
+                yield evt
+
+    return EventSourceResponse(generator())
+```
+
+> Match `DeployJobService(...)` and `.create(...)` to their real signatures in `api/services/deploy_service.py`. If the deploys route resolves team + enforces role inline rather than via a service method, replicate that exact sequence (don't skip `enforce_team_role`). The governance pipeline MUST NOT be bypassed (CLAUDE.md §2).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/integration/test_builder_sessions.py -k "deploy or stream" -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full Part C suite + the existing builders/deploys suites (no regressions)**
+
+Run: `pytest tests/integration/test_builder_sessions.py tests/integration/test_deploys.py tests/unit/test_sandbox_*.py tests/unit/test_coding_*.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/routes/builder_sessions.py tests/integration/test_builder_sessions.py
+git commit -m "feat(builder): /deploy from session + aggregate /stream (W3 §6)"
+```
+
+---
+
+## PART D — Frontend: two-pane build console + Code tab + eject UI
+
+**File structure:**
+- Modify: `dashboard/src/lib/api.ts` — `builderSessions` client + types
+- Create: `dashboard/src/components/agent-wizard/CodeArtifactPanel.tsx` — file tree + diff viewer
+- Create: `dashboard/src/components/agent-wizard/CodeArtifactPanel.test.tsx`
+- Modify: `dashboard/src/components/agent-wizard/ChatBuildPanel.tsx` — add artifact panel tabs (Spec | Code | Deploy) + "Eject to code" affordance
+- Modify: `dashboard/src/components/agent-wizard/ChatBuildPanel.test.tsx`
+
+### Task D1: `builderSessions` API client + types
+
+**Files:**
+- Modify: `dashboard/src/lib/api.ts`
+- Test: `dashboard/src/lib/api.test.ts` (if present; else cover via component tests)
+
+- [ ] **Step 1: Add types + client** (`api.ts`, near the `builders` object ~line 2421)
+
+```typescript
+export interface BuilderSession {
+  id: string;
+  team: string;
+  engine: "claude" | "codex";
+  agent_yaml: string | null;
+  files: Record<string, string>;
+  deploy_job_id: string | null;
+  history: { role: string; content: string }[];
+}
+
+export interface BuilderFileChange {
+  path: string;
+  diff: string;
+}
+
+// in the api object, after `builders: { ... },`
+builderSessions: {
+  create: (engine: "claude" | "codex" = "claude") =>
+    request<BuilderSession>("/builder/sessions", {
+      method: "POST",
+      body: JSON.stringify({ engine }),
+    }),
+  get: (id: string) => request<BuilderSession>(`/builder/sessions/${id}`),
+  sendMessage: (
+    id: string,
+    content: string,
+    onEvent: (event: string, data: unknown) => void,
+  ) =>
+    streamSSE(
+      `/builder/sessions/${id}/messages`,
+      { method: "POST", body: JSON.stringify({ content }) },
+      onEvent,
+    ),
+  eject: (
+    id: string,
+    instruction: string,
+    onEvent: (event: string, data: unknown) => void,
+    engine?: "claude" | "codex",
+  ) =>
+    streamSSE(
+      `/builder/sessions/${id}/eject`,
+      { method: "POST", body: JSON.stringify({ instruction, engine }) },
+      onEvent,
+    ),
+  deploy: (id: string) =>
+    request<BuilderSession>(`/builder/sessions/${id}/deploy`, { method: "POST" }),
+},
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd dashboard && npm run typecheck`
+Expected: 0 errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/src/lib/api.ts
+git commit -m "feat(builder): builderSessions API client + types (W3)"
+```
+
+### Task D2: CodeArtifactPanel — file tree + diff viewer
+
+**Files:**
+- Create: `dashboard/src/components/agent-wizard/CodeArtifactPanel.tsx`
+- Test: `dashboard/src/components/agent-wizard/CodeArtifactPanel.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// CodeArtifactPanel.test.tsx
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { CodeArtifactPanel } from "./CodeArtifactPanel";
+
+const files = { "agent.py": "print('hi')\n", "tools/search.py": "x = 1\n" };
+
+describe("CodeArtifactPanel", () => {
+  it("lists generated files", () => {
+    render(<CodeArtifactPanel files={files} />);
+    expect(screen.getByText("agent.py")).toBeInTheDocument();
+    expect(screen.getByText("tools/search.py")).toBeInTheDocument();
+  });
+
+  it("shows file contents when a file is selected", () => {
+    render(<CodeArtifactPanel files={files} />);
+    fireEvent.click(screen.getByText("tools/search.py"));
+    expect(screen.getByText(/x = 1/)).toBeInTheDocument();
+  });
+
+  it("renders an empty state when there are no files", () => {
+    render(<CodeArtifactPanel files={{}} />);
+    expect(screen.getByText(/No code generated yet/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dashboard && npx vitest run src/components/agent-wizard/CodeArtifactPanel.test.tsx`
+Expected: FAIL — cannot find `./CodeArtifactPanel`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```tsx
+// CodeArtifactPanel.tsx
+import { useState } from "react";
+
+interface CodeArtifactPanelProps {
+  files: Record<string, string>;
+}
+
+export function CodeArtifactPanel({ files }: CodeArtifactPanelProps) {
+  const paths = Object.keys(files).sort();
+  const [selected, setSelected] = useState<string | null>(paths[0] ?? null);
+
+  if (paths.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-gray-500">
+        No code generated yet. Use “Eject to code” to generate agent.py and tools.
+      </div>
+    );
+  }
+
+  const active = selected && files[selected] !== undefined ? selected : paths[0];
+
+  return (
+    <div className="flex h-full">
+      <ul className="w-48 shrink-0 overflow-auto border-r border-gray-200 text-sm">
+        {paths.map((p) => (
+          <li key={p}>
+            <button
+              type="button"
+              onClick={() => setSelected(p)}
+              className={`block w-full truncate px-3 py-2 text-left hover:bg-gray-50 ${
+                p === active ? "bg-gray-100 font-medium" : ""
+              }`}
+            >
+              {p}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <pre className="flex-1 overflow-auto bg-gray-50 p-4 text-xs leading-relaxed">
+        {files[active]}
+      </pre>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dashboard && npx vitest run src/components/agent-wizard/CodeArtifactPanel.test.tsx`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/src/components/agent-wizard/CodeArtifactPanel.tsx dashboard/src/components/agent-wizard/CodeArtifactPanel.test.tsx
+git commit -m "feat(builder): CodeArtifactPanel file tree + viewer (W3)"
+```
+
+### Task D3: Wire eject + Code tab into ChatBuildPanel
+
+**Files:**
+- Modify: `dashboard/src/components/agent-wizard/ChatBuildPanel.tsx`
+- Modify: `dashboard/src/components/agent-wizard/ChatBuildPanel.test.tsx`
+
+The W1/W2 `ChatBuildPanel` is single-pane (thread + inline `SpecReadyCard`). W3 adds: a session id (created lazily on first message via `api.builderSessions`), an artifact panel with tabs **Spec | Code | Deploy**, an "Eject to code" button on the validated spec card that calls `api.builderSessions.eject(...)` and accumulates `file_change` events into a `files` state feeding `CodeArtifactPanel`.
+
+- [ ] **Step 1: Write the failing test** (add to `ChatBuildPanel.test.tsx` — mock `api.builderSessions.eject` to invoke its `onEvent` with a `file_change` then `complete`, assert the Code tab shows the file). Follow the existing mock structure in that 548-line file (key guard + `builders.chatStream` mock already present).
+
+```tsx
+// ChatBuildPanel.test.tsx (add within the existing describe)
+it("eject-to-code streams a file into the Code tab", async () => {
+  // ...arrange: render with a key present and a validated spec already shown
+  // mock api.builderSessions.eject:
+  vi.mocked(api.builderSessions.eject).mockImplementation(
+    async (_id, _instr, onEvent) => {
+      onEvent("file_change", { path: "agent.py", diff: "+print('hi')" });
+      onEvent("complete", { summary: "done" });
+    },
+  );
+  // act: click "Eject to code", then the "Code" tab
+  fireEvent.click(await screen.findByRole("button", { name: /eject to code/i }));
+  fireEvent.click(await screen.findByRole("tab", { name: /code/i }));
+  // assert
+  expect(await screen.findByText("agent.py")).toBeInTheDocument();
+});
+```
+
+> Extend the existing `api` mock object in this file to include `builderSessions: { create, get, eject, deploy }` (vi.fn()). Mirror how `builders.chatStream` is already mocked.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dashboard && npx vitest run src/components/agent-wizard/ChatBuildPanel.test.tsx -t "eject-to-code"`
+Expected: FAIL — no "Eject to code" button / no Code tab
+
+- [ ] **Step 3: Implement** — in `ChatBuildPanel.tsx`:
+  1. Add state: `const [sessionId, setSessionId] = useState<string|null>(null)`, `const [files, setFiles] = useState<Record<string,string>>({})`, `const [artifactTab, setArtifactTab] = useState<"spec"|"code"|"deploy">("spec")`, `const [ejecting, setEjecting] = useState(false)`.
+  2. Ensure a session exists before eject: a `ensureSession()` helper that calls `api.builderSessions.create(engine)` once and stores the id. (For W3, interview can still run via the existing `builders.chatStream`; only eject needs the session — minimal coupling. A later pass can migrate the interview onto `builderSessions.sendMessage`.)
+  3. Add the artifact panel markup: a tab bar (`role="tablist"` with three `role="tab"` buttons Spec/Code/Deploy) and a body that renders the existing spec `<pre>` for "spec", `<CodeArtifactPanel files={files} />` for "code", and the existing deploy logs for "deploy".
+  4. Add an "Eject to code" button inside `SpecReadyCard` (only when `valid`) that sets `ejecting`, calls `ensureSession()`, then `api.builderSessions.eject(id, instruction, (event, data) => {...})` accumulating `file_change` into `files` (keyed by path; reconstruct content by applying the write — since the backend sends only a diff, ALSO have the backend include the full content: update the `/eject` `file_change` frame to carry `content` alongside `diff`, and update `BuilderFileChange` + this handler to store `data.content`). On `complete`, `setEjecting(false)` and switch to the Code tab.
+
+  > IMPORTANT contract fix: the W3 `file_change` SSE frame must include `content` (full file) in addition to `diff`, so the Code tab can render the file without replaying diffs. Update `run_eject` in `builder_session_service.py` to emit `{"path", "diff", "content"}` and `BuilderFileChange` accordingly. Add a backend test asserting `content` is present in the frame.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dashboard && npx vitest run src/components/agent-wizard/ChatBuildPanel.test.tsx`
+Expected: PASS (existing + new)
+
+- [ ] **Step 5: Typecheck + lint + full FE suite**
+
+Run: `cd dashboard && npm run typecheck && npm run lint && npx vitest run`
+Expected: 0 type errors, 0 lint errors, all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/src/components/agent-wizard/ChatBuildPanel.tsx dashboard/src/components/agent-wizard/ChatBuildPanel.test.tsx api/routes/builder_sessions.py api/services/builder_session_service.py tests/integration/test_builder_sessions.py
+git commit -m "feat(builder): eject-to-code UI + Code artifact tab; file_change carries content (W3)"
+```
+
+---
+
+## PART E — Cross-repo (cloud), docs, model-e2e, analytics
+
+### Task E1: Cloud proxy passthrough for builder sessions
+
+Per `feedback_cross_repo_sync` + CLAUDE.md §Cross-Repo Sync. The cloud repo currently only proxies `/builders/chat` (+recommend) via a buffered `_forward()`. Wave 3 adds streaming session endpoints. Cloud must passthrough `/cloud/builder/sessions/*` with `httpx.stream` (no event-name filtering) + per-turn / per-eject metering.
+
+**Files (in `/Users/rajit/personal-github/agentbreeder-cloud`):**
+- Modify: `agentbreeder-cloud/api/routes/builders.py` — add session passthrough routes
+- Test: `agentbreeder-cloud/tests/...` matching its layout
+
+- [ ] **Step 1:** Read `agentbreeder-cloud/api/routes/builders.py` to learn its `_forward()`, `TenantMiddleware`, and `QuotaCounter` usage.
+- [ ] **Step 2:** Add an SSE passthrough helper (`_forward_stream(request, path)`) using `httpx.AsyncClient.stream`, relaying `event:`/`data:` frames verbatim, counting one metered unit per `/messages` and per `/eject` against `QuotaCounter` (and, for eject, sandbox-minutes — stub the minute counter to 0 until W4 cloud sandbox exists, with a `# TODO(W4)` note).
+- [ ] **Step 3:** Add routes mirroring the six OSS endpoints under `/cloud/builder/sessions`.
+- [ ] **Step 4:** Test the passthrough with a mocked upstream SSE response asserting frames are relayed unbuffered and quota incremented.
+- [ ] **Step 5:** Commit in the cloud repo:
+
+```bash
+git -C /Users/rajit/personal-github/agentbreeder-cloud add -A
+git -C /Users/rajit/personal-github/agentbreeder-cloud commit -m "feat(builder): proxy BuilderSession streaming + metering (OSS W3 parity)"
+```
+
+> This is a companion change in a separate repo — do NOT bundle into the OSS commit. Keep it on a matching branch in the cloud repo.
+
+### Task E2: Docs sync
+
+Per CLAUDE.md docs-sync table (new feature → `how-to.mdx`; the chat builder section already exists from W1/W2).
+
+**Files:**
+- Modify: `website/content/docs/how-to.mdx` — add an "Eject to code" subsection under the chat-builder flow: how to click eject, choose engine (Claude/Codex), what gets generated (`agent.py`/`tools/`/tests), that it runs in a local sandbox, and that cloud codegen needs `AGENTBREEDER_SANDBOX` (lands fully in cloud at W4).
+- Modify: `website/content/docs/agent-yaml.mdx` — only if a field changed (none in W3; skip if so).
+- Create (optional): `website/content/docs/conversational-builder.mdx` if the how-to section grows too large — otherwise keep it inline.
+
+- [ ] **Step 1:** Read the existing chat-builder section in `how-to.mdx` (W2 added "Inline setup" after step 6).
+- [ ] **Step 2:** Add the "Eject to code" subsection with a worked example and a note on the `AGENTBREEDER_SANDBOX` env gate.
+- [ ] **Step 3:** Commit (same branch as the OSS code):
+
+```bash
+git add website/content/docs/how-to.mdx
+git commit -m "docs(builder): document eject-to-code flow (W3)"
+```
+
+### Task E3: Model-e2e gated test (BYO key) + analytics events
+
+Per spec §11 (one transcript per engine) and §12 (funnel events).
+
+**Files:**
+- Create: `tests/e2e/test_builder_eject_e2e.py` — gated behind an env flag + real key (skipped in CI by default), asserts: create session → seed a tiny valid `agent.yaml` → eject → at least one `file_change` with `agent.py` → snapshot contains `agent.py`. Mirror any existing gated model-e2e test (`model-e2e-test` skill / existing `tests/e2e`).
+- Modify: frontend analytics hook — emit `eject_to_code_started`, `coding_agent_turn`, `deploy_started/succeeded/failed` where the existing W1/W2 funnel events are emitted (search for the existing `builder_session_started`/`spec_validated` emit sites; if analytics wiring doesn't exist yet, add a thin `track()` call alongside the new eject handler and note it).
+
+- [ ] **Step 1:** Write the gated e2e test with `@pytest.mark.skipif(not os.environ.get("AGENTBREEDER_E2E_ANTHROPIC_KEY"), reason=...)`.
+- [ ] **Step 2:** Run it locally with a real key once to confirm the loop genuinely writes a file end-to-end (manual verification — this is the real proof the provider-loop works against a live model).
+- [ ] **Step 3:** Add the analytics emits.
+- [ ] **Step 4:** Commit:
+
+```bash
+git add tests/e2e/test_builder_eject_e2e.py dashboard/src/...
+git commit -m "test(builder): gated eject e2e + analytics funnel events (W3)"
+```
+
+### Task E4: Wave 3 gate + memory update
+
+- [ ] **Step 1:** Run the full gate (per the `gate` skill): backend `pytest`, frontend `vitest` + `tsc` + `lint`, `ruff check . && ruff format --check .`, `mypy` on changed files, security scan, FE build. All green.
+- [ ] **Step 2:** Update the epic memory file `project_conversational_builder_epic.md`: mark W3 done, list what shipped, note W4 (CloudSandbox + metering + analytics dashboard) as the remaining wave, and that the PR is still deferred until W4 per `feedback_defer_pr_until_done`.
+- [ ] **Step 3:** Do NOT open the PR yet (epic not complete). Confirm the branch is committed and clean.
+
+---
+
+## Self-review notes (gaps the implementer must watch)
+
+1. **Tool-message format round-trip (highest risk) — RESOLVED into Task B0.** Spiked 2026-06-14: confirmed neither `AnthropicProvider._build_payload` nor `OpenAIProvider._build_payload` translates the loop's `role="tool"` + assistant `tool_calls` messages into native tool_result/tool_use blocks. Task B0 adds that provider-layer translation with unit tests and runs **before** the loop (B2). Do not skip or reorder B0 — the whole provider-loop rests on it, and loop unit tests (FakeProvider) won't catch a regression here.
+2. **Codex provider parity.** Part B's `CodexEngine` uses `OpenAIProvider`; ensure `_provider_for_engine` (Task C5) constructs the right provider + BYO-key secret for `engine="codex"`. Don't leave Codex as a Claude alias.
+3. **Sandbox security.** `LocalSandbox` runs host commands; the `AGENTBREEDER_SANDBOX` gate (Task C5) is the only thing keeping cloud from running user code in-process. The gate check must be **before** the stream opens and must fail closed. Cloud deploy config must set `AGENTBREEDER_SANDBOX=cloud` (note this in E1).
+4. **`file_change` frame carries `content`** (Task D3 contract fix) — make sure the backend emits it and a backend test asserts it, or the Code tab can't render files.
+5. **Governance preserved.** `/deploy` (Task C6) must route through the real `DeployJobService` used by `/deploys` — RBAC, team check, audit, registry are non-negotiable (CLAUDE.md §2). No duplicated pipeline.
+6. **Fixture names.** Integration tests assume `async_client` / `auth_headers` / `other_team_headers` / `fake_builder_key`. Before writing tests, open the integration conftest + `tests/integration/test_deploys.py` and use the real fixture names; don't invent.
+7. **Migration number.** Confirm the next alembic revision id + correct `down_revision` (Task C1 Step 1) — don't hard-code `023` without checking.

--- a/docs/superpowers/plans/2026-06-14-studio-conversational-builder-wave4.md
+++ b/docs/superpowers/plans/2026-06-14-studio-conversational-builder-wave4.md
@@ -1,0 +1,1988 @@
+# Wave 4 — Studio Conversational Builder Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the conversational-builder epic: a managed CloudSandbox so `AGENTBREEDER_SANDBOX=cloud` works, real sandbox-minutes metering in the cloud, a Studio Builder analytics funnel, and a Codex golden-transcript gated e2e.
+
+**Architecture:** CloudSandbox is a thin `Sandbox`-Protocol client over a pluggable `SandboxBackend` (v1 = e2b microVM; `FakeBackend` for unit tests). The OSS eject stream emits `sandbox_seconds` in its terminal `complete` frame; the cloud proxy pre-checks the daily sandbox-minute quota, relays the stream, sniffs `sandbox_seconds`, and charges `ceil(minutes)`. Analytics events land in a dedicated OSS Postgres table behind an ingest endpoint; a Studio "Builder" view renders the funnel + per-engine scorecards using the house CSS-bar idiom (no new chart dep).
+
+**Tech Stack:** Python 3.11 / FastAPI / SQLAlchemy / Alembic (OSS + cloud), e2b Python SDK (async), React 18 / TS / Tailwind / shadcn / React Query, pytest, Vitest.
+
+**Design source:** `docs/superpowers/specs/2026-06-14-studio-conversational-builder-wave4-design.md` (read §3–§5 and §11 before starting; the security rails in §11.2 are load-bearing).
+
+**Repos:** `agentbreeder` (OSS, this repo) and `agentbreeder-cloud` (`/Users/rajit/personal-github/agentbreeder-cloud`).
+
+**Scope check:** This plan has 4 independent parts; each produces working, testable software on its own. Part C (analytics) is the heaviest and full-stack — it may be executed as its own session. Recommended order: A → B → C → D (B depends on A's `sandbox_seconds` contract).
+
+---
+
+## File Structure
+
+**Part A — CloudSandbox (OSS)**
+- Create `engine/sandbox/backends/__init__.py` — `make_backend_from_env()` factory
+- Create `engine/sandbox/backends/base.py` — `SandboxBackend` Protocol
+- Create `engine/sandbox/backends/fake.py` — `FakeBackend` (in-memory, unit tests)
+- Create `engine/sandbox/backends/e2b.py` — `E2BBackend` (e2b async SDK; gated integration)
+- Create `engine/sandbox/cloud.py` — `CloudSandbox` (implements `Sandbox`, guards + caps, delegates)
+- Modify `api/services/builder_session_service.py` — flip `_make_sandbox`; add `sandbox_seconds`+`code` to frames
+- Test `tests/unit/test_cloud_sandbox.py`
+
+**Part B — Cloud sandbox-minutes metering (`agentbreeder-cloud`)**
+- Modify `api/models/tenancy.py:41-43` — add enum values
+- Modify `api/config.py` — add minute limits
+- Modify `api/services/quota.py` — `amount` param, `peek_count`, `charge_sandbox_minutes`
+- Modify `api/routes/builder_sessions.py:175-188` — pre-check + sniff + charge
+- Create `alembic/versions/<next>_add_sandbox_minute_scopes.py` — ALTER enum
+- Test `tests/test_builder_sessions_metering.py`
+
+**Part C — Analytics funnel (OSS + dashboard)**
+- Modify `api/models/database.py` — add `AnalyticsEvent`
+- Create `alembic/versions/025_add_analytics_events.py`
+- Modify `api/models/schemas.py` — ingest + funnel schemas
+- Create `api/routes/analytics.py` — POST ingest, GET funnel
+- Modify `api/main.py` — register router
+- Modify `dashboard/src/lib/analytics.ts` — expand union + network ingest
+- Modify `dashboard/src/lib/api.ts` — `api.analytics`
+- Create `dashboard/src/pages/builder-insights.tsx` — the Builder view
+- Modify `dashboard/src/App.tsx` + `dashboard/src/components/shell.tsx` — route + nav
+- Modify `dashboard/src/components/agent-wizard/ChatBuildPanel.tsx:598` — derive engine
+- Tests `tests/integration/test_analytics.py`, `dashboard/src/pages/builder-insights.test.tsx`
+
+**Part D — Codex golden e2e (OSS)**
+- Create `tests/e2e/test_builder_eject_codex_e2e.py`
+
+---
+
+# Part A — CloudSandbox
+
+### Task A1: `SandboxBackend` Protocol
+
+**Files:**
+- Create: `engine/sandbox/backends/__init__.py`
+- Create: `engine/sandbox/backends/base.py`
+- Test: `tests/unit/test_cloud_sandbox.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_cloud_sandbox.py
+"""Unit tests for CloudSandbox + the SandboxBackend abstraction (no network)."""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.sandbox.backends.base import SandboxBackend
+from engine.sandbox.backends.fake import FakeBackend
+
+
+def test_fake_backend_satisfies_protocol():
+    assert isinstance(FakeBackend(), SandboxBackend)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/unit/test_cloud_sandbox.py::test_fake_backend_satisfies_protocol -v`
+Expected: FAIL — `ModuleNotFoundError: engine.sandbox.backends`.
+
+- [ ] **Step 3: Create the package + Protocol**
+
+```python
+# engine/sandbox/backends/__init__.py
+"""Pluggable execution backends for CloudSandbox.
+
+CloudSandbox is a thin Sandbox-Protocol client; the backend is the substrate
+that actually runs code (e2b microVM in prod, FakeBackend in tests). Selected by
+AGENTBREEDER_SANDBOX_BACKEND (default 'e2b').
+"""
+
+from __future__ import annotations
+
+import os
+
+from engine.sandbox.backends.base import SandboxBackend
+
+
+def make_backend_from_env() -> SandboxBackend:
+    name = os.environ.get("AGENTBREEDER_SANDBOX_BACKEND", "e2b").strip().lower()
+    if name == "e2b":
+        from engine.sandbox.backends.e2b import E2BBackend
+
+        return E2BBackend()
+    if name == "fake":
+        from engine.sandbox.backends.fake import FakeBackend
+
+        return FakeBackend()
+    raise ValueError(f"unknown AGENTBREEDER_SANDBOX_BACKEND={name!r}")
+```
+
+```python
+# engine/sandbox/backends/base.py
+"""SandboxBackend — the execution substrate behind CloudSandbox.
+
+The backend deals in already-validated, workspace-relative paths; CloudSandbox
+applies path containment + size/timeout caps before delegating here. This split
+keeps the security boundary in one place (cloud.py) and lets us swap e2b for a
+self-hosted Firecracker backend without touching callers.
+"""
+
+from __future__ import annotations
+
+import builtins
+from typing import Protocol, runtime_checkable
+
+from engine.sandbox.base import ExecResult
+
+
+@runtime_checkable
+class SandboxBackend(Protocol):
+    async def start(self) -> None: ...
+    async def write_file(self, path: str, content: str) -> None: ...
+    async def read_file(self, path: str) -> str: ...
+    async def list_files(self, directory: str = ".") -> builtins.list[str]: ...
+    async def run(self, cmd: builtins.list[str], timeout: float) -> ExecResult: ...
+    async def snapshot(self) -> bytes: ...
+    async def destroy(self) -> None: ...
+```
+
+- [ ] **Step 4: Write `FakeBackend` (test double)**
+
+```python
+# engine/sandbox/backends/fake.py
+"""In-memory SandboxBackend for unit tests — no network, no subprocess."""
+
+from __future__ import annotations
+
+import builtins
+import io
+import zipfile
+
+from engine.sandbox.base import ExecResult
+
+
+class FakeBackend:
+    """Records lifecycle; stores files in a dict; run() returns a canned success."""
+
+    def __init__(self) -> None:
+        self.files: dict[str, str] = {}
+        self.started = False
+        self.destroyed = False
+        self.commands: list[list[str]] = []
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def write_file(self, path: str, content: str) -> None:
+        self.files[path] = content
+
+    async def read_file(self, path: str) -> str:
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        return self.files[path]
+
+    async def list_files(self, directory: str = ".") -> builtins.list[str]:
+        prefix = "" if directory in (".", "") else f"{directory.rstrip('/')}/"
+        return sorted(p for p in self.files if p.startswith(prefix))
+
+    async def run(self, cmd: builtins.list[str], timeout: float) -> ExecResult:
+        self.commands.append(cmd)
+        return ExecResult(stdout="", stderr="", exit_code=0)
+
+    async def snapshot(self) -> bytes:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            for path, content in sorted(self.files.items()):
+                zf.writestr(path, content)
+        return buf.getvalue()
+
+    async def destroy(self) -> None:
+        self.destroyed = True
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pytest tests/unit/test_cloud_sandbox.py::test_fake_backend_satisfies_protocol -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add engine/sandbox/backends/ tests/unit/test_cloud_sandbox.py
+git commit -m "feat(builder): SandboxBackend abstraction + FakeBackend (W4 A1)"
+```
+
+---
+
+### Task A2: `CloudSandbox` with path containment + caps
+
+**Files:**
+- Create: `engine/sandbox/cloud.py`
+- Test: `tests/unit/test_cloud_sandbox.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/unit/test_cloud_sandbox.py
+from engine.sandbox.base import Sandbox
+from engine.sandbox.cloud import CloudSandbox, _MAX_FILE_BYTES, _safe_relpath
+
+
+def test_cloud_sandbox_satisfies_protocol():
+    assert isinstance(CloudSandbox(FakeBackend()), Sandbox)
+
+
+@pytest.mark.parametrize("bad", ["/etc/passwd", "../escape", "a/../../b", "\\abs"])
+def test_safe_relpath_rejects_escapes(bad):
+    with pytest.raises(ValueError):
+        _safe_relpath(bad)
+
+
+def test_safe_relpath_normalizes():
+    assert _safe_relpath("./a/b.py") == "a/b.py"
+
+
+@pytest.mark.asyncio
+async def test_cloud_sandbox_write_read_roundtrip_starts_backend():
+    backend = FakeBackend()
+    sb = CloudSandbox(backend)
+    await sb.write("agent.py", "print('hi')")
+    assert backend.started is True
+    assert await sb.read("agent.py") == "print('hi')"
+
+
+@pytest.mark.asyncio
+async def test_cloud_sandbox_write_rejects_oversize():
+    sb = CloudSandbox(FakeBackend())
+    with pytest.raises(ValueError):
+        await sb.write("big.txt", "x" * (_MAX_FILE_BYTES + 1))
+
+
+@pytest.mark.asyncio
+async def test_cloud_sandbox_close_records_elapsed_and_destroys():
+    backend = FakeBackend()
+    sb = CloudSandbox(backend)
+    await sb.write("a.py", "1")  # starts backend
+    await sb.close()
+    assert backend.destroyed is True
+    assert sb.elapsed_seconds >= 0.0
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/unit/test_cloud_sandbox.py -v`
+Expected: FAIL — `ModuleNotFoundError: engine.sandbox.cloud`.
+
+- [ ] **Step 3: Implement `CloudSandbox`**
+
+```python
+# engine/sandbox/cloud.py
+"""CloudSandbox — Sandbox Protocol over a managed microVM backend (Wave 4).
+
+SECURITY (design §11.2): this is the single place client-side guards live —
+path containment + per-file/byte and exec-timeout caps — applied BEFORE the
+backend runs anything. The microVM is defense-in-depth, not a reason to drop
+these checks. No long-lived secrets are placed in the workspace.
+"""
+
+from __future__ import annotations
+
+import builtins
+import time
+from pathlib import PurePosixPath
+
+from engine.sandbox.backends.base import SandboxBackend
+from engine.sandbox.base import ExecResult
+
+_MAX_EXEC_TIMEOUT = 120.0
+_MAX_FILE_BYTES = 1_000_000  # 1 MB per file cap (parity with LocalSandbox)
+
+
+def _safe_relpath(path: str) -> str:
+    """Return a normalized workspace-relative path or raise on escape."""
+    if path.startswith("/") or path.startswith("\\"):
+        raise ValueError(f"absolute paths are not allowed: {path!r}")
+    parts: list[str] = []
+    for part in PurePosixPath(path).parts:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            raise ValueError(f"path escapes the sandbox workspace: {path!r}")
+        parts.append(part)
+    return "/".join(parts)
+
+
+class CloudSandbox:
+    """Sandbox backed by a managed microVM (via a pluggable SandboxBackend)."""
+
+    def __init__(self, backend: SandboxBackend) -> None:
+        self._backend = backend
+        self._started = False
+        self._t0: float | None = None
+        self.elapsed_seconds: float = 0.0
+
+    async def _ensure_started(self) -> None:
+        if not self._started:
+            await self._backend.start()
+            self._started = True
+            self._t0 = time.monotonic()
+
+    async def write(self, path: str, content: str) -> None:
+        if len(content.encode("utf-8")) > _MAX_FILE_BYTES:
+            raise ValueError(f"file exceeds {_MAX_FILE_BYTES} byte cap: {path!r}")
+        await self._ensure_started()
+        await self._backend.write_file(_safe_relpath(path), content)
+
+    async def read(self, path: str) -> str:
+        await self._ensure_started()
+        return await self._backend.read_file(_safe_relpath(path))
+
+    async def list(self, directory: str = ".") -> builtins.list[str]:
+        await self._ensure_started()
+        norm = _safe_relpath(directory) if directory not in (".", "") else "."
+        return await self._backend.list_files(norm)
+
+    async def exec(self, cmd: builtins.list[str], timeout: float = 30.0) -> ExecResult:
+        await self._ensure_started()
+        return await self._backend.run(cmd, min(timeout, _MAX_EXEC_TIMEOUT))
+
+    async def snapshot(self) -> bytes:
+        await self._ensure_started()
+        return await self._backend.snapshot()
+
+    async def close(self) -> None:
+        if self._t0 is not None:
+            self.elapsed_seconds = time.monotonic() - self._t0
+        await self._backend.destroy()
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest tests/unit/test_cloud_sandbox.py -v`
+Expected: PASS (all CloudSandbox tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/sandbox/cloud.py tests/unit/test_cloud_sandbox.py
+git commit -m "feat(builder): CloudSandbox with path containment + caps (W4 A2)"
+```
+
+---
+
+### Task A3: `E2BBackend` (e2b async SDK)
+
+> **Verify first:** e2b's async SDK surface changes across versions. Before writing, run
+> `python -c "import e2b; help(e2b)"` (after install) and confirm the async class name and the
+> `files.write/read/list`, `commands.run`, and `kill` method names. Adjust the calls below to match
+> the installed version. This backend is **not** unit-tested (it hits e2b) — it is covered by the
+> gated integration test in Step 4 and by Part D's live path.
+
+**Files:**
+- Create: `engine/sandbox/backends/e2b.py`
+- Modify: `pyproject.toml` (add optional dep)
+- Test: `tests/integration/test_e2b_backend.py` (gated)
+
+- [ ] **Step 1: Add the optional dependency**
+
+Add to `pyproject.toml` under `[project.optional-dependencies]` (create the `cloud` extra if absent):
+
+```toml
+cloud = [
+  "e2b>=1.0,<2.0",
+]
+```
+
+Run: `pip install -e ".[cloud]"`
+Expected: e2b installs.
+
+- [ ] **Step 2: Write the gated integration test**
+
+```python
+# tests/integration/test_e2b_backend.py
+"""Gated integration test for E2BBackend. Skipped unless E2B_API_KEY is set."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+_KEY = os.environ.get("E2B_API_KEY")
+pytestmark = pytest.mark.skipif(not _KEY, reason="E2B_API_KEY not set")
+
+
+@pytest.mark.asyncio
+async def test_e2b_write_read_exec_roundtrip():
+    from engine.sandbox.backends.e2b import E2BBackend
+
+    backend = E2BBackend()
+    try:
+        await backend.start()
+        await backend.write_file("hello.txt", "world")
+        assert await backend.read_file("hello.txt") == "world"
+        res = await backend.run(["echo", "ok"], timeout=30.0)
+        assert res.exit_code == 0
+    finally:
+        await backend.destroy()
+```
+
+- [ ] **Step 3: Implement `E2BBackend`**
+
+```python
+# engine/sandbox/backends/e2b.py
+"""E2BBackend — managed Firecracker microVM via the e2b async SDK (Wave 4).
+
+SECURITY (design §11.2): no long-lived secrets are injected; egress is a
+default-deny allowlist (LLM endpoints + PyPI + npm) configured on the e2b
+template; CPU/mem/wall-clock caps come from the template + per-call timeouts.
+e2b is a third-party sub-processor — requires a signed DPA + privacy-policy
+disclosure before GA (see design §11.2 / Open Q #1).
+"""
+
+from __future__ import annotations
+
+import builtins
+import io
+import os
+import zipfile
+
+from engine.sandbox.base import ExecResult
+
+# Workspace root inside the microVM.
+_WORKDIR = "/home/user/project"
+_TEMPLATE = os.environ.get("AGENTBREEDER_E2B_TEMPLATE", "base")
+
+
+class E2BBackend:
+    """Thin adapter over e2b's AsyncSandbox. One microVM per builder session."""
+
+    def __init__(self) -> None:
+        self._sbx = None  # type: ignore[var-annotated]
+
+    async def start(self) -> None:
+        from e2b import AsyncSandbox  # imported lazily so the dep stays optional
+
+        # NB: verify kwargs against the installed e2b version (see Task A3 note).
+        self._sbx = await AsyncSandbox.create(template=_TEMPLATE)
+        await self._sbx.files.make_dir(_WORKDIR)
+
+    def _abs(self, path: str) -> str:
+        return f"{_WORKDIR}/{path}"
+
+    async def write_file(self, path: str, content: str) -> None:
+        await self._sbx.files.write(self._abs(path), content)
+
+    async def read_file(self, path: str) -> str:
+        return await self._sbx.files.read(self._abs(path))
+
+    async def list_files(self, directory: str = ".") -> builtins.list[str]:
+        base = _WORKDIR if directory in (".", "") else self._abs(directory)
+        entries = await self._sbx.files.list(base)
+        # Return workspace-relative file paths only.
+        out: list[str] = []
+        for e in entries:
+            full = getattr(e, "path", str(e))
+            if getattr(e, "is_dir", False):
+                continue
+            out.append(full.removeprefix(f"{_WORKDIR}/"))
+        return sorted(out)
+
+    async def run(self, cmd: builtins.list[str], timeout: float) -> ExecResult:
+        import shlex
+
+        joined = " ".join(shlex.quote(c) for c in cmd)
+        try:
+            res = await self._sbx.commands.run(
+                joined, cwd=_WORKDIR, timeout=int(timeout)
+            )
+        except Exception as exc:  # e2b raises on non-zero/timeout in some versions
+            return ExecResult(stdout="", stderr=str(exc), exit_code=1)
+        return ExecResult(
+            stdout=getattr(res, "stdout", "") or "",
+            stderr=getattr(res, "stderr", "") or "",
+            exit_code=int(getattr(res, "exit_code", 0) or 0),
+        )
+
+    async def snapshot(self) -> bytes:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            for rel in await self.list_files("."):
+                zf.writestr(rel, await self.read_file(rel))
+        return buf.getvalue()
+
+    async def destroy(self) -> None:
+        if self._sbx is not None:
+            await self._sbx.kill()
+            self._sbx = None
+```
+
+- [ ] **Step 4: Run the gated test (skips without a key)**
+
+Run: `pytest tests/integration/test_e2b_backend.py -v`
+Expected: SKIPPED (no `E2B_API_KEY`). With a key set: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add engine/sandbox/backends/e2b.py tests/integration/test_e2b_backend.py pyproject.toml
+git commit -m "feat(builder): E2BBackend microVM adapter + gated test (W4 A3)"
+```
+
+---
+
+### Task A4: Flip `_make_sandbox` + emit `sandbox_seconds`/`code`
+
+**Files:**
+- Modify: `api/services/builder_session_service.py:25-43` and `:132-167`
+- Test: `tests/unit/test_builder_session_service_sandbox.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/test_builder_session_service_sandbox.py
+"""_make_sandbox selection + eject frame contract (W4)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from api.services import builder_session_service as svc
+from engine.sandbox.cloud import CloudSandbox
+from engine.sandbox.local import LocalSandbox
+
+
+def test_make_sandbox_local(monkeypatch):
+    monkeypatch.setenv("AGENTBREEDER_SANDBOX", "local")
+    sb = svc._make_sandbox()
+    assert isinstance(sb, LocalSandbox)
+
+
+def test_make_sandbox_cloud_returns_cloud_sandbox(monkeypatch):
+    monkeypatch.setenv("AGENTBREEDER_SANDBOX", "cloud")
+    monkeypatch.setenv("AGENTBREEDER_SANDBOX_BACKEND", "fake")
+    sb = svc._make_sandbox()
+    assert isinstance(sb, CloudSandbox)
+
+
+def test_make_sandbox_disabled_raises(monkeypatch):
+    monkeypatch.setenv("AGENTBREEDER_SANDBOX", "disabled")
+    with pytest.raises(svc.CloudSandboxUnavailable):
+        svc._make_sandbox()
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/unit/test_builder_session_service_sandbox.py -v`
+Expected: FAIL — cloud branch still raises `CloudSandboxUnavailable`.
+
+- [ ] **Step 3: Update imports + `_make_sandbox`**
+
+In `api/services/builder_session_service.py`, change the imports block (lines 24-26) to add `time`, `CloudSandbox`, the backend factory, and the `Sandbox` type:
+
+```python
+import time
+...
+from engine.sandbox.backends import make_backend_from_env
+from engine.sandbox.base import Sandbox, select_sandbox_mode
+from engine.sandbox.cloud import CloudSandbox
+from engine.sandbox.local import LocalSandbox
+```
+
+Replace `_make_sandbox` (lines 37-43) with:
+
+```python
+def _make_sandbox() -> Sandbox:
+    mode = select_sandbox_mode()
+    if mode == "local":
+        return LocalSandbox()
+    if mode == "cloud":
+        return CloudSandbox(make_backend_from_env())
+    raise CloudSandboxUnavailable("Sandbox is disabled (AGENTBREEDER_SANDBOX=disabled)")
+```
+
+- [ ] **Step 4: Add `sandbox_seconds` + `code` to the eject frames**
+
+In `run_eject` (lines 132-167), capture a start time and enrich the `done`/`error` frames. Replace the loop body's `done`/`error` arms:
+
+```python
+    async def run_eject(self, sess, provider, instruction: str, engine_name: str):
+        """Run the coding agent in a sandbox; stream events; persist files."""
+        sandbox = _make_sandbox()
+        state = dict(sess.state or {})
+        for path, content in (state.get("files") or {}).items():
+            await sandbox.write(path, content)
+        if state.get("agent_yaml"):
+            await sandbox.write("agent.yaml", state["agent_yaml"])
+
+        engine = engine_for(engine_name, provider=provider)
+        t0 = time.monotonic()
+        try:
+            async for evt in engine.run(instruction, state.get("history", []), sandbox):
+                if evt.type == "token":
+                    yield {"event": "token", "data": _json({"text": evt.text})}
+                elif evt.type == "tool_call":
+                    yield {"event": "tool_call", "data": _json({"tool": evt.tool_name})}
+                elif evt.type == "file_change":
+                    try:
+                        content = await sandbox.read(evt.path)
+                    except FileNotFoundError:
+                        content = ""
+                    yield {
+                        "event": "file_change",
+                        "data": _json(
+                            {"path": evt.path, "diff": evt.diff, "content": content}
+                        ),
+                    }
+                elif evt.type == "done":
+                    yield {
+                        "event": "complete",
+                        "data": _json(
+                            {
+                                "summary": evt.text,
+                                "code": "ok",
+                                "sandbox_seconds": round(time.monotonic() - t0, 3),
+                            }
+                        ),
+                    }
+                elif evt.type == "error":
+                    yield {
+                        "event": "error",
+                        "data": _json({"detail": evt.error, "code": "engine_error"}),
+                    }
+            state["files"] = {p: await sandbox.read(p) for p in await sandbox.list(".")}
+            await self.save_state(sess, state)
+            await self._db.commit()
+        finally:
+            await sandbox.close()
+```
+
+- [ ] **Step 5: Add a frame-contract test**
+
+```python
+# append to tests/unit/test_builder_session_service_sandbox.py
+from unittest.mock import AsyncMock, MagicMock
+
+from engine.coding_agent.base import AgentEvent
+
+
+class _FakeEngine:
+    name = "claude"
+
+    async def run(self, instruction, history, sandbox, bounds=None):
+        yield AgentEvent(type="done", text="built it")
+
+
+@pytest.mark.asyncio
+async def test_eject_complete_frame_has_code_and_sandbox_seconds(monkeypatch):
+    monkeypatch.setenv("AGENTBREEDER_SANDBOX", "cloud")
+    monkeypatch.setenv("AGENTBREEDER_SANDBOX_BACKEND", "fake")
+    monkeypatch.setattr(svc, "engine_for", lambda name, provider: _FakeEngine())
+
+    db = AsyncMock()
+    service = svc.BuilderSessionService(db, svc.SessionEventBus())
+    sess = MagicMock()
+    sess.state = {"history": [], "files": {}, "agent_yaml": None}
+
+    frames = [f async for f in service.run_eject(sess, provider=None,
+                                                 instruction="x", engine_name="claude")]
+    complete = [f for f in frames if f["event"] == "complete"][0]
+    payload = json.loads(complete["data"])
+    assert payload["code"] == "ok"
+    assert "sandbox_seconds" in payload and payload["sandbox_seconds"] >= 0.0
+```
+
+- [ ] **Step 6: Run all Part A tests**
+
+Run: `pytest tests/unit/test_cloud_sandbox.py tests/unit/test_builder_session_service_sandbox.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/services/builder_session_service.py tests/unit/test_builder_session_service_sandbox.py
+git commit -m "feat(builder): enable cloud sandbox + emit sandbox_seconds/code frames (W4 A4)"
+```
+
+---
+
+# Part B — Cloud sandbox-minutes metering (`agentbreeder-cloud`)
+
+> All paths in Part B are under `/Users/rajit/personal-github/agentbreeder-cloud`. Commit in that repo.
+
+### Task B1: Quota scope enum + minute limits + migration
+
+**Files:**
+- Modify: `api/models/tenancy.py:41-43`
+- Modify: `api/config.py`
+- Create: `alembic/versions/<next>_add_sandbox_minute_scopes.py`
+- Test: `tests/test_quota_sandbox_minutes.py`
+
+- [ ] **Step 1: Add enum values**
+
+In `api/models/tenancy.py`, extend `QuotaScopeEnum` (lines 41-43):
+
+```python
+class QuotaScopeEnum(enum.StrEnum):
+    user = "user"
+    tenant = "tenant"
+    user_sandbox_minutes = "user_sandbox_minutes"
+    tenant_sandbox_minutes = "tenant_sandbox_minutes"
+```
+
+- [ ] **Step 2: Add config limits**
+
+In `api/config.py`, next to `user_daily_free_limit` / `tenant_daily_free_limit` (lines 19-20), add:
+
+```python
+    user_daily_sandbox_minutes_limit: int = 30
+    tenant_daily_sandbox_minutes_limit: int = 30
+```
+
+- [ ] **Step 3: Create the migration (ALTER enum — additive)**
+
+> Find the current head: `alembic heads`. Use that as `down_revision`. Postgres `ADD VALUE` cannot
+> run inside a transaction, so set `op.execute` with autocommit per the snippet.
+
+```python
+# alembic/versions/<next>_add_sandbox_minute_scopes.py
+"""Add sandbox-minute scopes to quota_scope_enum (W4).
+
+Revision ID: <next>
+Revises: <current_head>
+Create Date: 2026-06-14
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "<next>"
+down_revision: str | None = "<current_head>"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_NEW = ("user_sandbox_minutes", "tenant_sandbox_minutes")
+
+
+def upgrade() -> None:
+    # ADD VALUE must run outside a transaction block.
+    with op.get_context().autocommit_block():
+        for value in _NEW:
+            op.execute(f"ALTER TYPE quota_scope_enum ADD VALUE IF NOT EXISTS '{value}'")
+
+
+def downgrade() -> None:
+    # Postgres cannot drop enum values; downgrade is a no-op (additive-only).
+    pass
+```
+
+- [ ] **Step 4: Commit (schema)**
+
+```bash
+git add api/models/tenancy.py api/config.py alembic/versions/
+git commit -m "feat(cloud): sandbox-minute quota scopes + limits + migration (W4 B1)"
+```
+
+---
+
+### Task B2: Quota service — amount, peek, charge
+
+**Files:**
+- Modify: `api/services/quota.py`
+- Test: `tests/test_quota_sandbox_minutes.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_quota_sandbox_minutes.py
+"""Sandbox-minute metering: increment-by-N, peek, charge + 429 path."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from api.services import quota
+
+
+@pytest.mark.asyncio
+async def test_charge_sandbox_minutes_over_limit_raises(db_session):
+    uid, tid = uuid.uuid4(), uuid.uuid4()
+    # 31 minutes against a 30/day limit → QuotaExceeded on user scope.
+    with pytest.raises(quota.QuotaExceeded) as ei:
+        await quota.charge_sandbox_minutes(
+            db_session, user_id=uid, tenant_id=tid, minutes=31,
+            user_limit=30, tenant_limit=30,
+        )
+    assert ei.value.scope == "user_sandbox_minutes"
+
+
+@pytest.mark.asyncio
+async def test_peek_count_zero_before_any_charge(db_session):
+    uid = uuid.uuid4()
+    assert await quota.peek_count(db_session, scope="user_sandbox_minutes", scope_id=uid) == 0
+```
+
+> Uses the cloud repo's existing `db_session` fixture (ephemeral Postgres — see other tests in
+> `tests/`). If absent, mirror the session fixture from `tests/test_builder_sessions.py`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `venv/bin/pytest tests/test_quota_sandbox_minutes.py -v`
+Expected: FAIL — `charge_sandbox_minutes`/`peek_count` undefined.
+
+- [ ] **Step 3: Extend `quota.py`**
+
+Add an `amount` param to `_increment_one`, and add `peek_count` + `charge_sandbox_minutes`:
+
+```python
+async def _increment_one(
+    session: AsyncSession,
+    *,
+    scope: str,
+    scope_id: uuid.UUID,
+    amount: int = 1,
+) -> int:
+    sql = text(
+        """
+        INSERT INTO quota_counters (id, scope, scope_id, day, count)
+        VALUES (gen_random_uuid(), :scope, :scope_id, CURRENT_DATE, :amount)
+        ON CONFLICT (scope, scope_id, day)
+        DO UPDATE SET count = quota_counters.count + :amount
+        RETURNING count
+        """
+    )
+    res = await session.execute(
+        sql, {"scope": scope, "scope_id": scope_id, "amount": amount}
+    )
+    return int(res.scalar_one())
+
+
+async def peek_count(
+    session: AsyncSession, *, scope: str, scope_id: uuid.UUID
+) -> int:
+    """Current day's count for a scope without incrementing (for pre-checks)."""
+    sql = text(
+        """
+        SELECT count FROM quota_counters
+        WHERE scope = :scope AND scope_id = :scope_id AND day = CURRENT_DATE
+        """
+    )
+    res = await session.execute(sql, {"scope": scope, "scope_id": scope_id})
+    row = res.scalar_one_or_none()
+    return int(row) if row is not None else 0
+
+
+async def charge_sandbox_minutes(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    tenant_id: uuid.UUID,
+    minutes: int,
+    user_limit: int,
+    tenant_limit: int,
+) -> QuotaResult:
+    """Add `minutes` to the per-day user+tenant sandbox-minute counters; raise if over."""
+    user_count = await _increment_one(
+        session, scope="user_sandbox_minutes", scope_id=user_id, amount=minutes
+    )
+    tenant_count = await _increment_one(
+        session, scope="tenant_sandbox_minutes", scope_id=tenant_id, amount=minutes
+    )
+    if user_count > user_limit:
+        raise QuotaExceeded("user_sandbox_minutes", user_limit)
+    if tenant_count > tenant_limit:
+        raise QuotaExceeded("tenant_sandbox_minutes", tenant_limit)
+    return QuotaResult(user_count=user_count, tenant_count=tenant_count)
+```
+
+Keep the existing `increment_and_check` unchanged (turn metering still uses post-increment-by-1).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `venv/bin/pytest tests/test_quota_sandbox_minutes.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/services/quota.py tests/test_quota_sandbox_minutes.py
+git commit -m "feat(cloud): quota peek + charge_sandbox_minutes (increment-by-N) (W4 B2)"
+```
+
+---
+
+### Task B3: Eject route — pre-check + sniff + charge
+
+**Files:**
+- Modify: `api/routes/builder_sessions.py` (imports, `eject_session`, add helpers)
+- Test: `tests/test_builder_sessions_metering.py`
+
+- [ ] **Step 1: Write the failing test (respx + ASGITransport, per E1 pattern)**
+
+```python
+# tests/test_builder_sessions_metering.py
+"""Eject sandbox-minute metering: pre-check 429 + post-stream charge."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from api.routes import builder_sessions as bs
+
+
+def test_extract_sandbox_seconds_from_complete_frame():
+    frame = 'event: complete\ndata: {"summary": "done", "code": "ok", "sandbox_seconds": 95.4}'
+    assert bs._extract_sandbox_seconds(frame) == 95.4
+
+
+def test_extract_sandbox_seconds_ignores_non_complete():
+    assert bs._extract_sandbox_seconds('event: token\ndata: {"text": "hi"}') is None
+
+
+def test_minutes_rounds_up():
+    assert math.ceil(95.4 / 60) == 2
+```
+
+> A full SSE-relay metering test (respx mock of the OSS upstream + asserting a 2-minute charge on
+> the cloud DB) should mirror `tests/test_builder_sessions.py`'s respx + ASGITransport setup. Add it
+> after the unit helpers pass.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `venv/bin/pytest tests/test_builder_sessions_metering.py -v`
+Expected: FAIL — `_extract_sandbox_seconds` undefined.
+
+- [ ] **Step 3: Add the frame parser + minute-charge helpers**
+
+In `api/routes/builder_sessions.py`, add imports and helpers:
+
+```python
+import json
+import math
+import uuid as _uuid
+
+from api.db import get_sessionmaker  # verify export name; see Step 3 note
+from api.services.quota import (
+    QuotaExceeded,
+    charge_sandbox_minutes,
+    increment_and_check,
+    peek_count,
+)
+```
+
+> **Verify:** confirm how a fresh session is obtained outside a request (the post-stream charge runs
+> after the request session may have closed). Grep `api/db.py` for the sessionmaker/`async_session`
+> export and use it in `_charge_after_stream`. If only `get_session` (a generator dep) exists, add a
+> thin `get_sessionmaker()` returning the `async_sessionmaker`.
+
+```python
+def _extract_sandbox_seconds(frame: str) -> float | None:
+    """Return sandbox_seconds from an SSE 'complete' frame, else None."""
+    if "event: complete" not in frame:
+        return None
+    for line in frame.splitlines():
+        if line.startswith("data:"):
+            try:
+                payload = json.loads(line[len("data:"):].strip())
+            except json.JSONDecodeError:
+                return None
+            val = payload.get("sandbox_seconds")
+            return float(val) if val is not None else None
+    return None
+
+
+async def _sandbox_minutes_precheck(db: AsyncSession, user: CloudUser, tenant: Tenant) -> None:
+    """429 before opening the stream if the daily sandbox-minute cap is already met."""
+    s = get_settings()
+    user_used = await peek_count(db, scope="user_sandbox_minutes", scope_id=user.id)
+    tenant_used = await peek_count(db, scope="tenant_sandbox_minutes", scope_id=tenant.id)
+    if user_used >= s.user_daily_sandbox_minutes_limit:
+        raise HTTPException(
+            status_code=429,
+            detail=f"user_sandbox_minutes daily quota exceeded "
+            f"(limit={s.user_daily_sandbox_minutes_limit})",
+        )
+    if tenant_used >= s.tenant_daily_sandbox_minutes_limit:
+        raise HTTPException(
+            status_code=429,
+            detail=f"tenant_sandbox_minutes daily quota exceeded "
+            f"(limit={s.tenant_daily_sandbox_minutes_limit})",
+        )
+
+
+async def _charge_after_stream(user_id: _uuid.UUID, tenant_id: _uuid.UUID, seconds: float) -> None:
+    """Charge ceil(minutes) on a fresh session once the stream has fully relayed.
+
+    NB(W4): idempotency across network retries is deferred — each completed eject genuinely
+    consumes minutes. A retry-keyed idempotency store is a documented follow-up (design §11.2).
+    """
+    if seconds <= 0:
+        return
+    minutes = math.ceil(seconds / 60)
+    s = get_settings()
+    maker = get_sessionmaker()
+    async with maker() as db:
+        try:
+            await charge_sandbox_minutes(
+                db, user_id=user_id, tenant_id=tenant_id, minutes=minutes,
+                user_limit=s.user_daily_sandbox_minutes_limit,
+                tenant_limit=s.tenant_daily_sandbox_minutes_limit,
+            )
+            await db.commit()
+        except QuotaExceeded:
+            # Over-cap on the trailing charge: the work already ran; record the overage and move on.
+            await db.commit()
+```
+
+- [ ] **Step 4: Rewrite `eject_session` to pre-check, relay-with-sniff, then charge**
+
+Replace `eject_session` (lines 175-188) with a custom streaming relay (the generic `_forward_stream`
+can't sniff frames):
+
+```python
+@router.post("/{session_id}/eject")
+async def eject_session(
+    session_id: str,
+    body: dict[str, Any],
+    user: CloudUser = Depends(require_user),
+    tenant: Tenant = Depends(require_tenant),
+    db: AsyncSession = Depends(get_session),
+) -> StreamingResponse:
+    """Eject to code (SSE). Metered: one turn unit + actual sandbox-minutes."""
+    await _meter_turn(db, user, tenant)
+    await _sandbox_minutes_precheck(db, user, tenant)
+
+    s = get_settings()
+    url = f"{s.agentbreeder_api_url.rstrip('/')}/api/v1/builder/sessions/{session_id}/eject"
+    user_id, tenant_id = user.id, tenant.id
+
+    async def gen() -> AsyncIterator[bytes]:
+        buffer = ""
+        seconds = 0.0
+        async with (
+            httpx.AsyncClient(timeout=None) as client,
+            client.stream("POST", url, json=body, headers=_auth_headers()) as upstream,
+        ):
+            async for chunk in upstream.aiter_raw():
+                yield chunk
+                buffer += chunk.decode("utf-8", "replace")
+                while "\n\n" in buffer:
+                    frame, buffer = buffer.split("\n\n", 1)
+                    found = _extract_sandbox_seconds(frame)
+                    if found is not None:
+                        seconds = found
+        await _charge_after_stream(user_id, tenant_id, seconds)
+
+    return StreamingResponse(gen(), media_type="text/event-stream")
+```
+
+- [ ] **Step 5: Run Part B tests + lint**
+
+Run: `venv/bin/pytest tests/test_builder_sessions_metering.py tests/test_quota_sandbox_minutes.py -v && ruff check api/`
+Expected: PASS, no lint errors (combine nested `async with` per SIM117 — already done above).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/routes/builder_sessions.py tests/test_builder_sessions_metering.py
+git commit -m "feat(cloud): meter eject sandbox-minutes (pre-check + sniff + charge) (W4 B3)"
+```
+
+---
+
+# Part C — Analytics funnel (OSS + dashboard)
+
+> Backend paths under `agentbreeder` (this repo). The view reuses the house CSS-bar idiom — **no new
+> chart dependency** (design §11.3). Events are PII-free + structural-only (design §11.2/§11.4).
+
+### Task C1: `AnalyticsEvent` model + migration
+
+**Files:**
+- Modify: `api/models/database.py`
+- Create: `alembic/versions/025_add_analytics_events.py`
+- Test: `tests/unit/test_analytics_model.py`
+
+- [ ] **Step 1: Add the model**
+
+Append to `api/models/database.py`:
+
+```python
+class AnalyticsEvent(Base):
+    """Structural product-analytics event (W4). PII-free: no message/prompt bodies."""
+
+    __tablename__ = "analytics_events"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    event: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    engine: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    team: Mapped[str | None] = mapped_column(String(100), nullable=True, index=True)
+    session_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    props: Mapped[dict[str, Any]] = mapped_column(JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), index=True
+    )
+```
+
+- [ ] **Step 2: Create the migration**
+
+```python
+# alembic/versions/025_add_analytics_events.py
+"""Add analytics_events table (W4 funnel).
+
+Revision ID: 025
+Revises: 024
+Create Date: 2026-06-14
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+revision: str = "025"
+down_revision: str | None = "024"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "analytics_events",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("event", sa.String(64), nullable=False),
+        sa.Column("engine", sa.String(20), nullable=True),
+        sa.Column("team", sa.String(100), nullable=True),
+        sa.Column("session_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("props", sa.JSON(), server_default="{}"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    op.create_index("ix_analytics_events_event", "analytics_events", ["event"])
+    op.create_index("ix_analytics_events_team", "analytics_events", ["team"])
+    op.create_index("ix_analytics_events_created_at", "analytics_events", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_table("analytics_events")
+```
+
+- [ ] **Step 3: Test the model imports + apply migration**
+
+```python
+# tests/unit/test_analytics_model.py
+from api.models.database import AnalyticsEvent
+
+
+def test_analytics_event_table_name():
+    assert AnalyticsEvent.__tablename__ == "analytics_events"
+```
+
+Run: `pytest tests/unit/test_analytics_model.py -v && alembic upgrade head`
+Expected: PASS; migration applies cleanly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/models/database.py alembic/versions/025_add_analytics_events.py tests/unit/test_analytics_model.py
+git commit -m "feat(builder): analytics_events table + migration (W4 C1)"
+```
+
+---
+
+### Task C2: Schemas + ingest/funnel routes
+
+**Files:**
+- Modify: `api/models/schemas.py`
+- Create: `api/routes/analytics.py`
+- Modify: `api/main.py` (register)
+- Test: `tests/integration/test_analytics.py`
+
+- [ ] **Step 1: Add schemas**
+
+Append to `api/models/schemas.py`:
+
+```python
+class AnalyticsEventIngest(BaseModel):
+    event: str = Field(..., min_length=1, max_length=64)
+    engine: str | None = None
+    session_id: str | None = None
+    props: dict[str, Any] = Field(default_factory=dict)
+
+
+class FunnelStage(BaseModel):
+    key: str
+    label: str
+    count: int
+    dropoff_pct: float  # vs previous stage; 0.0 for the first
+
+
+class EngineScorecard(BaseModel):
+    engine: str
+    samples: int
+    spec_validity_rate: float
+    deploy_success_rate: float
+    turns_to_spec: float
+    hallucinated_field_rate: float
+
+
+class FunnelMetrics(BaseModel):
+    period: str
+    time_to_first_deploy_p50_s: float | None = None
+    time_to_first_deploy_p90_s: float | None = None
+    stages: list[FunnelStage] = Field(default_factory=list)
+    engines: list[EngineScorecard] = Field(default_factory=list)
+```
+
+- [ ] **Step 2: Write the failing integration test**
+
+```python
+# tests/integration/test_analytics.py
+"""Analytics ingest + funnel aggregation."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture
+def _override_db():
+    from api.database import get_db
+    app.dependency_overrides[get_db] = lambda: AsyncMock()
+    yield
+    app.dependency_overrides.pop(get_db, None)
+
+
+def test_ingest_rejects_unknown_event(client, _override_db):
+    r = client.post("/api/v1/analytics/events",
+                    json={"event": "x" * 100})  # too long
+    assert r.status_code == 422
+
+
+def test_funnel_requires_auth(client):
+    r = client.get("/api/v1/analytics/funnel?period=7d")
+    assert r.status_code in (401, 403)
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `pytest tests/integration/test_analytics.py -v`
+Expected: FAIL — route not registered (404).
+
+- [ ] **Step 4: Implement the route**
+
+```python
+# api/routes/analytics.py
+"""/api/v1/analytics/* — product funnel ingest + aggregation (W4).
+
+PII rule (design §11.2): events are structural only. The ingest endpoint stores
+event/engine/team/session_id/props; callers must never send message or prompt
+bodies. A retention job (TTL) prunes old rows (see ops runbook).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.auth import get_current_user
+from api.database import get_db
+from api.models.database import AnalyticsEvent, User
+from api.models.schemas import (
+    AnalyticsEventIngest,
+    ApiResponse,
+    FunnelMetrics,
+    FunnelStage,
+)
+
+router = APIRouter(prefix="/api/v1", tags=["analytics"])
+
+# Macro-stages shown in the headline funnel (design §11.4 — collapse the 11 raw events).
+_FUNNEL: list[tuple[str, str]] = [
+    ("builder_session_started", "Converse"),
+    ("spec_validated", "Spec validated"),
+    ("eject_to_code_started", "Eject"),
+    ("deploy_started", "Deploy"),
+    ("deploy_succeeded", "Live"),
+]
+
+_PERIODS = {"7d": 7, "30d": 30, "all": 3650}
+
+
+@router.post("/analytics/events", status_code=201)
+async def ingest_event(
+    body: AnalyticsEventIngest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ApiResponse[dict]:
+    row = AnalyticsEvent(
+        event=body.event,
+        engine=body.engine,
+        team=getattr(user, "team", None),
+        session_id=uuid.UUID(body.session_id) if body.session_id else None,
+        props=body.props or {},
+    )
+    db.add(row)
+    await db.commit()
+    return ApiResponse(data={"id": str(row.id)})
+
+
+@router.get("/analytics/funnel")
+async def get_funnel(
+    period: str = Query("7d"),
+    _user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ApiResponse[FunnelMetrics]:
+    days = _PERIODS.get(period, 7)
+    since = datetime.now(timezone.utc) - timedelta(days=days)
+
+    counts: dict[str, int] = {}
+    for key, _label in _FUNNEL:
+        res = await db.execute(
+            select(func.count())
+            .select_from(AnalyticsEvent)
+            .where(AnalyticsEvent.event == key, AnalyticsEvent.created_at >= since)
+        )
+        counts[key] = int(res.scalar_one())
+
+    stages: list[FunnelStage] = []
+    prev: int | None = None
+    for key, label in _FUNNEL:
+        c = counts[key]
+        dropoff = 0.0 if prev in (None, 0) else round((1 - c / prev) * 100, 1)
+        stages.append(FunnelStage(key=key, label=label, count=c, dropoff_pct=dropoff))
+        prev = c
+
+    metrics = FunnelMetrics(period=period, stages=stages, engines=[])
+    return ApiResponse(data=metrics)
+```
+
+> Per-engine scorecards + p50/p90 time-to-first-deploy are computed in Task C3 (they need a join
+> across `eval_runs` / timing props); C2 ships the funnel stages so the view has data immediately.
+
+- [ ] **Step 5: Register the router**
+
+In `api/main.py`, add `analytics` to the routes import and add near the other `include_router` calls (around line 233):
+
+```python
+app.include_router(analytics.router)
+```
+
+- [ ] **Step 6: Run to verify it passes**
+
+Run: `pytest tests/integration/test_analytics.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/models/schemas.py api/routes/analytics.py api/main.py tests/integration/test_analytics.py
+git commit -m "feat(builder): analytics ingest + funnel endpoint (W4 C2)"
+```
+
+---
+
+### Task C3: Per-engine scorecards + p50/p90
+
+**Files:**
+- Modify: `api/routes/analytics.py` (`get_funnel`)
+- Test: `tests/unit/test_funnel_metrics.py`
+
+- [ ] **Step 1: Write the failing test (pure helper)**
+
+```python
+# tests/unit/test_funnel_metrics.py
+from api.routes.analytics import _percentile, _scorecard_from_rows
+
+
+def test_percentile_p50_p90():
+    data = [10.0, 20.0, 30.0, 40.0, 50.0]
+    assert _percentile(data, 50) == 30.0
+    assert _percentile(data, 90) == 50.0
+
+
+def test_percentile_empty_is_none():
+    assert _percentile([], 50) is None
+
+
+def test_scorecard_rates():
+    # 4 sessions: 3 valid specs, 2 deploy successes, avg 5 turns, 1 hallucination
+    sc = _scorecard_from_rows(
+        engine="claude", samples=4, valid=3, deployed=2, total_turns=20, hallucinated=1
+    )
+    assert sc.spec_validity_rate == 0.75
+    assert sc.deploy_success_rate == 0.5
+    assert sc.turns_to_spec == 5.0
+    assert sc.hallucinated_field_rate == 0.25
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/unit/test_funnel_metrics.py -v`
+Expected: FAIL — helpers undefined.
+
+- [ ] **Step 3: Add the helpers + wire into `get_funnel`**
+
+Add to `api/routes/analytics.py`:
+
+```python
+from api.models.schemas import EngineScorecard
+
+
+def _percentile(values: list[float], pct: int) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    k = (len(ordered) - 1) * (pct / 100)
+    lo = int(k)
+    hi = min(lo + 1, len(ordered) - 1)
+    if lo == hi:
+        return ordered[lo]
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * (k - lo)
+
+
+def _scorecard_from_rows(
+    *, engine: str, samples: int, valid: int, deployed: int,
+    total_turns: int, hallucinated: int,
+) -> EngineScorecard:
+    rate = lambda n: round(n / samples, 4) if samples else 0.0  # noqa: E731
+    return EngineScorecard(
+        engine=engine,
+        samples=samples,
+        spec_validity_rate=rate(valid),
+        deploy_success_rate=rate(deployed),
+        turns_to_spec=round(total_turns / samples, 2) if samples else 0.0,
+        hallucinated_field_rate=rate(hallucinated),
+    )
+```
+
+Then in `get_funnel`, replace `engines=[]` by aggregating `coding_agent_turn` counts + `deploy_succeeded`
+per `engine`, and compute p50/p90 from any `deploy_succeeded` events carrying a
+`props["time_to_deploy_s"]`. Minimal wiring:
+
+```python
+    # p50/p90 time-to-first-deploy from deploy_succeeded props
+    res = await db.execute(
+        select(AnalyticsEvent.props).where(
+            AnalyticsEvent.event == "deploy_succeeded",
+            AnalyticsEvent.created_at >= since,
+        )
+    )
+    times = [
+        float(p["time_to_deploy_s"])
+        for (p,) in res.all()
+        if isinstance(p, dict) and p.get("time_to_deploy_s") is not None
+    ]
+    metrics = FunnelMetrics(
+        period=period,
+        stages=stages,
+        engines=[],  # full per-engine joins are a follow-on; helpers above are unit-covered
+        time_to_first_deploy_p50_s=_percentile(times, 50),
+        time_to_first_deploy_p90_s=_percentile(times, 90),
+    )
+    return ApiResponse(data=metrics)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest tests/unit/test_funnel_metrics.py tests/integration/test_analytics.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/routes/analytics.py tests/unit/test_funnel_metrics.py
+git commit -m "feat(builder): funnel p50/p90 + engine scorecard helpers (W4 C3)"
+```
+
+---
+
+### Task C4: Frontend — analytics seam + api client
+
+**Files:**
+- Modify: `dashboard/src/lib/analytics.ts`
+- Modify: `dashboard/src/lib/api.ts`
+- Modify: `dashboard/src/components/agent-wizard/ChatBuildPanel.tsx:598`
+- Test: `dashboard/src/lib/analytics.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// dashboard/src/lib/analytics.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { track, ANALYTICS_EVENTS } from "./analytics";
+
+describe("analytics seam", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
+  });
+
+  it("includes the full funnel taxonomy", () => {
+    expect(ANALYTICS_EVENTS).toContain("builder_session_started");
+    expect(ANALYTICS_EVENTS).toContain("first_invoke");
+  });
+
+  it("POSTs the event to the ingest endpoint", () => {
+    track("eject_to_code_started", { engine: "codex" });
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/analytics/events"),
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd dashboard && npx vitest run src/lib/analytics.test.ts`
+Expected: FAIL — `ANALYTICS_EVENTS` not exported; no fetch.
+
+- [ ] **Step 3: Expand `analytics.ts` (network ingest, PII-free)**
+
+```typescript
+// dashboard/src/lib/analytics.ts
+/** Product funnel analytics (W4). track() POSTs a structural, PII-free event to the
+ *  ingest endpoint and also dispatches a CustomEvent for any in-page listener.
+ *  NEVER pass message/prompt bodies in props (design §11.2). */
+import { ingestAnalytics } from "@/lib/api";
+
+export const ANALYTICS_EVENTS = [
+  "builder_session_started",
+  "user_message_sent",
+  "stack_recommended",
+  "setup_card_shown",
+  "setup_card_completed",
+  "spec_validated",
+  "eject_to_code_started",
+  "coding_agent_turn",
+  "deploy_started",
+  "deploy_succeeded",
+  "deploy_failed",
+  "first_invoke",
+] as const;
+
+export type AnalyticsEvent = (typeof ANALYTICS_EVENTS)[number];
+
+export function track(event: AnalyticsEvent, props: Record<string, unknown> = {}): void {
+  // Fire-and-forget network ingest (never block UI; swallow failures).
+  void ingestAnalytics(event, props).catch(() => {});
+  if (typeof window !== "undefined" && typeof window.dispatchEvent === "function") {
+    window.dispatchEvent(new CustomEvent("agentbreeder:analytics", { detail: { event, props } }));
+  }
+}
+```
+
+- [ ] **Step 4: Add `api.analytics` + `ingestAnalytics` to `api.ts`**
+
+Add the funnel types near the other types, the `ingestAnalytics` export, and the `analytics`
+namespace inside the `api` object (mirror `builderSessions`):
+
+```typescript
+// types
+export interface FunnelStage { key: string; label: string; count: number; dropoff_pct: number; }
+export interface EngineScorecard {
+  engine: string; samples: number; spec_validity_rate: number;
+  deploy_success_rate: number; turns_to_spec: number; hallucinated_field_rate: number;
+}
+export interface FunnelMetrics {
+  period: string;
+  time_to_first_deploy_p50_s: number | null;
+  time_to_first_deploy_p90_s: number | null;
+  stages: FunnelStage[];
+  engines: EngineScorecard[];
+}
+
+// standalone helper (used by analytics.ts to avoid a circular import on the `api` object)
+export function ingestAnalytics(event: string, props: Record<string, unknown>): Promise<unknown> {
+  return request("/analytics/events", {
+    method: "POST",
+    body: JSON.stringify({ event, engine: props.engine ?? null, props }),
+  });
+}
+
+// inside the `api` object:
+analytics: {
+  funnel: (period: string) => request<FunnelMetrics>(`/analytics/funnel?period=${period}`),
+},
+```
+
+- [ ] **Step 5: Fix the hardcoded engine prop**
+
+In `dashboard/src/components/agent-wizard/ChatBuildPanel.tsx:598`, change
+`track("eject_to_code_started", { engine: "claude" })` to use the active engine
+(the panel already has the session's engine in scope — use that variable, e.g. `session.engine`):
+
+```typescript
+track("eject_to_code_started", { engine: session.engine });
+```
+
+- [ ] **Step 6: Run to verify it passes**
+
+Run: `cd dashboard && npx vitest run src/lib/analytics.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add dashboard/src/lib/analytics.ts dashboard/src/lib/api.ts dashboard/src/components/agent-wizard/ChatBuildPanel.tsx dashboard/src/lib/analytics.test.ts
+git commit -m "feat(builder): analytics network ingest + funnel api client (W4 C4)"
+```
+
+---
+
+### Task C5: Frontend — Studio "Builder" view
+
+**Files:**
+- Create: `dashboard/src/pages/builder-insights.tsx`
+- Modify: `dashboard/src/App.tsx`, `dashboard/src/components/shell.tsx`
+- Test: `dashboard/src/pages/builder-insights.test.tsx`
+
+- [ ] **Step 1: Write the failing render test**
+
+```typescript
+// dashboard/src/pages/builder-insights.test.tsx
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import BuilderInsightsPage from "./builder-insights";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    analytics: {
+      funnel: vi.fn().mockResolvedValue({
+        data: {
+          period: "7d",
+          time_to_first_deploy_p50_s: 240,
+          time_to_first_deploy_p90_s: 600,
+          stages: [
+            { key: "builder_session_started", label: "Converse", count: 100, dropoff_pct: 0 },
+            { key: "deploy_succeeded", label: "Live", count: 38, dropoff_pct: 62 },
+          ],
+          engines: [],
+        },
+        meta: {}, errors: [],
+      }),
+    },
+  },
+}));
+
+function wrap(ui: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>;
+}
+
+describe("BuilderInsightsPage", () => {
+  it("renders the funnel heading and a stage label", async () => {
+    render(wrap(<BuilderInsightsPage />));
+    expect(await screen.findByText("Converse")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Builder/i })).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd dashboard && npx vitest run src/pages/builder-insights.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the view (house CSS-bar idiom; a11y per design §11.4)**
+
+```tsx
+// dashboard/src/pages/builder-insights.tsx
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { BarChart3 } from "lucide-react";
+import { api, type FunnelMetrics } from "@/lib/api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
+
+const PERIODS = ["7d", "30d", "all"] as const;
+
+function fmtSeconds(s: number | null): string {
+  if (s == null) return "--";
+  if (s < 90) return `${Math.round(s)}s`;
+  return `${(s / 60).toFixed(1)}m`;
+}
+
+export default function BuilderInsightsPage() {
+  const [period, setPeriod] = useState<(typeof PERIODS)[number]>("7d");
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["builder-funnel", period],
+    queryFn: () => api.analytics.funnel(period),
+  });
+  const metrics: FunnelMetrics | null = data?.data ?? null;
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <h1 className="flex items-center gap-2 font-display text-2xl">
+          <BarChart3 className="h-6 w-6" aria-hidden /> Builder
+        </h1>
+        <Tabs value={period} onValueChange={(v) => setPeriod(v as typeof period)}>
+          <TabsList>
+            {PERIODS.map((p) => (
+              <TabsTrigger key={p} value={p}>{p}</TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      </div>
+
+      {isLoading && (
+        <div className="animate-pulse space-y-4" aria-busy="true">
+          <div className="h-28 rounded-lg border border-border bg-card" />
+          <div className="h-72 rounded-lg border border-border bg-card" />
+        </div>
+      )}
+
+      {error && (
+        <div className="text-sm text-destructive">
+          Failed to load builder analytics: {(error as Error).message}
+        </div>
+      )}
+
+      {metrics && (
+        <>
+          {/* North-star band */}
+          <Card>
+            <CardHeader><CardTitle>Time to first deployed agent</CardTitle></CardHeader>
+            <CardContent className="flex items-end gap-8">
+              <div>
+                <div className="text-xs text-muted-foreground">p50</div>
+                <div className="text-4xl font-semibold tabular-nums">
+                  {fmtSeconds(metrics.time_to_first_deploy_p50_s)}
+                </div>
+              </div>
+              <div>
+                <div className="text-xs text-muted-foreground">p90</div>
+                <div className="text-2xl font-medium tabular-nums text-muted-foreground">
+                  {fmtSeconds(metrics.time_to_first_deploy_p90_s)}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Funnel ribbon — semantic list, value labels always visible (a11y §11.4) */}
+          <Card>
+            <CardHeader><CardTitle>Conversion funnel</CardTitle></CardHeader>
+            <CardContent>
+              {metrics.stages.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No builder sessions yet. Start one from the Agent Wizard.
+                </p>
+              ) : (
+                <ul role="list" className="space-y-3"
+                    aria-label={`Builder funnel for ${metrics.period}`}>
+                  {metrics.stages.map((s, i) => {
+                    const top = metrics.stages[0]?.count || 1;
+                    const pct = Math.round((s.count / top) * 100);
+                    const worst = Math.max(...metrics.stages.map((x) => x.dropoff_pct));
+                    const isWorst = i > 0 && s.dropoff_pct === worst && worst > 0;
+                    return (
+                      <li key={s.key} className={cn("rounded-md", isWorst && "border-l-2 border-amber-500 pl-2")}>
+                        <div className="flex items-center justify-between text-sm">
+                          <span>{s.label}</span>
+                          <span className="tabular-nums text-muted-foreground">
+                            {s.count.toLocaleString()}
+                            {i > 0 && (
+                              <span className="ml-2 text-amber-600 dark:text-amber-400">
+                                ▼ {s.dropoff_pct}%
+                              </span>
+                            )}
+                          </span>
+                        </div>
+                        <div className="mt-1 h-2 w-full rounded-full bg-muted">
+                          <div className="h-full rounded-full bg-emerald-500 transition-all"
+                               style={{ width: `${pct}%` }} />
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Per-engine scorecards */}
+          {metrics.engines.length > 0 && (
+            <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+              {metrics.engines.map((e) => (
+                <Card key={e.engine}>
+                  <CardHeader><CardTitle className="capitalize">{e.engine} ({e.samples})</CardTitle></CardHeader>
+                  <CardContent className="space-y-2 text-sm">
+                    <ScoreRow label="Spec validity" v={e.spec_validity_rate} />
+                    <ScoreRow label="Deploy success" v={e.deploy_success_rate} />
+                    <div className="flex justify-between">
+                      <span>Turns to spec</span>
+                      <span className="tabular-nums">{e.turns_to_spec}</span>
+                    </div>
+                    <ScoreRow label="Hallucinated fields" v={e.hallucinated_field_rate} invert />
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function ScoreRow({ label, v, invert = false }: { label: string; v: number; invert?: boolean }) {
+  const good = invert ? v <= 0.2 : v >= 0.8;
+  const mid = invert ? v <= 0.4 : v >= 0.6;
+  const color = good ? "bg-emerald-500" : mid ? "bg-amber-500" : "bg-red-500";
+  return (
+    <div>
+      <div className="flex justify-between">
+        <span>{label}</span>
+        <span className="tabular-nums">{Math.round(v * 100)}%</span>
+      </div>
+      <div className="mt-1 h-1.5 w-full rounded-full bg-muted">
+        <div className={cn("h-full rounded-full", color)} style={{ width: `${Math.round(v * 100)}%` }} />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Register the route + nav**
+
+In `dashboard/src/App.tsx`: add `import BuilderInsightsPage from "@/pages/builder-insights";` and
+inside the authed `<Routes>`: `<Route path="builder-insights" element={<BuilderInsightsPage />} />`.
+
+In `dashboard/src/components/shell.tsx`: add `BarChart3` to the `lucide-react` import and add to
+`OBSERVABILITY_NAV`: `{ to: "/builder-insights", icon: BarChart3, label: "Builder" }`.
+
+- [ ] **Step 5: Run the test + typecheck + build**
+
+Run: `cd dashboard && npx vitest run src/pages/builder-insights.test.tsx && npm run typecheck && npm run build`
+Expected: PASS; clean typecheck + build.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/src/pages/builder-insights.tsx dashboard/src/pages/builder-insights.test.tsx dashboard/src/App.tsx dashboard/src/components/shell.tsx
+git commit -m "feat(builder): Studio Builder analytics view (funnel + scorecards) (W4 C5)"
+```
+
+---
+
+# Part D — Codex golden-transcript gated e2e
+
+### Task D1: Codex eject e2e (mirror the Claude path)
+
+**Files:**
+- Create: `tests/e2e/test_builder_eject_codex_e2e.py`
+
+- [ ] **Step 1: Write the gated test**
+
+```python
+# tests/e2e/test_builder_eject_codex_e2e.py
+"""Gated e2e: the Codex engine writes real code against a live OpenAI model.
+
+Skipped unless AGENTBREEDER_E2E_OPENAI_KEY is set (BYO key, costs tokens).
+Mirrors test_builder_eject_e2e.py (the Claude path) for engine parity.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from engine.coding_agent.base import AgentBounds
+from engine.coding_agent.engines import engine_for
+from engine.providers.models import ProviderConfig, ProviderType
+from engine.providers.openai_provider import OpenAIProvider
+from engine.sandbox.local import LocalSandbox
+
+_KEY = os.environ.get("AGENTBREEDER_E2E_OPENAI_KEY")
+
+pytestmark = pytest.mark.skipif(not _KEY, reason="AGENTBREEDER_E2E_OPENAI_KEY not set")
+
+
+@pytest.mark.asyncio
+async def test_eject_writes_agent_py_against_live_codex():
+    provider = OpenAIProvider(
+        ProviderConfig(provider_type=ProviderType.openai, api_key=_KEY)
+    )
+    sandbox = LocalSandbox()
+    try:
+        engine = engine_for("codex", provider=provider)
+        instruction = (
+            "Create a minimal Python agent project for this spec:\n"
+            "name: hello-agent\nframework: custom\n"
+            "Write agent.py with a `run(input: str) -> str` function that echoes "
+            "the input, and tools/__init__.py. Use write_file for each file, then stop."
+        )
+        file_changes: list[str] = []
+        async for evt in engine.run(instruction, [], sandbox, AgentBounds(max_turns=6)):
+            if evt.type == "file_change":
+                file_changes.append(evt.path)
+        assert any(p.endswith("agent.py") for p in file_changes), file_changes
+        files = await sandbox.list(".")
+        assert any(p.endswith("agent.py") for p in files), files
+    finally:
+        await sandbox.close()
+        await provider.close()
+```
+
+> **Verify:** confirm `OpenAIProvider`'s import path + `ProviderType.openai` value match
+> `engine/providers/openai_provider.py` and `engine/providers/models.py` (grep before running).
+
+- [ ] **Step 2: Run (skips without a key)**
+
+Run: `pytest tests/e2e/test_builder_eject_codex_e2e.py -v`
+Expected: SKIPPED (no key). With `AGENTBREEDER_E2E_OPENAI_KEY`: PASS, agent.py written.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/test_builder_eject_codex_e2e.py
+git commit -m "test(builder): Codex eject gated e2e for engine parity (W4 D1)"
+```
+
+---
+
+# Final verification (both repos)
+
+- [ ] **OSS:** `pytest tests/unit tests/integration -q` (e2e skips cleanly without keys); `ruff check . && ruff format --check .`; `cd dashboard && npm run lint && npm run typecheck && npm run build && npx vitest run`.
+- [ ] **Cloud:** `venv/bin/pytest -q && ruff check api/`; `alembic upgrade head` against an ephemeral Postgres.
+- [ ] **Gate:** run `/gate` (Gates 1–3 always; Gate 5 cloud-security re-runs the live scan before any cloud deploy — confirm the §11.2 CRITICALs landed: no secrets in sandbox, metadata-egress block, e2b DPA/disclosure).
+- [ ] **Docs sync (CLAUDE.md rule):** update `website/content/docs/` — `agent-yaml.mdx` is unaffected, but add CloudSandbox + `AGENTBREEDER_SANDBOX=cloud` + `AGENTBREEDER_SANDBOX_BACKEND` to `how-to.mdx`, and a "Builder analytics" note where Studio views are documented. Update the cloud repo's stale `ARCHITECTURE.md` (ECS Fargate → Cloud Run) per Open Q #3.
+- [ ] **PR:** open the epic PR (W1–W4) only after the full implementation + local tests pass (per the defer-PR-until-done preference). Preserve wave-by-wave commit history (no squash).
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** CloudSandbox (A1–A4 ↔ design §3), metering (B1–B3 ↔ §4), analytics (C1–C5 ↔ §5/§11.3/§11.4), Codex e2e (D1 ↔ §6). Security §11.2 rails appear as code comments + the final Gate-5 checklist.
+- **Deferred (documented, not silent):** full per-engine scorecard DB joins (C3 ships unit-covered helpers + p50/p90; engine cards render when populated), metering idempotency across network retries (B3 comment), BigQuery export (design §5 follow-on), self-hosted Firecracker backend (design v2).
+- **Verify-before-write flags:** e2b async SDK surface (A3), cloud session-maker export name (B3), `OpenAIProvider` import path (D1), current cloud Alembic head (B1).
+- **Type consistency:** `sandbox_seconds` (float) flows A4 frame → B3 `_extract_sandbox_seconds` → `ceil(/60)`; `FunnelMetrics`/`FunnelStage`/`EngineScorecard` identical names across schemas.py (C2), api.ts (C4), and the view (C5).

--- a/docs/superpowers/specs/2026-06-14-studio-conversational-builder-design.md
+++ b/docs/superpowers/specs/2026-06-14-studio-conversational-builder-design.md
@@ -1,0 +1,260 @@
+# Studio Conversational Agent Builder ("White-Glove") — Design
+
+> Status: Approved direction (brainstorm complete) — pending spec review
+> Date: 2026-06-14
+> Branch: `feat/studio-conversational-builder`
+> Author: Rajit + Claude
+
+## 1. Problem & Vision
+
+AgentBreeder Studio's first-run experience is a static onboarding checklist (Connect a
+model → Create agent → Test → Deploy). The pieces of a conversational builder already
+exist but are disconnected and under-ambitious. We want the **first interface a user
+sees to be a conversation**: an agent that asks what they want to build, what the
+business use case is, where it should run — navigates them with the right questions,
+collects what it needs (models, MCP servers, secrets) inline and securely, then
+**builds and deploys the agent from the chat itself**. White-glove service, Lovable-style.
+
+This must work identically when Studio runs **locally** (`agentbreeder` on the user's
+machine) and **in the cloud** (console.agentbreeder.io), because the cloud is a thin
+metered proxy over the same OSS surface.
+
+### One-sentence goal
+A user lands in Studio, types "a support agent that reads our docs and Zendesk," and a
+guided conversation produces a governed, deployed, running agent — without leaving the
+thread.
+
+## 2. What already exists (grounding)
+
+The build→deploy loop is ~75% wired but fragmented:
+
+| Capability | Where | State |
+|---|---|---|
+| Chat-to-build (interview → validated `agent.yaml`) | `dashboard/src/components/agent-wizard/ChatBuildPanel.tsx` → `POST /api/v1/builders/chat` → `engine/agent_chat_builder.py` | Works, one-shot, non-streaming |
+| Deterministic stack advisor | `engine/recommend.py` + `POST /builders/recommend` | Pure function, reusable |
+| Deploy from raw YAML + SSE logs | `POST /api/v1/deploys`, `GET /api/v1/deployments/{job}/stream` | Works |
+| Secrets (BYO key, server-side, masked) | `engine/secrets/*`, `POST /api/v1/secrets` | Works |
+| Provider catalog + key entry | `dashboard/src/components/provider-catalog.tsx`, `/providers/catalog` | Works |
+| MCP register/discover | `POST /api/v1/mcp-servers`, `/{id}/discover` | Works |
+| Streaming provider support | `engine/providers/base.py::generate_stream()` | Exists, not wired into builder |
+| Cloud proxy + metering + multi-tenant | `agentbreeder-cloud` `/cloud/builders/chat`, `QuotaCounter`, `TenantMiddleware` | Works |
+
+### Gaps that prevent the "Lovable feeling"
+1. Builder is one-shot interview → YAML; it cannot write `agent.py`, custom tools, or iterate (no code generation).
+2. No streaming in chat (`generate()` not `generate_stream()`).
+3. No refinement loop after validation fails.
+4. Deploy is a separate page (`/deploy-wizard`), not continuous from the chat.
+5. No conversational front door — users land on a checklist.
+6. Secrets/MCP/provider setup happen on separate settings pages, not inline.
+
+## 3. Decisions (locked)
+
+| Decision | Choice |
+|---|---|
+| Builder brain | **Hybrid**: interview → governed `agent.yaml` (Phase 1), then optional eject to coding agent for `agent.py`/tools/tests (Phase 2) |
+| Coding-agent engine | **Both Claude (Agent SDK) and Codex (OpenAI Agents), selectable per session** |
+| Code-gen sandbox | **Local in-process + managed cloud sandbox service** (symmetric UX) |
+| Cloud sandbox provider | **Managed e2b-style code-exec sandbox** (Cloud Run jobs as fallback) |
+| Front door | **Conversation replaces the home checklist** as primary empty-state; checklist becomes a quiet progress rail |
+| Eject scope (v1) | Coding agent writes `agent.py`/tools/tests **and may propose `agent.yaml` edits, always re-validated through governance** — never a silent bypass |
+| Delivery | **Phased epic, 4 waves**, each independently shippable; PR opened only after the epic + local tests pass |
+| Deliverable for this session | Design spec + implementation plan |
+
+## 4. The Experience (end to end)
+
+The front door is a single prompt — *"What do you want to build today?"* — with example
+chips. Once a build starts, it becomes a two-pane **build console**.
+
+1. **Interview (Phase 1 brain)** — agent asks 3–5 targeted questions (use case,
+   framework/cloud/scale, tools/data), streamed token-by-token. Backed by
+   `recommend.py` so it *proposes* a stack rather than interrogating.
+2. **Inline setup cards** — when the plan needs a model key, MCP server, or secret, a
+   secure inline card appears in the thread. Values go straight to the secrets backend,
+   masked, never in browser state.
+3. **Spec preview** — the validated `agent.yaml` renders live in the artifact panel,
+   editable, with inline validation errors.
+4. **Eject to code (Phase 2 brain, optional)** — "Need custom logic?" hands the project
+   to the selected coding agent (Claude or Codex) in a sandbox, which writes
+   `agent.py` + `tools/` + tests, shows diffs, and iterates on follow-up messages.
+5. **Deploy from the thread** — Deploy runs the existing 8-step pipeline with live SSE
+   logs streaming into the same conversation, ending with the endpoint URL and a
+   "test it now" link to the playground.
+
+## 5. Architecture (architect lens)
+
+The unifying abstraction is a server-side, tenant-scoped, resumable **`BuilderSession`**
+holding: conversation history, evolving `agent.yaml`, scaffold workspace handle, deploy
+job handle, selected engine, and satisfied-dependency references (secrets/MCP by ref).
+
+```
+Studio chat thread (local + cloud, same React surface)
+        │  SSE (tokens, setup-card requests, spec updates, file diffs, deploy logs)
+        ▼
+BuilderSession  ──┬─ Interviewer  → engine/agent_chat_builder + recommend.py   (Phase 1)
+                  ├─ CodingAgent   → ClaudeAgentEngine | CodexEngine           (Phase 2)
+                  │                     └─ Sandbox (interface)
+                  │                          ├─ LocalSandbox   (in-process)
+                  │                          └─ CloudSandbox   (managed microVM)
+                  ├─ SecretsBridge → engine/secrets/* (inline capture)
+                  ├─ MCPBridge     → /mcp-servers discover/connect
+                  └─ Deployer      → existing /deploys pipeline + SSE
+```
+
+### Principles (honoring CLAUDE.md)
+- **Governance is non-negotiable.** The coding agent writes files into a scaffold
+  workspace; results still flow through Parse → RBAC → Resolve → Build → Provision →
+  Deploy → Health → Register. No "quick deploy." Registry writes go through `registry/`.
+- **`Sandbox` is a pluggable interface** — the coding agent is written once against it.
+- **Engine selection is a strategy** behind one `CodingAgentEngine` protocol.
+- **Cloud stays a thin metered proxy** — it forwards `BuilderSession` traffic to OSS and
+  counts turns + sandbox-minutes against quota. No logic fork.
+- **Framework-agnostic** — codegen targets whatever framework `recommend.py`/the spec
+  chose; no framework names hard-coded outside `engine/runtimes/`.
+
+## 6. Backend contracts
+
+New `BuilderSession` resource (OSS API):
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/api/v1/builder/sessions` | Create session; returns id + opening assistant message |
+| GET | `/api/v1/builder/sessions/{id}` | Get state (history, current yaml, files, deploy status) |
+| POST | `/api/v1/builder/sessions/{id}/messages` | Send user message; SSE stream of the response |
+| POST | `/api/v1/builder/sessions/{id}/eject` | Begin Phase 2 with `engine: claude|codex` |
+| GET | `/api/v1/builder/sessions/{id}/stream` | SSE for all session events |
+| POST | `/api/v1/builder/sessions/{id}/deploy` | Trigger deploy from current spec |
+
+- Builder switches to `provider.generate_stream()`.
+- **SSE event taxonomy**: `token`, `assistant_message`, `spec_update`, `setup_request`
+  (kind = secret|mcp|provider), `validation` (valid + errors), `file_change` (path +
+  diff), `deploy_log`, `complete`, `error`.
+- Underneath, reuses `/secrets`, `/mcp-servers`, `/deploys` — no duplicate logic.
+- **Cloud**: mirrored as `/cloud/builder/sessions/*` proxy with quota metering on turns
+  and sandbox-minutes.
+- Bounds: max messages/chars per session (extend current 40 msg / 100k char limits),
+  per-user rate limit on sessions and deploy triggers.
+
+## 7. Sandbox + Coding-Agent Engine interfaces
+
+```python
+class Sandbox(Protocol):
+    async def write(self, path: str, content: str) -> None
+    async def read(self, path: str) -> str
+    async def list(self, dir: str) -> list[str]
+    async def exec(self, cmd: list[str], timeout: float) -> ExecResult
+    async def snapshot(self) -> bytes        # export project for deploy
+    async def close(self) -> None
+```
+
+- **LocalSandbox** — temp dir + subprocess on the user's machine.
+- **CloudSandbox** — managed e2b-style microVM per session: tenant-scoped, ephemeral,
+  network egress allowlist, CPU/mem/wall-clock caps, auto-teardown, **secrets injected
+  as env vars, never written to disk**.
+
+```python
+class CodingAgentEngine(Protocol):
+    async def run(self, session, instruction: str, sandbox: Sandbox) -> AsyncIterator[AgentEvent]
+```
+
+- **ClaudeAgentEngine** — Claude Agent SDK headless; tools = filesystem + bash scoped to
+  the sandbox; BYO Anthropic key from secrets backend.
+- **CodexEngine** — OpenAI Agents loop; same tool surface; BYO OpenAI key.
+- Both bounded by max turns/tokens/wall-clock; emit `file_change` + tool-call events.
+
+## 8. Secrets & MCP in-conversation
+
+- Interviewer and coding agent emit `setup_request` events; the UI renders an inline
+  card (not a modal, not a page).
+- On submit, the frontend calls `/secrets` (masked, server-side) or `/mcp-servers`
+  (register + `/{id}/discover` to pull tools). The session records the dependency as
+  satisfied **by reference**, never the value; `agent.yaml` gets the `secrets:` /
+  `mcp_servers:` / `tools:` refs and is re-validated.
+- Reuses `provider-catalog.tsx` and the `ChatBuildPanel` key-entry pattern (password
+  field, cleared after submit, never in component state).
+
+## 9. UI/UX & Frontend (ui-ux-pro-max + frontend-design lens)
+
+- **Two-pane build console**: conversation thread (left) + **artifact panel** (right)
+  tabbing between *Spec* (`agent.yaml`), *Code* (file tree + diffs, Phase 2), *Deploy*
+  (streaming logs → endpoint). Lovable/Bolt pattern; reuses `MessageBubble`,
+  `ToolCallCard`, `StreamingBubble`.
+- **Inline cards as first-class messages**: secret capture, MCP connect, plan approval,
+  deploy confirm — all inside the thread.
+- **Progressive disclosure**: beginners see only the conversation; the artifact panel and
+  "eject to code" reveal as the build matures. Power users can jump to the existing
+  YAML/visual `agent-builder.tsx` (tier mobility preserved).
+- **Front door**: full-width centered prompt + example chips as home empty-state,
+  collapsing into the two-pane console once a build begins.
+- **States & a11y**: every streaming/loading/error state handled (TS standards); a11y on
+  inline cards, focus management on auto-scroll, WCAG 2.2 AA on the new surface.
+
+## 10. Local vs Cloud parity
+
+Same React surface, same `BuilderSession` API. Differences are isolated:
+
+| Concern | Local | Cloud |
+|---|---|---|
+| Auth | single-user / local token | multi-tenant JWT + `TenantMiddleware` |
+| Sandbox | `LocalSandbox` (in-process) | `CloudSandbox` (managed) |
+| Metering | none | quota on turns + sandbox-minutes |
+| Engine selection | available | available |
+| Secrets backend | env/keychain | tenant workspace backend |
+
+## 11. Model E2E testing (model-e2e-test lens)
+
+- **Unit**: `recommend.py` decisions, session state machine, sandbox interface against a
+  `FakeSandbox`, engine event parsing with a mocked provider.
+- **Integration**: API endpoints with deterministic mocked tool-call fixtures — interview
+  turn, eject turn, deploy trigger, setup-card flow.
+- **E2E (gated, BYO key)**: scripted golden-transcript conversations against real models
+  asserting build → valid `agent.yaml` → local deploy → `/health` 200 → invoke returns.
+  One transcript set **per engine** (Claude, Codex) to catch behavioral divergence.
+- **Sandbox safety**: egress blocked outside allowlist, CPU/mem/time caps enforced,
+  teardown verified, secrets-not-on-disk asserted.
+- **Eval metrics**: spec-validity rate, deploy-success rate, turns-to-spec,
+  hallucinated-field rate.
+
+## 12. Analytics & tracking (analytics-tracking lens)
+
+- **Funnel taxonomy**: `builder_session_started` → `user_message_sent` →
+  `stack_recommended` → `setup_card_shown/completed` (secret|mcp|provider) →
+  `spec_validated` (valid|invalid) → `eject_to_code_started` → `coding_agent_turn` →
+  `deploy_started/succeeded/failed` → `first_invoke`.
+- **North-star**: time-to-first-deployed-agent. Activation = first successful deploy +
+  first invoke.
+- **Properties**: engine, framework, cloud, sandbox (local|cloud), turns, duration,
+  tenant plan.
+- **Wiring**: existing audit/cost infra + a frontend analytics hook; cloud meters turns +
+  sandbox-minutes (ties to `QuotaCounter`).
+- **Privacy**: never log secret values or PII-bearing prompts; hash user ids.
+
+## 13. Phasing (epic, 4 waves)
+
+| Wave | Scope | Independently shippable value |
+|---|---|---|
+| **W1** | Conversational front door + streaming interview + deploy-from-chat (`BuilderSession` MVP reusing `agent_chat_builder`, SSE). Replaces home empty-state. | Talk → spec → deploy in one thread |
+| **W2** | Inline secrets / MCP / provider capture cards | No more leaving the thread to configure |
+| **W3** | Eject-to-code: `CodingAgentEngine` (Claude + Codex) + `Sandbox` interface + `LocalSandbox` + artifact Code tab | Real code generation locally |
+| **W4** | `CloudSandbox` (e2b-style) + cloud metering parity + analytics dashboard | Full Lovable parity in cloud |
+
+Cross-cutting per wave: grow the model-e2e suite, add analytics events, and sync docs
+(`website/content/docs/cli-reference|how-to|agent-yaml`), `agentbreeder-cloud`, and the
+website per the CLAUDE.md cross-repo rules — in the same commit as the code.
+
+## 14. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Server-side code execution security (biggest) | Strong sandbox isolation; deferred to W3/W4 behind an interface; egress allowlist, caps, auto-teardown |
+| Cost/abuse (codegen + sandbox minutes) | Quota metering on turns + sandbox-minutes; per-user rate limits |
+| BYO-key friction | Offer org-level keys in cloud; reuse existing secure key entry |
+| Engine parity (Claude vs Codex divergence) | Golden transcripts per engine; shared `CodingAgentEngine` contract |
+| Streaming latency through cloud proxy | SSE passthrough; measure; keepalive pings (existing pattern) |
+| Two competing build flows | Phased evolution of existing surfaces, not a greenfield fork |
+
+## 15. Out of scope (YAGNI for now)
+
+- Visual/no-code canvas changes (existing `VisualBuilder` stays; tier mobility preserved).
+- Orchestration (multi-agent) conversational builder — future epic.
+- Marketplace template instantiation via chat — future.
+- Non-Anthropic/OpenAI coding-agent engines.

--- a/docs/superpowers/specs/2026-06-14-studio-conversational-builder-wave4-design.md
+++ b/docs/superpowers/specs/2026-06-14-studio-conversational-builder-wave4-design.md
@@ -1,0 +1,437 @@
+# Wave 4 — Studio Conversational Builder: Design & Architecture
+
+> **Status:** Design (pre-implementation)
+> **Date:** 2026-06-14
+> **Branch:** `feat/studio-conversational-builder`
+> **Closes:** the conversational builder epic (W1–W3 complete and committed)
+> **Master spec:** `docs/superpowers/specs/2026-06-14-studio-conversational-builder-design.md`
+> **Repos touched:** `agentbreeder` (OSS engine + Studio), `agentbreeder-cloud` (GCP Cloud Run control plane)
+
+This document is the detailed design for W4 and the home for the multi-lens review
+(architect / cloud-security / frontend / UX / marketing). It is grounded in the existing
+code — every anchor below cites a real file:line.
+
+---
+
+## 1. Scope
+
+W4 has four deliverables:
+
+1. **CloudSandbox** — a managed, tenant-scoped, ephemeral microVM implementing the existing
+   `Sandbox` Protocol, flipping `AGENTBREEDER_SANDBOX=cloud` from a `RuntimeError` to working.
+2. **Cloud sandbox-minutes metering** — wire real wall-clock minutes into the cloud
+   `QuotaCounter` (currently stubbed at 0, `agentbreeder-cloud/api/routes/builder_sessions.py:185`).
+3. **Analytics funnel dashboard** — replace the W3 `track()` browser-CustomEvent stub with a
+   real collector, the full funnel taxonomy, per-engine eval metrics, and a Studio view.
+4. **Codex golden-transcript gated e2e** — mirror the Claude e2e for the `codex` engine.
+
+Non-goals for W4: self-hosted Firecracker backend (designed for, not built), BigQuery funnel
+modeling beyond raw event export, tenant-tier sandbox-minute pricing plans.
+
+---
+
+## 2. Existing-code anchors (what we build on)
+
+| Area | File:line | Note |
+|---|---|---|
+| Sandbox Protocol (6 async methods) | `engine/sandbox/base.py:52-61` | `write/read/list/exec/snapshot/close` |
+| `ExecResult` + `.ok` | `engine/sandbox/base.py:24-35` | |
+| `select_sandbox_mode()` | `engine/sandbox/base.py:38-49` | reads `AGENTBREEDER_SANDBOX`, fails closed |
+| `LocalSandbox` (path containment, caps) | `engine/sandbox/local.py:24-94` | the contract CloudSandbox must match |
+| cloud branch raises | `api/services/builder_session_service.py:37-43` | flip point |
+| eject flow + SSE contract | `api/services/builder_session_service.py:132-167` | `token/tool_call/file_change/complete/error` |
+| coding loop (B2) | `engine/coding_agent/loop.py:79-146` | turns/tokens/wall-clock bounds |
+| engines (claude + codex) | `engine/coding_agent/engines.py:50-65` | `codex` already first-class |
+| analytics stub | `dashboard/src/lib/analytics.ts` (whole file) | CustomEvent, no collector |
+| emit sites | `dashboard/.../ChatBuildPanel.tsx:598,607,610` | engine hardcoded `"claude"` |
+| cloud proxy metering | `agentbreeder-cloud/api/routes/builder_sessions.py:94-111,185` | turn unit; minutes TODO |
+| QuotaCounter | `agentbreeder-cloud/api/services/quota.py:25-59` | post-increment-by-1, 429 |
+| QuotaScopeEnum | `agentbreeder-cloud/api/models/tenancy.py:41` | `{user,tenant}` only today |
+| quota limits | `agentbreeder-cloud/api/config.py:19-20` | both default 100/day |
+| Claude gated e2e | `tests/e2e/test_builder_eject_e2e.py` | gated on `AGENTBREEDER_E2E_ANTHROPIC_KEY` |
+
+---
+
+## 3. CloudSandbox
+
+### 3.1 Decision
+
+Implement CloudSandbox as a **thin Protocol-conformant client** behind a pluggable
+`SandboxBackend` abstraction. **v1 backend = e2b** (managed Firecracker microVMs). Self-hosted
+**Firecracker-on-GKE** is the documented enterprise/data-residency v2 (designed for, not built).
+
+Decision matrix (weighted): e2b **8.45** vs Cloud Run/gVisor 6.35 vs Cloud Run Jobs 5.0 vs
+self-host Firecracker/GKE 6.55. The `Sandbox` Protocol is *stateful and interactive*
+(write→exec→read→snapshot→close over a session), which eliminates batch Cloud Run Jobs;
+true microVM isolation for arbitrary BYO-key code rules in e2b/Firecracker over gVisor.
+
+### 3.2 Shape
+
+```
+engine/sandbox/
+  base.py            # Sandbox Protocol (unchanged)
+  local.py           # LocalSandbox (unchanged)
+  cloud.py           # NEW: CloudSandbox(Sandbox) — delegates to a SandboxBackend
+  backends/
+    base.py          # NEW: SandboxBackend interface (provision/exec/read/write/list/snapshot/destroy)
+    e2b_backend.py   # NEW: E2BBackend wrapping the e2b SDK
+    fake_backend.py  # NEW: in-memory backend for unit tests (no network)
+```
+
+- `CloudSandbox` maps the 6 Protocol methods 1:1 onto `SandboxBackend`, applying the SAME
+  guardrails LocalSandbox enforces: path containment (no absolute, no `..`), `_MAX_FILE_BYTES`,
+  `_MAX_EXEC_TIMEOUT`. The microVM is defense-in-depth, **not** an excuse to drop client checks.
+- `_make_sandbox()` (`builder_session_service.py:41-42`) stops raising and returns
+  `CloudSandbox(backend=make_backend_from_env())`.
+
+### 3.3 e2b backend contract
+
+| Protocol concern | e2b mapping |
+|---|---|
+| per-session VM | one e2b sandbox per builder session; tenant id in sandbox metadata/tag |
+| secrets | **NONE by default.** The coding-loop LLM calls run in the OSS engine *outside* the VM, so eject needs no key inside it. Untrusted in-VM code could exfiltrate any env var, so we inject nothing long-lived; a future test-invoke step gets only a short-lived, narrowly-scoped token (see cloud-security §11.2 CRITICAL). |
+| network | egress **default-deny allowlist**: LLM endpoints + PyPI + npm only. **Drop link-local/metadata ranges (169.254.0.0/16 incl. 169.254.169.254)** — mandatory for the self-hosted GKE backend to prevent SSRF-to-metadata token theft. |
+| caps | CPU/mem from e2b template; wall-clock from `AgentBounds.wall_clock_s`; e2b idle-timeout backstop |
+| image | non-root `USER`, pinned base, minimal tooling, no build secrets (defense-in-depth inside the µVM) |
+| snapshot | `snapshot()` zips the workspace (parity with LocalSandbox); snapshot bytes are tenant data → encrypted at rest, TTL, tenant-scoped |
+| teardown | `close()` destroys the VM; e2b idle-timeout is the backstop if the process dies |
+
+The `SandboxBackend` abstraction is a **security requirement** (not just architecture): e2b is a
+third-party sub-processor, so data-residency-bound tenants need the self-hosted backend.
+`E2B_API_KEY` resolves from GCP Secret Manager in cloud; from user env in self-host (BYO).
+e2b ships only as a v1 self-serve option with a signed **DPA** + privacy-policy sub-processor
+disclosure + region pinning.
+
+### 3.4 Failure policy (load-bearing)
+
+In cloud mode, if the backend is unavailable, CloudSandbox raises → the eject route surfaces
+a **503 with a clear message**. It **never** falls back to `LocalSandbox` — that would breach
+the W3 invariant ("In cloud mode, LocalSandbox construction raises — only CloudSandbox is
+allowed", `docs/superpowers/plans/...wave3.md:13`). Circuit-break repeated e2b failures.
+
+### 3.5 Duration reporting
+
+`CloudSandbox` tracks VM wall-clock (provision → close) and exposes `sandbox_seconds`. The
+eject service includes it in the terminal `complete` SSE frame so the cloud proxy can meter
+actuals (see §4). This also folds in the C5 polish item by adding a `code` field to
+engine-origin `complete`/`error` frames.
+
+---
+
+## 4. Cloud sandbox-minutes metering
+
+### 4.1 Pattern: pre-check, then charge actuals
+
+Turns use post-increment-by-1 (`quota.py:44-59`). Minutes are variable-per-call and must not
+be charged only *after* expensive work. So:
+
+1. **Pre-check** (before forwarding eject): if the user or tenant is already at the daily
+   sandbox-minute cap → **429** immediately (reuse the `QuotaExceeded` → 429 shape,
+   `builder_sessions.py:94-111`).
+2. **Charge actuals** (after the stream): sniff `sandbox_seconds` from the terminal `complete`
+   frame, post-increment by `ceil(seconds / 60)` with an **idempotency key** on `session_id`
+   to avoid double-charging on retries.
+3. **Backstop**: if the client disconnects mid-stream, a best-effort charge keyed on
+   backend session-close prevents free unmetered minutes.
+
+### 4.2 Schema / code changes (agentbreeder-cloud)
+
+- `QuotaScopeEnum` (`api/models/tenancy.py:41`): add `user_sandbox_minutes`,
+  `tenant_sandbox_minutes`. **Alembic migration** to ALTER the Postgres enum (gated review —
+  enum ALTER is awkward to roll back).
+- `quota.py`: add `amount: int = 1` to `_increment_one` / `increment_and_check`; add a
+  pre-check helper `check_only(scope, scope_id, limit)`.
+- `api/config.py`: add `user_daily_sandbox_minutes_limit` / `tenant_daily_sandbox_minutes_limit`
+  (proposed default **30 min/day** free tier — confirm).
+- `builder_sessions.py:185`: replace the TODO stub with pre-check + post-stream charge.
+
+### 4.3 Why not meter in OSS
+
+Free-tier quotas are a **cloud** concern; OSS self-host is unmetered. OSS only contributes the
+`sandbox_seconds` value in the SSE contract. No quota logic enters the OSS engine.
+
+---
+
+## 5. Analytics funnel
+
+### 5.1 Decision
+
+Replace the CustomEvent stub with a real collector: **OSS Postgres `analytics_events` table +
+ingest endpoint + funnel aggregation endpoint + a Studio "Builder" view**. Cloud additionally
+streams the same events to **BigQuery** (cold tier) for funnel SQL at scale. Events are **not**
+written to `audit_log` (keep the immutable compliance log clean).
+
+### 5.2 Event taxonomy (master spec §12)
+
+`builder_session_started → user_message_sent → stack_recommended →
+setup_card_shown → setup_card_completed → spec_validated → eject_to_code_started →
+coding_agent_turn → deploy_started → deploy_succeeded | deploy_failed → first_invoke`
+
+- **North-star metric:** time-to-first-deployed-agent.
+- Expand the typed `AnalyticsEvent` union in `dashboard/src/lib/analytics.ts` to the full set.
+- Fix the hardcoded `engine: "claude"` (ChatBuildPanel.tsx:598) → derive from the active engine.
+- **PII rule (cloud-security §11.2):** events carry **structural data only** — event name,
+  engine, counts, ids. **Never** message bodies or prompt content in `props` jsonb (user
+  messages may contain PII). Pin the typed union as the contract; add a **retention/TTL** on
+  `analytics_events`; the BigQuery export inherits both.
+
+### 5.3 Per-engine eval metrics (master spec §11)
+
+Computed from `analytics_events` + eval-run records, grouped by engine (`claude`, `codex`):
+spec-validity rate, deploy-success rate, turns-to-spec, hallucinated-field rate.
+
+### 5.4 Shape
+
+```
+OSS:    track() (batched) ──POST /api/v1/analytics/events──► analytics_events (Postgres)
+                                                            └► GET /api/v1/analytics/funnel (aggregates)
+Cloud:  same events ──► BigQuery (cold tier) for funnel SQL  [follow-on / via existing pipeline]
+Studio: new "Builder" view renders the funnel + per-engine scorecards
+```
+
+### 5.5 Naming (CLAUDE.md "Studio rule")
+
+The view is **"Studio › Builder"** (functional noun). **Never** "Analytics Studio" / "Builder
+Studio". The funnel chart inside it is "the funnel", lowercase, unbranded.
+
+---
+
+## 6. Codex golden-transcript gated e2e
+
+Mirror `tests/e2e/test_builder_eject_e2e.py` for the `codex` engine:
+
+- Gate on `AGENTBREEDER_E2E_OPENAI_KEY` (skip cleanly when absent — same pattern as Claude).
+- Build `OpenAIProvider`, run `engine_for("codex", provider=...)`.
+- Elevate to a **golden transcript** (master spec §11): scripted conversation asserting
+  build → valid `agent.yaml` → local deploy → `/health` 200 → invoke.
+- Apply the same golden transcript to the Claude path for parity.
+
+---
+
+## 7. Cross-repo & polish items folded in
+
+- **C5 error frames:** add a `code` field to engine-origin `complete`/`error` SSE frames (needed
+  by §4 metering anyway).
+- **Eject engine prop:** derive engine in analytics instead of hardcoding `"claude"` (§5.2).
+- **B2 loop:** name the bare `20_000` truncation constant; note `tokens_seen` counts chars not
+  tokens (out of strict W4 scope; fix if cheap).
+- **Cloud doc drift:** `agentbreeder-cloud/ARCHITECTURE.md` says "ECS Fargate" but
+  `infra/stacks/compute.py` provisions Cloud Run — fix the doc (cross-repo sync rule).
+- **hono dev-only CVE:** separate `npm audit` / security PR (shadcn CLI, not bundled).
+
+---
+
+## 8. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Untrusted code escapes sandbox | microVM isolation + client-side path/size/timeout caps + egress allowlist |
+| Secrets leak via e2b / on disk | env-only injection, never disk; Secret Manager; trust-boundary review (§ cloud-security) |
+| e2b outage | circuit-break → 503; never fall back to LocalSandbox in cloud |
+| Sandbox-minute cost abuse | pre-check quota + charge actuals + idempotency + backstop charge on close |
+| Postgres enum ALTER hard to revert | gated migration review; additive-only |
+| Funnel jsonb sprawl | typed `AnalyticsEvent` union as the contract |
+
+---
+
+## 9. Implementation phasing
+
+1. **Immediate (days):** `SandboxBackend` + `CloudSandbox(e2b)` + flip `_make_sandbox`;
+   `FakeBackend` unit tests; `sandbox_seconds` in `complete` frame + `code` field.
+2. **Short-term (weeks):** cloud metering (enum + migration + amount + pre-check + sniff);
+   analytics table + ingest + funnel endpoint + Studio Builder view; Codex golden e2e.
+3. **Long-term (months):** self-hosted Firecracker-on-GKE backend; BigQuery funnel; per-engine
+   eval scorecards; tenant-tier sandbox-minute plans.
+
+---
+
+## 10. Open questions (for review lenses)
+
+1. Is e2b acceptable as a v1 data/secret processor, or must v1 be self-hosted? → **cloud-security**
+2. Free-tier sandbox-minute default (30/day?) and overage behavior (hard 429 vs soft)? → architect/marketing
+3. Standalone Studio "Builder" view vs a tab in an existing view? → **ui-ux-pro-max / frontend**
+4. Cloud `ARCHITECTURE.md` ECS-vs-Cloud-Run fix — same PR or follow-on? → cross-repo
+
+---
+
+## 11. Multi-lens review
+
+### 11.1 Architect — DONE
+See §3–§5 verdicts and the §3.1 decision matrix. Summary: e2b-backed CloudSandbox behind a
+`SandboxBackend` abstraction; pre-check-then-charge-actuals metering; dedicated analytics
+events table + Studio Builder view. North-star = time-to-first-deployed-agent.
+
+### 11.2 Cloud-security — DONE
+
+Design-time threat model (the scan skill targets deployed infra; applied here as a pre-impl
+review in its CRITICAL/HIGH/MEDIUM/LOW + Gate-5 vocabulary). **The microVM is the easy part;
+the trust boundary inside it is where W4 can go wrong.**
+
+**[CRITICAL] Secrets injected into the sandbox are readable by the untrusted code.**
+§3.3 originally said "secrets injected as env vars." But the coding agent executes
+*untrusted, model-generated commands* inside that same VM — any env var is exfiltratable to
+the allowlisted egress. **Revised stance: inject ZERO long-lived secrets into the sandbox.**
+The coding-loop LLM calls happen in the OSS engine process *outside* the VM, so the eject
+sandbox needs no model key at all. If a future "test-invoke the generated agent" step needs a
+credential, inject only a **short-lived, narrowly-scoped** token and treat the VM as hostile.
+→ Design updated (§3.3).
+
+**[CRITICAL] Block cloud metadata endpoint (169.254.169.254) from sandbox egress.** For the
+self-hosted Firecracker-on-GKE v2, an un-blocked metadata server lets sandbox code steal the
+node/SA token → full tenant-data compromise (SSRF-to-metadata). The egress allowlist must be
+**default-deny** and explicitly drop link-local/metadata ranges. e2b (off-GCP) is lower risk
+but the allowlist requirement stands. → Added to §3.3 / §8.
+
+**[HIGH] e2b is a third-party sub-processor.** User prompts + generated code (and any token we
+pass) transit e2b infrastructure. Required before GA: signed **DPA with e2b**, e2b added to the
+**privacy-policy sub-processor list**, documented **data residency** (e2b region pinning), and
+the self-hosted Firecracker path positioned as the answer for regulated/enterprise tenants.
+This is the answer to Open Question #1: **e2b is acceptable for v1 self-serve with disclosure +
+DPA; it is NOT acceptable as the only option for data-residency-bound tenants** — hence the
+SandboxBackend abstraction is a security requirement, not just architecture.
+
+**[HIGH] Egress allowlist must be explicit and minimal.** Default-deny; allow only configured
+LLM endpoints + PyPI + npm registry. Prevents data exfiltration and crypto-mining-to-pool.
+
+**[HIGH] Sandbox runs non-root, pinned base, minimal tooling.** Defense-in-depth even inside a
+microVM — the e2b template image gets a non-root `USER`, pinned base, no build secrets.
+
+**[MEDIUM] Analytics events must be PII-free.** User messages may contain PII; funnel events
+must carry **structural data only** (event name, engine, counts, ids) — never message bodies or
+prompt content in `props` jsonb. Pin the typed union, add a **retention/TTL** on
+`analytics_events`, and inherit both in the BigQuery export. → Added to §5.
+
+**[MEDIUM] Metering integrity.** `sandbox_seconds` must be read by the cloud proxy from the
+*OSS stream* (trusted, bearer-authed), never settable by the client. Idempotency key on the
+metering write prevents double-charge on retry; the close-time backstop prevents under-charge
+on mid-stream disconnect (DoS-by-disconnect). Pre-check quota caps resource-exhaustion abuse.
+
+**[LOW] Snapshot bytes** may contain whatever the agent wrote — treat snapshot storage as
+tenant data (encrypted at rest, TTL, tenant-scoped access).
+
+**Gate 5 (design-time): CONDITIONAL PASS** — the two CRITICALs (no-secrets-in-sandbox,
+metadata-egress-block) and the e2b DPA/sub-processor HIGH **must be reflected in the design and
+landed in implementation** before the cloud path ships. With §3.3/§5/§8 updated below, the
+design clears the gate; implementation re-runs the live scan (Gate 5) before the cloud deploy.
+
+### 11.3 Frontend design — DONE
+
+**Aesthetic direction: "instrument panel, not dashboard slop."** Editorial, data-dense,
+restrained — intentionality within the existing Studio design system, *not* a bolt-on with a
+foreign look. The one memorable thing: a **left-to-right funnel ribbon** where each step's bar
+width encodes survivors and the **gap between bars is labeled with the drop-off %** — the eye
+reads conversion loss as literal negative space.
+
+**House-style constraint (load-bearing):** Studio ships **no charting library**. Every chart is
+Tailwind: `costs.tsx:140-224` renders bars via `style={{ width: \`${pct}%\` }}` with
+emerald/amber/red thresholds; `eval-comparison.tsx:41-117` already has `getScoreColor` /
+`getBarColor` / delta-badge / metric-card. **W4 adds zero new deps** (recharts/tremor/d3) —
+this keeps the bundle lean *and* clears a security concern (no new npm attack surface, ref §11.2).
+
+**Route/file:** `dashboard/src/pages/builder-insights.tsx`, nav label **"Builder"** (Studio rule —
+never "Analytics Studio"/"Builder Studio"). Sits in the existing sidebar next to Evals/Costs.
+
+**Layout (top → bottom):**
+1. **North-star band** — one wide `Card`, oversized tabular-nums figure for
+   *time-to-first-deployed-agent* (p50 big, p90 secondary), a sparkline-as-CSS-bars trend strip,
+   and a period selector (`Tabs`: 7d / 30d / all). This is the hero; give it air.
+2. **Funnel ribbon** — full-width `Card`. Vertical stack of 11 steps
+   (`builder_session_started … first_invoke`); each row = step label + count + a bar
+   (`width: survivors/total`) reusing the costs.tsx bar. Between rows, a muted
+   `text-xs text-muted-foreground` drop-off delta (`−37%`) using the eval-comparison delta-badge
+   colors. Biggest drop-off row gets a subtle left accent border to draw the eye to the leak.
+3. **Per-engine scorecards** — 2-col grid (`grid-cols-1 lg:grid-cols-2`), one `Card` per engine
+   (claude / codex), each with 4 metric rows (spec-validity, deploy-success, turns-to-spec,
+   hallucinated-field) rendered with `eval-comparison`'s metric-card + threshold bars. A compact
+   header `Badge` shows the engine + sample size. Reuse `getScoreColor`/`getBarColor` verbatim.
+
+**Components:** shadcn `Card`, `Tabs`, `Badge` (all already in `src/components/ui`). Data via
+React Query (`useQuery(['builder-funnel', period])` → `GET /api/v1/analytics/funnel`). Honor the
+CLAUDE.md rule: handle `isLoading` (`<Skeleton />` rows) and `error` (`<ErrorBanner />`); empty
+state ("no builder sessions yet") for fresh installs. Tabular figures use `tabular-nums`; respect
+dark mode via the existing `dark:` thresholds. Typography/colors inherit the Studio theme — no
+new font (consistency beats novelty for an internal instrument).
+
+### 11.4 UI/UX (ui-ux-pro-max) — DONE
+
+Validated against the skill's chart DB (Funnel/Flow = AA; Compare-Categories bar = AAA) and the
+§1/§10 a11y rules. Two refinements to the frontend design + an a11y contract:
+
+**[REFINEMENT 1 — funnel length] 11 raw steps exceeds the "3–8 stages optimal" rule** ("beyond
+8, group minor steps"). Fix: the **headline funnel shows ~5 macro-stages** —
+*Converse → Spec validated → Eject → Deploy → Live (first invoke)* — with the 11 raw events
+available on **expand/drill** per stage. Keeps the hero readable; preserves granularity for
+debugging. Single-hue gradient start→end; **highlight the biggest drop-off** (already in §11.3).
+
+**[REFINEMENT 2 — scorecard chart type] Do NOT use radar/spider for engine comparison** (DB
+grade B: "values need precise comparison → use grouped bar"). The `eval-comparison.tsx`
+metric-card + threshold-bar idiom (Compare-Categories, **AAA**) is the correct choice — confirms
+§11.3. Two side-by-side engine cards with aligned metric rows read more precisely than a radar.
+
+**[A11y contract for div-based bars] (CRITICAL §1, §10):**
+- **`color-not-only`:** drop-off and pass/fail must carry **text + icon**, never color alone
+  (the emerald/amber/red bars need a numeric label and an ▲/▼ glyph).
+- **`screen-reader-summary`:** each chart container gets an `aria-label` stating the key insight
+  (e.g. "Builder funnel: 1,204 sessions started, 38% reach first deploy; biggest drop at Eject").
+- **`data-table` fallback:** render the funnel as a semantic list/table (`role="list"` rows with
+  stage name + count + drop-off %) — value labels **always visible**, not hover-only (hover
+  tooltips fail keyboard + touch; `tooltip-keyboard`).
+- **`contrast-data`:** bars vs background ≥3:1, text labels ≥4.5:1; verify the amber threshold in
+  **both** light and dark (`color-dark-mode`).
+- **`number-tabular` + locale formatting** on all figures; **`reduced-motion`** disables bar-fill
+  animation (data must be readable immediately, `animation-optional`).
+- **`empty-data-state`** ("No builder sessions yet" + a link to start one) and **skeleton loading**
+  (`loading-chart`) — never a bare axis frame. (Echoes §11.3.)
+- Custom SVG/div is an **accepted funnel implementation** per the DB ("Custom SVG") — the no-new-
+  dependency decision (§11.3) stands and is a11y-viable.
+
+**[CSV export]** Data-dense analytics views should offer **CSV export** of the funnel + scorecard
+data (`export-option`) — cheap to add, expected by PM/ops users.
+
+### 11.5 Marketing — DONE
+
+W4 is the piece that makes the epic *demoable to a stranger with zero setup* — that's the
+marketing unlock. CloudSandbox turns "clone the repo and run the CLI" into "open a tab and talk."
+
+**Positioning.** Lead with the outcome, not the microVM. The line:
+> **"Describe your agent. Watch it get built. Ship it governed — without leaving the browser."**
+Tie to the master tagline: CloudSandbox is how *"Define Once. Deploy Anywhere"* becomes true for
+people who don't have a terminal. **Avoid** "Lovable for agents" in public copy as the *headline*
+(borrowed equity, and it undersells governance) — use it only as a one-line analogy for warm
+audiences. The real differentiator vs. Lovable/Replit/v0: **the eject is real code AND the deploy
+is governed** (RBAC, cost, audit as a side effect). Nobody else pairs no-code speed with
+enterprise governance. That's the wedge.
+
+**Audience framing (one product, three hooks):**
+- **PMs / citizen builders:** "Build a working agent in a conversation. No setup, no YAML."
+- **ML engineers:** "Prototype by chatting, then `eject` to real LangGraph/CrewAI/Claude SDK code
+  you own — no lock-in."
+- **Developers/platform teams:** "Every agent your org ships is governed automatically. The
+  builder is the on-ramp; the registry is the moat."
+
+**Most relevant plays from the library (stage = console.agentbreeder.io launch):**
+1. **Product Hunt launch (#78) + waitlist referrals (#79).** The browser demo IS the launch
+   asset — a 30-sec "prompt → live agent" screen recording is the hero. Ties to the existing
+   Vercel-KV waitlist (`project_website_waitlist_kv`). *Start:* cut the demo video; gate cloud
+   builder access behind the waitlist; referral bumps queue position. *Outcome:* launch-day
+   signups + a ranked lead list.
+2. **Product-led viral loop / Powered-by (#93, #87).** Agents built in the cloud builder carry an
+   optional "Built with AgentBreeder" attribution on their public agent card / A2A endpoint.
+   *Outcome:* every shared agent is a distribution surface.
+3. **Engineering-as-marketing / free tool (#15, #14).** The conversational builder itself is the
+   free tool — a public, no-login "spec your agent" mode that produces a downloadable `agent.yaml`
+   (the eject-to-deploy step requires signup). *Outcome:* top-of-funnel that maps directly to the
+   §5 funnel's `builder_session_started`.
+4. **DevRel + the eject story (#133–136).** A "from chat to production code in 4 minutes" tutorial
+   + livestream; the *no-lock-in eject* is the credibility hook for skeptical engineers.
+5. **Comparison pages (#11).** "AgentBreeder vs. [no-code agent builders]" — axis = *does the
+   output deploy with governance / can you own the code*. Most competitors lose both columns.
+
+**The funnel view is also a GTM asset, not just an internal tool.** North-star
+(time-to-first-deployed-agent) is the exact number to publish as a proof point ("median user ships
+a governed agent in N minutes") and to A/B-test launch copy against. The §5 funnel events are the
+measurement backbone for every play above — instrument before launch, not after.
+
+**Sequencing:** CloudSandbox must be load-tested and the sandbox-minute free tier tuned (Open
+Q #2) *before* a Product Hunt spike — a launch that 503s on the demo is the one risk that turns
+the marketing unlock into a liability. Gate the launch on cloud-path reliability.

--- a/engine/agent_chat_builder.py
+++ b/engine/agent_chat_builder.py
@@ -11,9 +11,10 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml as pyyaml
 
@@ -62,6 +63,63 @@ _SUBMIT_TOOL_DEFINITION = ToolDefinition(
 SUBMIT_TOOL: ToolDefinition = _SUBMIT_TOOL_DEFINITION
 
 # ---------------------------------------------------------------------------
+# request_setup tool — lets the interviewer ask the user for a dependency
+# (a secret/API key, a model-provider key, or an MCP server) BEFORE finishing
+# the spec. The frontend renders an inline card; once satisfied, the user
+# confirms and the model references the dependency by name in the final spec.
+# Values never flow through this module — only the *request* for one.
+# ---------------------------------------------------------------------------
+
+REQUEST_SETUP_TOOL_NAME = "request_setup"
+
+_REQUEST_SETUP_TOOL_DEFINITION = ToolDefinition(
+    type="function",
+    function=ToolFunction(
+        name=REQUEST_SETUP_TOOL_NAME,
+        description=(
+            "Request that the user provide a dependency the agent needs before the spec "
+            "can be finished: an API key/secret (kind='secret'), a model-provider key "
+            "(kind='provider'), or an MCP server (kind='mcp'). Call this BEFORE "
+            "submit_agent_spec whenever the agent requires a credential or tool you cannot "
+            "supply yourself. After the user confirms it is connected, reference it by name "
+            "in the spec (secrets / mcp_servers / tools) and then call submit_agent_spec."
+        ),
+        parameters={
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "kind": {
+                    "type": "string",
+                    "enum": ["secret", "mcp", "provider"],
+                    "description": "The kind of dependency to collect.",
+                },
+                "name": {
+                    "type": "string",
+                    "description": (
+                        "The dependency name the spec will reference — e.g. "
+                        "'ZENDESK_API_KEY' (secret), 'openai' (provider), 'zendesk' (mcp)."
+                    ),
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "A short, friendly explanation shown to the user on the card.",
+                },
+            },
+            "required": ["kind", "name"],
+        },
+    ),
+)
+
+# Public accessor so tests / callers can inspect the exact tool definition.
+REQUEST_SETUP_TOOL: ToolDefinition = _REQUEST_SETUP_TOOL_DEFINITION
+
+# Both tools are offered on every turn so the model can either finish the spec
+# or pause to collect a dependency.
+_BUILDER_TOOLS = [SUBMIT_TOOL, REQUEST_SETUP_TOOL]
+
+_VALID_SETUP_KINDS = {"secret", "mcp", "provider"}
+
+# ---------------------------------------------------------------------------
 # System prompt (static). The large, static part of each turn is the
 # submit_agent_spec tool (its input_schema is the full agent.schema.json);
 # AnthropicProvider auto-caches it via cache_control, so it is not reprocessed
@@ -81,15 +139,36 @@ create a valid agent.yaml configuration by asking just the right questions.
 3. Fill in sensible defaults for everything else: version "1.0.0", team "default", \
    owner "owner@example.com" (unless the user provided a team/owner), min replicas 1 \
    max 3.
-4. Once you have all required fields, immediately call the `submit_agent_spec` tool — do \
-   NOT ask for confirmation, do NOT emit YAML as plain text.
-5. Never reveal or repeat the user's API key or any secret. Never embed secrets in the spec.
-6. Be concise and friendly.
+4. If the agent needs a dependency you cannot supply yourself — an API key/secret, a \
+   model-provider key, or an MCP server/tool — call the `request_setup` tool BEFORE \
+   submitting the spec. The user will be shown a secure inline card to provide it. Once \
+   they confirm it is connected, reference it by name in the spec (under `secrets`, \
+   `mcp_servers`, or `tools`) and then submit. Request only what the agent truly needs.
+5. Once you have all required fields and any needed dependencies are connected, \
+   immediately call the `submit_agent_spec` tool — do NOT ask for confirmation, do NOT \
+   emit YAML as plain text.
+6. Never reveal or repeat the user's API key or any secret. Never embed secret values in \
+   the spec — only references (names).
+7. Be concise and friendly.
 """
 
 # ---------------------------------------------------------------------------
 # Result dataclass
 # ---------------------------------------------------------------------------
+
+
+@dataclass
+class SetupRequest:
+    """A request for the user to provide a dependency before the spec can finish.
+
+    Emitted when the model calls the `request_setup` tool. The frontend renders an
+    inline card; values are captured straight to the secrets / MCP backends and the
+    spec records only a reference (name) — never the value.
+    """
+
+    kind: Literal["secret", "mcp", "provider"]
+    name: str
+    reason: str = ""
 
 
 @dataclass
@@ -108,6 +187,24 @@ class ChatTurnResult:
     errors: list[str] = field(default_factory=list)
     """Validation error messages when valid is False and agent_yaml is set."""
 
+    setup_request: SetupRequest | None = None
+    """Set when the model called request_setup instead of submitting the spec."""
+
+
+@dataclass
+class ChatStreamEvent:
+    """One event from run_chat_turn_stream().
+
+    type == "token":         `text` carries an incremental assistant text fragment.
+    type == "setup_request": `setup` carries a dependency the user must provide.
+    type == "done":          `result` carries the final ChatTurnResult.
+    """
+
+    type: Literal["token", "setup_request", "done"]
+    text: str = ""
+    result: ChatTurnResult | None = None
+    setup: SetupRequest | None = None
+
 
 # ---------------------------------------------------------------------------
 # Core conversation driver
@@ -116,6 +213,21 @@ class ChatTurnResult:
 # Maximum number of messages we'll send to the model in a single turn.
 # The API layer enforces this at the request boundary; we defensively re-check.
 MAX_HISTORY_MESSAGES = 40
+
+
+def _normalise_history(history: list[dict[str, Any]], caller: str) -> list[dict[str, Any]]:
+    """Truncate to MAX_HISTORY_MESSAGES and drop non user/assistant roles, logging both."""
+    if len(history) > MAX_HISTORY_MESSAGES:
+        logger.warning(
+            "%s: history has %d messages (max %d); truncating to last %d",
+            caller, len(history), MAX_HISTORY_MESSAGES, MAX_HISTORY_MESSAGES,
+        )
+        history = history[-MAX_HISTORY_MESSAGES:]
+    allowed_roles = {"user", "assistant"}
+    filtered = [m for m in history if m.get("role") in allowed_roles]
+    if len(filtered) != len(history):
+        logger.warning("%s: dropped %d message(s) with invalid role", caller, len(history) - len(filtered))
+    return filtered
 
 
 async def run_chat_turn(
@@ -136,26 +248,10 @@ async def run_chat_turn(
     Returns:
         ChatTurnResult — see dataclass docstring above.
     """
-    if len(history) > MAX_HISTORY_MESSAGES:
-        logger.warning(
-            "run_chat_turn: history has %d messages (max %d); truncating to last %d",
-            len(history),
-            MAX_HISTORY_MESSAGES,
-            MAX_HISTORY_MESSAGES,
-        )
-        history = history[-MAX_HISTORY_MESSAGES:]
-
-    # Defensively filter out any message whose role is not user/assistant.
-    # This is a belt-and-suspenders guard; the API layer already rejects other
+    # Defensively normalise history: truncate and filter roles.
+    # Belt-and-suspenders guard; the API layer already rejects other
     # roles via Pydantic Literal["user", "assistant"].
-    allowed_roles = {"user", "assistant"}
-    filtered = [m for m in history if m.get("role") in allowed_roles]
-    if len(filtered) != len(history):
-        logger.warning(
-            "run_chat_turn: dropped %d message(s) with invalid role",
-            len(history) - len(filtered),
-        )
-    history = filtered
+    history = _normalise_history(history, "run_chat_turn")
 
     # Build the full messages list with system first.
     # AnthropicProvider._build_payload() extracts the system message.
@@ -169,15 +265,28 @@ async def run_chat_turn(
         messages=messages,
         model=DEFAULT_MODEL,
         max_tokens=2048,
-        tools=[SUBMIT_TOOL],
+        tools=_BUILDER_TOOLS,
     )
 
-    # ── Case A: model called submit_agent_spec ───────────────────────────
+    # ── Case A: model called submit_agent_spec (always wins) ─────────────
     for tool_call in result.tool_calls:
         if tool_call.function_name == SUBMIT_TOOL_NAME:
             return _handle_spec_submission(tool_call.function_arguments)
 
-    # ── Case B: plain text reply ─────────────────────────────────────────
+    # ── Case B: model called request_setup ───────────────────────────────
+    for tool_call in result.tool_calls:
+        if tool_call.function_name == REQUEST_SETUP_TOOL_NAME:
+            setup = _parse_setup_request(tool_call.function_arguments)
+            if setup is not None:
+                return ChatTurnResult(
+                    assistant_message=result.content or "",
+                    agent_yaml=None,
+                    valid=False,
+                    errors=[],
+                    setup_request=setup,
+                )
+
+    # ── Case C: plain text reply ─────────────────────────────────────────
     return ChatTurnResult(
         assistant_message=result.content or "",
         agent_yaml=None,
@@ -186,9 +295,102 @@ async def run_chat_turn(
     )
 
 
+async def run_chat_turn_stream(
+    provider: Any,
+    history: list[dict[str, Any]],
+) -> AsyncIterator[ChatStreamEvent]:
+    """Streaming variant of run_chat_turn().
+
+    Yields ChatStreamEvent(type="token") for each text fragment as it arrives,
+    then exactly one ChatStreamEvent(type="done") with the final ChatTurnResult.
+    Security contract is identical to run_chat_turn(): the key lives inside the
+    injected provider and is never read, logged, or returned here.
+    """
+    history = _normalise_history(history, "run_chat_turn_stream")
+
+    messages: list[dict[str, Any]] = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        *history,
+    ]
+
+    text_parts: list[str] = []
+    submit_args: str | None = None
+    setup_args: str | None = None
+
+    async for chunk in provider.generate_stream(
+        messages=messages,
+        model=DEFAULT_MODEL,
+        max_tokens=2048,
+        tools=_BUILDER_TOOLS,
+    ):
+        if chunk.content:
+            text_parts.append(chunk.content)
+            yield ChatStreamEvent(type="token", text=chunk.content)
+        if chunk.tool_calls:
+            for tc in chunk.tool_calls:
+                if not tc.function_arguments:
+                    continue
+                if tc.function_name == SUBMIT_TOOL_NAME and submit_args is None:
+                    submit_args = tc.function_arguments
+                elif tc.function_name == REQUEST_SETUP_TOOL_NAME and setup_args is None:
+                    setup_args = tc.function_arguments
+
+    # A real spec submission always wins over a setup request in the same turn.
+    if submit_args is not None:
+        result = _handle_spec_submission(submit_args)
+    elif setup_args is not None and (setup := _parse_setup_request(setup_args)) is not None:
+        yield ChatStreamEvent(type="setup_request", setup=setup)
+        result = ChatTurnResult(
+            assistant_message="".join(text_parts),
+            agent_yaml=None,
+            valid=False,
+            errors=[],
+            setup_request=setup,
+        )
+    else:
+        result = ChatTurnResult(
+            assistant_message="".join(text_parts),
+            agent_yaml=None,
+            valid=False,
+            errors=[],
+        )
+    yield ChatStreamEvent(type="done", result=result)
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _parse_setup_request(arguments_json: str) -> SetupRequest | None:
+    """Parse request_setup tool arguments into a SetupRequest.
+
+    The arguments are model-generated (untrusted). Anything malformed — bad JSON,
+    missing fields, or an unrecognised kind — degrades to None (logged) so the turn
+    falls back to a plain text reply rather than raising.
+    """
+    try:
+        data = json.loads(arguments_json)
+    except json.JSONDecodeError as exc:
+        logger.warning("request_setup: JSON decode failed: %s", exc)
+        return None
+
+    if not isinstance(data, dict):
+        logger.warning("request_setup: arguments were not a JSON object")
+        return None
+
+    kind = data.get("kind")
+    name = data.get("name")
+    if kind not in _VALID_SETUP_KINDS or not isinstance(name, str) or not name.strip():
+        logger.warning("request_setup: invalid kind/name (kind=%r)", kind)
+        return None
+
+    reason = data.get("reason")
+    return SetupRequest(
+        kind=kind,
+        name=name.strip(),
+        reason=reason.strip() if isinstance(reason, str) else "",
+    )
 
 
 def _handle_spec_submission(arguments_json: str) -> ChatTurnResult:

--- a/engine/agent_chat_builder.py
+++ b/engine/agent_chat_builder.py
@@ -220,13 +220,18 @@ def _normalise_history(history: list[dict[str, Any]], caller: str) -> list[dict[
     if len(history) > MAX_HISTORY_MESSAGES:
         logger.warning(
             "%s: history has %d messages (max %d); truncating to last %d",
-            caller, len(history), MAX_HISTORY_MESSAGES, MAX_HISTORY_MESSAGES,
+            caller,
+            len(history),
+            MAX_HISTORY_MESSAGES,
+            MAX_HISTORY_MESSAGES,
         )
         history = history[-MAX_HISTORY_MESSAGES:]
     allowed_roles = {"user", "assistant"}
     filtered = [m for m in history if m.get("role") in allowed_roles]
     if len(filtered) != len(history):
-        logger.warning("%s: dropped %d message(s) with invalid role", caller, len(history) - len(filtered))
+        logger.warning(
+            "%s: dropped %d message(s) with invalid role", caller, len(history) - len(filtered)
+        )
     return filtered
 
 

--- a/engine/coding_agent/__init__.py
+++ b/engine/coding_agent/__init__.py
@@ -1,0 +1,1 @@
+"""Provider-loop coding agent for the builder's eject-to-code flow."""

--- a/engine/coding_agent/base.py
+++ b/engine/coding_agent/base.py
@@ -1,0 +1,106 @@
+"""Coding-agent contracts: events, bounds, the engine protocol, and the
+sandbox-scoped tool surface (write/read/list/exec) shared by all engines."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Any, Literal, Protocol
+
+from engine.providers.models import ToolDefinition, ToolFunction
+from engine.sandbox.base import Sandbox
+
+AgentEventType = Literal["token", "tool_call", "file_change", "done", "error"]
+
+
+@dataclass
+class AgentEvent:
+    """One event emitted by a coding-agent run."""
+
+    type: AgentEventType
+    text: str = ""  # token text / done summary
+    tool_name: str = ""  # for tool_call
+    path: str = ""  # for file_change
+    diff: str = ""  # unified diff for file_change
+    error: str = ""  # for error
+
+
+@dataclass
+class AgentBounds:
+    """Hard bounds on a coding-agent run."""
+
+    max_turns: int = 12
+    max_tokens: int = 200_000
+    wall_clock_s: float = 180.0
+
+
+def _tool(name: str, description: str, params: dict[str, Any]) -> ToolDefinition:
+    return ToolDefinition(
+        type="function",
+        function=ToolFunction(name=name, description=description, parameters=params),
+    )
+
+
+CODING_TOOLS: list[ToolDefinition] = [
+    _tool(
+        "write_file",
+        "Create or overwrite a file in the agent project workspace.",
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "path": {"type": "string", "description": "Workspace-relative path."},
+                "content": {"type": "string", "description": "Full file contents."},
+            },
+            "required": ["path", "content"],
+        },
+    ),
+    _tool(
+        "read_file",
+        "Read a file from the workspace.",
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+    ),
+    _tool(
+        "list_files",
+        "List files in the workspace (recursively).",
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {"directory": {"type": "string", "default": "."}},
+        },
+    ),
+    _tool(
+        "run_command",
+        "Run a shell command in the workspace (e.g. run tests). Bounded by a timeout.",
+        {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "cmd": {"type": "array", "items": {"type": "string"}},
+                "timeout": {"type": "number", "default": 30},
+            },
+            "required": ["cmd"],
+        },
+    ),
+]
+
+TOOL_NAMES: set[str] = {t.function.name for t in CODING_TOOLS}
+
+
+class CodingAgentEngine(Protocol):
+    """Strategy: which provider+model+system-prompt drives the shared loop."""
+
+    name: str
+
+    def run(
+        self,
+        instruction: str,
+        history: list[dict[str, str]],
+        sandbox: Sandbox,
+        bounds: AgentBounds | None = None,
+    ) -> AsyncIterator[AgentEvent]: ...

--- a/engine/coding_agent/engines.py
+++ b/engine/coding_agent/engines.py
@@ -1,0 +1,65 @@
+"""Claude / Codex coding-agent strategies over the shared provider loop.
+
+Each engine is a thin strategy: it owns the model id + system prompt and hands
+an injected provider to run_coding_loop(). The provider is constructed by the
+API layer from the BYO key in the secrets backend (never here).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from engine.coding_agent.base import AgentBounds, AgentEvent
+from engine.coding_agent.loop import run_coding_loop
+from engine.sandbox.base import Sandbox
+
+_CODING_SYSTEM_PROMPT = """\
+You are AgentBreeder's coding agent. You are ejecting a validated agent.yaml into
+real code. Write agent.py, any tools/ modules, and tests into the workspace using
+the provided tools. Keep the code framework-correct for the chosen framework, runnable,
+and covered by at least one test. Use write_file to create files, run_command to run
+tests, and stop when the project is complete. Never print secrets."""
+
+
+class _BaseEngine:
+    name: str = ""
+    model: str = ""
+
+    def __init__(self, provider: Any) -> None:
+        self._provider = provider
+
+    def run(
+        self,
+        instruction: str,
+        history: list[dict[str, str]],
+        sandbox: Sandbox,
+        bounds: AgentBounds | None = None,
+    ) -> AsyncIterator[AgentEvent]:
+        return run_coding_loop(
+            provider=self._provider,
+            model=self.model,
+            system_prompt=_CODING_SYSTEM_PROMPT,
+            instruction=instruction,
+            history=history,
+            sandbox=sandbox,
+            bounds=bounds,
+        )
+
+
+class ClaudeAgentEngine(_BaseEngine):
+    name = "claude"
+    model = "claude-sonnet-4-6"
+
+
+class CodexEngine(_BaseEngine):
+    name = "codex"
+    model = "gpt-4o"
+
+
+def engine_for(name: str, *, provider: Any) -> _BaseEngine:
+    if name == "claude":
+        return ClaudeAgentEngine(provider)
+    if name == "codex":
+        return CodexEngine(provider)
+    raise ValueError(f"unknown coding engine: {name!r} (expected 'claude' or 'codex')")

--- a/engine/coding_agent/loop.py
+++ b/engine/coding_agent/loop.py
@@ -1,0 +1,146 @@
+"""The shared provider-loop driver.
+
+Drives one ``generate_stream()`` turn at a time, executing the model's
+write/read/list/exec tool calls against the sandbox and feeding the results
+back as OpenAI-format tool messages (role="tool", tool_call_id=...), which the
+provider abstraction normalises per backend. Bounded by AgentBounds.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import logging
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+from engine.coding_agent.base import (
+    CODING_TOOLS,
+    TOOL_NAMES,
+    AgentBounds,
+    AgentEvent,
+)
+from engine.providers.models import ToolCall
+from engine.sandbox.base import Sandbox
+
+logger = logging.getLogger(__name__)
+
+
+def _unified_diff(path: str, old: str, new: str) -> str:
+    return "".join(
+        difflib.unified_diff(
+            old.splitlines(keepends=True),
+            new.splitlines(keepends=True),
+            fromfile=f"a/{path}",
+            tofile=f"b/{path}",
+        )
+    )
+
+
+async def _apply_tool(sandbox: Sandbox, tc: ToolCall) -> tuple[str, AgentEvent | None]:
+    """Execute one tool call.
+
+    Returns ``(result_text_for_model, optional file_change event)``.
+    """
+    try:
+        args = json.loads(tc.function_arguments or "{}")
+    except json.JSONDecodeError:
+        return (f"ERROR: malformed arguments for {tc.function_name}", None)
+
+    name = tc.function_name
+    if name == "write_file":
+        path, content = args.get("path", ""), args.get("content", "")
+        try:
+            old = await sandbox.read(path)
+        except FileNotFoundError:
+            old = ""
+        await sandbox.write(path, content)
+        diff = _unified_diff(path, old, content)
+        return (
+            f"wrote {path} ({len(content)} bytes)",
+            AgentEvent(type="file_change", path=path, diff=diff),
+        )
+    if name == "read_file":
+        try:
+            return (await sandbox.read(args.get("path", "")), None)
+        except FileNotFoundError:
+            return (f"ERROR: file not found: {args.get('path')}", None)
+    if name == "list_files":
+        files = await sandbox.list(args.get("directory", "."))
+        return ("\n".join(files), None)
+    if name == "run_command":
+        res = await sandbox.exec(args.get("cmd", []), timeout=float(args.get("timeout", 30)))
+        body = f"exit={res.exit_code} timed_out={res.timed_out}\n{res.stdout}\n{res.stderr}"
+        return (body, None)
+    return (f"ERROR: unknown tool {name}", None)
+
+
+async def run_coding_loop(
+    *,
+    provider: Any,
+    model: str,
+    system_prompt: str,
+    instruction: str,
+    history: list[dict[str, str]],
+    sandbox: Sandbox,
+    bounds: AgentBounds | None = None,
+) -> AsyncIterator[AgentEvent]:
+    """Run the coding agent until it stops calling tools or a bound trips."""
+    bounds = bounds or AgentBounds()
+    started = time.monotonic()
+    tokens_seen = 0
+
+    messages: list[dict[str, Any]] = [{"role": "system", "content": system_prompt}]
+    messages.extend(history)
+    messages.append({"role": "user", "content": instruction})
+
+    for _turn in range(bounds.max_turns):
+        if time.monotonic() - started > bounds.wall_clock_s:
+            yield AgentEvent(type="done", text="stopped: wall-clock bound reached")
+            return
+
+        text_parts: list[str] = []
+        tool_calls: list[ToolCall] = []
+        async for chunk in provider.generate_stream(messages, model=model, tools=CODING_TOOLS):
+            if chunk.content:
+                text_parts.append(chunk.content)
+                tokens_seen += len(chunk.content)
+                yield AgentEvent(type="token", text=chunk.content)
+            if chunk.tool_calls:
+                tool_calls.extend(chunk.tool_calls)
+
+        if not tool_calls:
+            yield AgentEvent(type="done", text="".join(text_parts))
+            return
+
+        messages.append(
+            {
+                "role": "assistant",
+                "content": "".join(text_parts),
+                "tool_calls": [tc.model_dump() for tc in tool_calls],
+            }
+        )
+
+        for tc in tool_calls:
+            if tc.function_name not in TOOL_NAMES:
+                result = f"ERROR: tool {tc.function_name} is not available"
+                fc = None
+            else:
+                yield AgentEvent(type="tool_call", tool_name=tc.function_name)
+                result, fc = await _apply_tool(sandbox, tc)
+            if fc is not None:
+                yield fc
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tc.id,
+                    "content": result[:20_000],
+                }
+            )
+
+        if tokens_seen > bounds.max_tokens:
+            yield AgentEvent(type="done", text="stopped: token bound reached")
+            return
+
+    yield AgentEvent(type="done", text="stopped: max turns reached")

--- a/engine/providers/anthropic_provider.py
+++ b/engine/providers/anthropic_provider.py
@@ -125,6 +125,11 @@ class AnthropicProvider(ProviderBase):
         payload = self._build_payload(messages, resolved_model, temperature, max_tokens, tools)
         payload["stream"] = True
 
+        # Per-index accumulator for tool_use content blocks.
+        # Keyed by block index; each entry holds the block id, name, and the
+        # running concatenation of input_json_delta.partial_json fragments.
+        _tool_blocks: dict[int, dict[str, str]] = {}
+
         async with self._client.stream("POST", "/messages", json=payload) as resp:
             self._check_status(resp.status_code, "")
             async for line in resp.aiter_lines():
@@ -135,11 +140,67 @@ class AnthropicProvider(ProviderBase):
                     continue
                 try:
                     event_data = json.loads(data)
-                    chunk = self._parse_stream_event(event_data)
-                    if chunk is not None:
-                        yield chunk
                 except json.JSONDecodeError:
                     logger.warning("Failed to parse Anthropic stream event: %s", data)
+                    continue
+
+                event_type = event_data.get("type")
+
+                # ── Tool-use block accumulation ───────────────────────────
+                if event_type == "content_block_start":
+                    block = event_data.get("content_block", {})
+                    if block.get("type") == "tool_use":
+                        idx = event_data.get("index", 0)
+                        _tool_blocks[idx] = {
+                            "id": block.get("id", ""),
+                            "name": block.get("name", ""),
+                            "json_buf": "",
+                        }
+                    continue
+
+                if event_type == "content_block_delta":
+                    idx = event_data.get("index", 0)
+                    delta = event_data.get("delta", {})
+                    delta_type = delta.get("type")
+                    if delta_type == "input_json_delta" and idx in _tool_blocks:
+                        _tool_blocks[idx]["json_buf"] += delta.get("partial_json", "")
+                        continue
+                    # text_delta (and any unknown delta type) fall through to
+                    # the stateless parser below
+
+                if event_type == "content_block_stop":
+                    idx = event_data.get("index", 0)
+                    if idx in _tool_blocks:
+                        entry = _tool_blocks.pop(idx)
+                        yield StreamChunk(
+                            tool_calls=[
+                                ToolCall(
+                                    id=entry["id"],
+                                    function_name=entry["name"],
+                                    function_arguments=entry["json_buf"],
+                                )
+                            ],
+                            model="",
+                        )
+                    continue
+
+                # ── Stateless events (text deltas, message_start, finish) ─
+                chunk = self._parse_stream_event(event_data)
+                if chunk is not None:
+                    yield chunk
+
+        # Safety: flush any tool blocks that never received content_block_stop
+        for entry in _tool_blocks.values():
+            yield StreamChunk(
+                tool_calls=[
+                    ToolCall(
+                        id=entry["id"],
+                        function_name=entry["name"],
+                        function_arguments=entry["json_buf"],
+                    )
+                ],
+                model="",
+            )
 
     async def list_models(self) -> list[ModelInfo]:
         response = await self._request("GET", "/models")

--- a/engine/providers/anthropic_provider.py
+++ b/engine/providers/anthropic_provider.py
@@ -241,22 +241,60 @@ class AnthropicProvider(ProviderBase):
 
     def _build_payload(
         self,
-        messages: list[dict[str, str]],
+        messages: list[dict[str, Any]],
         model: str,
         temperature: float | None,
         max_tokens: int | None,
         tools: list[ToolDefinition] | None,
     ) -> dict[str, Any]:
-        # Split system message out; Anthropic puts it in a top-level field
+        # Split system message out; Anthropic puts it in a top-level field.
+        # Tool-loop turns (assistant tool_calls + role="tool" results) are
+        # translated into Anthropic tool_use / tool_result content blocks.
         system_content: str | None = None
         non_system: list[dict[str, Any]] = []
+        pending_tool_results: list[dict[str, Any]] = []
+
+        def _flush_tool_results() -> None:
+            if pending_tool_results:
+                non_system.append({"role": "user", "content": list(pending_tool_results)})
+                pending_tool_results.clear()
+
         for msg in messages:
-            if msg.get("role") == "system":
+            role = msg.get("role", "user")
+            if role == "system":
                 system_content = msg.get("content", "")
+                continue
+            if role == "tool":
+                pending_tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": msg.get("tool_call_id", ""),
+                        "content": msg.get("content", ""),
+                    }
+                )
+                continue
+            _flush_tool_results()
+            if role == "assistant" and msg.get("tool_calls"):
+                blocks: list[dict[str, Any]] = []
+                if msg.get("content"):
+                    blocks.append({"type": "text", "text": msg["content"]})
+                for tc in msg["tool_calls"]:
+                    name = tc.get("function_name") or tc.get("function", {}).get("name", "")
+                    raw = tc.get("function_arguments") or tc.get("function", {}).get(
+                        "arguments", "{}"
+                    )
+                    try:
+                        parsed = json.loads(raw) if isinstance(raw, str) else raw
+                    except json.JSONDecodeError:
+                        parsed = {}
+                    blocks.append(
+                        {"type": "tool_use", "id": tc.get("id", ""), "name": name, "input": parsed}
+                    )
+                non_system.append({"role": "assistant", "content": blocks})
             else:
-                role = msg.get("role", "user")
                 # Anthropic uses "assistant" same as OpenAI; "user" → "user"
                 non_system.append({"role": role, "content": msg.get("content", "")})
+        _flush_tool_results()
 
         payload: dict[str, Any] = {
             "model": model,

--- a/engine/providers/openai_provider.py
+++ b/engine/providers/openai_provider.py
@@ -156,16 +156,43 @@ class OpenAIProvider(ProviderBase):
 
     def _build_payload(
         self,
-        messages: list[dict[str, str]],
+        messages: list[dict[str, Any]],
         model: str,
         temperature: float | None,
         max_tokens: int | None,
         tools: list[ToolDefinition] | None,
         stream: bool,
     ) -> dict[str, Any]:
+        # Translate our internal ToolCall shape (function_name / function_arguments)
+        # into OpenAI's wire shape (function.name / function.arguments). Plain-text
+        # turns and tool-result turns pass through verbatim.
+        norm_messages: list[dict[str, Any]] = []
+        for msg in messages:
+            if msg.get("role") == "assistant" and msg.get("tool_calls"):
+                norm_messages.append(
+                    {
+                        "role": "assistant",
+                        "content": msg.get("content") or None,
+                        "tool_calls": [
+                            {
+                                "id": tc.get("id", ""),
+                                "type": "function",
+                                "function": {
+                                    "name": tc.get("function_name")
+                                    or tc.get("function", {}).get("name", ""),
+                                    "arguments": tc.get("function_arguments")
+                                    or tc.get("function", {}).get("arguments", "{}"),
+                                },
+                            }
+                            for tc in msg["tool_calls"]
+                        ],
+                    }
+                )
+            else:
+                norm_messages.append(dict(msg))
         payload: dict[str, Any] = {
             "model": model,
-            "messages": messages,
+            "messages": norm_messages,
         }
         if temperature is not None:
             payload["temperature"] = temperature

--- a/engine/sandbox/__init__.py
+++ b/engine/sandbox/__init__.py
@@ -1,0 +1,1 @@
+"""Pluggable sandbox interface for the conversational builder's eject-to-code flow."""

--- a/engine/sandbox/backends/__init__.py
+++ b/engine/sandbox/backends/__init__.py
@@ -1,0 +1,25 @@
+"""Pluggable execution backends for CloudSandbox.
+
+CloudSandbox is a thin Sandbox-Protocol client; the backend is the substrate
+that actually runs code (e2b microVM in prod, FakeBackend in tests). Selected by
+AGENTBREEDER_SANDBOX_BACKEND (default 'e2b').
+"""
+
+from __future__ import annotations
+
+import os
+
+from engine.sandbox.backends.base import SandboxBackend
+
+
+def make_backend_from_env() -> SandboxBackend:
+    name = os.environ.get("AGENTBREEDER_SANDBOX_BACKEND", "e2b").strip().lower()
+    if name == "e2b":
+        from engine.sandbox.backends.e2b import E2BBackend
+
+        return E2BBackend()
+    if name == "fake":
+        from engine.sandbox.backends.fake import FakeBackend
+
+        return FakeBackend()
+    raise ValueError(f"unknown AGENTBREEDER_SANDBOX_BACKEND={name!r}")

--- a/engine/sandbox/backends/base.py
+++ b/engine/sandbox/backends/base.py
@@ -1,0 +1,25 @@
+"""SandboxBackend — the execution substrate behind CloudSandbox.
+
+The backend deals in already-validated, workspace-relative paths; CloudSandbox
+applies path containment + size/timeout caps before delegating here. This split
+keeps the security boundary in one place (cloud.py) and lets us swap e2b for a
+self-hosted Firecracker backend without touching callers.
+"""
+
+from __future__ import annotations
+
+import builtins
+from typing import Protocol, runtime_checkable
+
+from engine.sandbox.base import ExecResult
+
+
+@runtime_checkable
+class SandboxBackend(Protocol):
+    async def start(self) -> None: ...
+    async def write_file(self, path: str, content: str) -> None: ...
+    async def read_file(self, path: str) -> str: ...
+    async def list_files(self, directory: str = ".") -> builtins.list[str]: ...
+    async def run(self, cmd: builtins.list[str], timeout: float) -> ExecResult: ...
+    async def snapshot(self) -> bytes: ...
+    async def destroy(self) -> None: ...

--- a/engine/sandbox/backends/e2b.py
+++ b/engine/sandbox/backends/e2b.py
@@ -1,0 +1,84 @@
+"""E2BBackend — managed Firecracker microVM via the e2b async SDK (Wave 4).
+
+SECURITY (design §11.2): no long-lived secrets are injected; egress is a
+default-deny allowlist (LLM endpoints + PyPI + npm) configured on the e2b
+template; CPU/mem/wall-clock caps come from the template + per-call timeouts.
+e2b is a third-party sub-processor — requires a signed DPA + privacy-policy
+disclosure before GA (see design §11.2 / Open Q #1).
+
+This backend is not unit-tested (it hits e2b); it is covered by the gated
+integration test in tests/integration/test_e2b_backend.py and Part D's live path.
+"""
+
+from __future__ import annotations
+
+import builtins
+import io
+import os
+import shlex
+import zipfile
+
+from engine.sandbox.base import ExecResult
+
+# Workspace root inside the microVM.
+_WORKDIR = "/home/user/project"
+_TEMPLATE = os.environ.get("AGENTBREEDER_E2B_TEMPLATE", "base")
+
+
+class E2BBackend:
+    """Thin adapter over e2b's AsyncSandbox. One microVM per builder session."""
+
+    def __init__(self) -> None:
+        self._sbx = None  # type: ignore[var-annotated]
+
+    async def start(self) -> None:
+        from e2b import AsyncSandbox  # imported lazily so the dep stays optional
+
+        # NB: verify kwargs against the installed e2b version (see Task A3 note).
+        self._sbx = await AsyncSandbox.create(template=_TEMPLATE)
+        await self._sbx.files.make_dir(_WORKDIR)
+
+    def _abs(self, path: str) -> str:
+        return f"{_WORKDIR}/{path}"
+
+    async def write_file(self, path: str, content: str) -> None:
+        await self._sbx.files.write(self._abs(path), content)
+
+    async def read_file(self, path: str) -> str:
+        return await self._sbx.files.read(self._abs(path))
+
+    async def list_files(self, directory: str = ".") -> builtins.list[str]:
+        base = _WORKDIR if directory in (".", "") else self._abs(directory)
+        entries = await self._sbx.files.list(base)
+        # Return workspace-relative file paths only.
+        out: list[str] = []
+        for e in entries:
+            full = getattr(e, "path", str(e))
+            if getattr(e, "is_dir", False):
+                continue
+            out.append(full.removeprefix(f"{_WORKDIR}/"))
+        return sorted(out)
+
+    async def run(self, cmd: builtins.list[str], timeout: float) -> ExecResult:
+        joined = " ".join(shlex.quote(c) for c in cmd)
+        try:
+            res = await self._sbx.commands.run(joined, cwd=_WORKDIR, timeout=int(timeout))
+        except Exception as exc:  # e2b raises on non-zero/timeout in some versions
+            return ExecResult(stdout="", stderr=str(exc), exit_code=1)
+        return ExecResult(
+            stdout=getattr(res, "stdout", "") or "",
+            stderr=getattr(res, "stderr", "") or "",
+            exit_code=int(getattr(res, "exit_code", 0) or 0),
+        )
+
+    async def snapshot(self) -> bytes:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            for rel in await self.list_files("."):
+                zf.writestr(rel, await self.read_file(rel))
+        return buf.getvalue()
+
+    async def destroy(self) -> None:
+        if self._sbx is not None:
+            await self._sbx.kill()
+            self._sbx = None

--- a/engine/sandbox/backends/e2b.py
+++ b/engine/sandbox/backends/e2b.py
@@ -17,6 +17,7 @@ import io
 import os
 import shlex
 import zipfile
+from typing import Any
 
 from engine.sandbox.base import ExecResult
 
@@ -29,7 +30,8 @@ class E2BBackend:
     """Thin adapter over e2b's AsyncSandbox. One microVM per builder session."""
 
     def __init__(self) -> None:
-        self._sbx = None  # type: ignore[var-annotated]
+        # e2b AsyncSandbox (untyped here so the dep stays optional).
+        self._sbx: Any = None
 
     async def start(self) -> None:
         from e2b import AsyncSandbox  # imported lazily so the dep stays optional
@@ -45,7 +47,7 @@ class E2BBackend:
         await self._sbx.files.write(self._abs(path), content)
 
     async def read_file(self, path: str) -> str:
-        return await self._sbx.files.read(self._abs(path))
+        return str(await self._sbx.files.read(self._abs(path)))
 
     async def list_files(self, directory: str = ".") -> builtins.list[str]:
         base = _WORKDIR if directory in (".", "") else self._abs(directory)

--- a/engine/sandbox/backends/fake.py
+++ b/engine/sandbox/backends/fake.py
@@ -1,0 +1,48 @@
+"""In-memory SandboxBackend for unit tests — no network, no subprocess."""
+
+from __future__ import annotations
+
+import builtins
+import io
+import zipfile
+
+from engine.sandbox.base import ExecResult
+
+
+class FakeBackend:
+    """Records lifecycle; stores files in a dict; run() returns a canned success."""
+
+    def __init__(self) -> None:
+        self.files: dict[str, str] = {}
+        self.started = False
+        self.destroyed = False
+        self.commands: list[list[str]] = []
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def write_file(self, path: str, content: str) -> None:
+        self.files[path] = content
+
+    async def read_file(self, path: str) -> str:
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        return self.files[path]
+
+    async def list_files(self, directory: str = ".") -> builtins.list[str]:
+        prefix = "" if directory in (".", "") else f"{directory.rstrip('/')}/"
+        return sorted(p for p in self.files if p.startswith(prefix))
+
+    async def run(self, cmd: builtins.list[str], timeout: float) -> ExecResult:
+        self.commands.append(cmd)
+        return ExecResult(stdout="", stderr="", exit_code=0)
+
+    async def snapshot(self) -> bytes:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            for path, content in sorted(self.files.items()):
+                zf.writestr(path, content)
+        return buf.getvalue()
+
+    async def destroy(self) -> None:
+        self.destroyed = True

--- a/engine/sandbox/base.py
+++ b/engine/sandbox/base.py
@@ -1,0 +1,61 @@
+"""Sandbox interface — a pluggable scaffold workspace for the coding agent.
+
+LocalSandbox runs on the host (local single-user Studio only). CloudSandbox
+(Wave 4) runs in a managed microVM. The AGENTBREEDER_SANDBOX env gate decides
+which the server is permitted to construct so the multi-tenant cloud can never
+run user code in-process.
+"""
+
+from __future__ import annotations
+
+import builtins
+import os
+from dataclasses import dataclass
+from typing import Literal, Protocol, runtime_checkable
+
+SandboxMode = Literal["local", "cloud", "disabled"]
+_VALID_MODES: frozenset[str] = frozenset({"local", "cloud", "disabled"})
+
+
+class SandboxDisabledError(RuntimeError):
+    """Raised when a sandbox is requested but disallowed by configuration."""
+
+
+@dataclass
+class ExecResult:
+    """Result of running a command inside a sandbox."""
+
+    stdout: str
+    stderr: str
+    exit_code: int
+    timed_out: bool = False
+
+    @property
+    def ok(self) -> bool:
+        return self.exit_code == 0 and not self.timed_out
+
+
+def select_sandbox_mode() -> SandboxMode:
+    """Return the configured sandbox mode (defaults to ``local``).
+
+    Raises SandboxDisabledError on an unrecognised value rather than silently
+    falling back, so a misconfigured cloud deploy fails closed.
+    """
+    raw = os.environ.get("AGENTBREEDER_SANDBOX", "local").strip().lower()
+    if raw not in _VALID_MODES:
+        raise SandboxDisabledError(
+            f"AGENTBREEDER_SANDBOX={raw!r} is not one of {sorted(_VALID_MODES)}"
+        )
+    return raw  # type: ignore[return-value]
+
+
+@runtime_checkable
+class Sandbox(Protocol):
+    """A scaffold workspace the coding agent reads from and writes into."""
+
+    async def write(self, path: str, content: str) -> None: ...
+    async def read(self, path: str) -> str: ...
+    async def list(self, directory: str = ".") -> builtins.list[str]: ...
+    async def exec(self, cmd: builtins.list[str], timeout: float = 30.0) -> ExecResult: ...
+    async def snapshot(self) -> bytes: ...
+    async def close(self) -> None: ...

--- a/engine/sandbox/cloud.py
+++ b/engine/sandbox/cloud.py
@@ -1,0 +1,77 @@
+"""CloudSandbox — Sandbox Protocol over a managed microVM backend (Wave 4).
+
+SECURITY (design §11.2): this is the single place client-side guards live —
+path containment + per-file/byte and exec-timeout caps — applied BEFORE the
+backend runs anything. The microVM is defense-in-depth, not a reason to drop
+these checks. No long-lived secrets are placed in the workspace.
+"""
+
+from __future__ import annotations
+
+import builtins
+import time
+from pathlib import PurePosixPath
+
+from engine.sandbox.backends.base import SandboxBackend
+from engine.sandbox.base import ExecResult
+
+_MAX_EXEC_TIMEOUT = 120.0
+_MAX_FILE_BYTES = 1_000_000  # 1 MB per file cap (parity with LocalSandbox)
+
+
+def _safe_relpath(path: str) -> str:
+    """Return a normalized workspace-relative path or raise on escape."""
+    if path.startswith("/") or path.startswith("\\"):
+        raise ValueError(f"absolute paths are not allowed: {path!r}")
+    parts: list[str] = []
+    for part in PurePosixPath(path).parts:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            raise ValueError(f"path escapes the sandbox workspace: {path!r}")
+        parts.append(part)
+    return "/".join(parts)
+
+
+class CloudSandbox:
+    """Sandbox backed by a managed microVM (via a pluggable SandboxBackend)."""
+
+    def __init__(self, backend: SandboxBackend) -> None:
+        self._backend = backend
+        self._started = False
+        self._t0: float | None = None
+        self.elapsed_seconds: float = 0.0
+
+    async def _ensure_started(self) -> None:
+        if not self._started:
+            await self._backend.start()
+            self._started = True
+            self._t0 = time.monotonic()
+
+    async def write(self, path: str, content: str) -> None:
+        if len(content.encode("utf-8")) > _MAX_FILE_BYTES:
+            raise ValueError(f"file exceeds {_MAX_FILE_BYTES} byte cap: {path!r}")
+        await self._ensure_started()
+        await self._backend.write_file(_safe_relpath(path), content)
+
+    async def read(self, path: str) -> str:
+        await self._ensure_started()
+        return await self._backend.read_file(_safe_relpath(path))
+
+    async def list(self, directory: str = ".") -> builtins.list[str]:
+        await self._ensure_started()
+        norm = _safe_relpath(directory) if directory not in (".", "") else "."
+        return await self._backend.list_files(norm)
+
+    async def exec(self, cmd: builtins.list[str], timeout: float = 30.0) -> ExecResult:
+        await self._ensure_started()
+        return await self._backend.run(cmd, min(timeout, _MAX_EXEC_TIMEOUT))
+
+    async def snapshot(self) -> bytes:
+        await self._ensure_started()
+        return await self._backend.snapshot()
+
+    async def close(self) -> None:
+        if self._t0 is not None:
+            self.elapsed_seconds = time.monotonic() - self._t0
+        await self._backend.destroy()

--- a/engine/sandbox/local.py
+++ b/engine/sandbox/local.py
@@ -1,0 +1,96 @@
+"""LocalSandbox — temp-dir + subprocess scaffold workspace for local Studio.
+
+SECURITY: runs commands on the host. Only constructed when AGENTBREEDER_SANDBOX
+is 'local'. The server guards construction (see api/services/builder_session_service).
+All paths are contained within the workspace root; absolute paths and '..' escapes
+are rejected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import builtins
+import io
+import logging
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+
+from engine.sandbox.base import ExecResult
+
+logger = logging.getLogger(__name__)
+
+_MAX_EXEC_TIMEOUT = 120.0
+_MAX_FILE_BYTES = 1_000_000  # 1 MB per file cap
+
+
+class LocalSandbox:
+    """In-process sandbox backed by a temporary directory."""
+
+    def __init__(self, prefix: str = "agentbreeder-builder-") -> None:
+        self.root: Path = Path(tempfile.mkdtemp(prefix=prefix)).resolve()
+
+    def _resolve(self, path: str) -> Path:
+        """Resolve ``path`` strictly inside the workspace root."""
+        if path.startswith("/") or path.startswith("\\"):
+            raise ValueError(f"absolute paths are not allowed: {path!r}")
+        candidate = (self.root / path).resolve()
+        if candidate != self.root and self.root not in candidate.parents:
+            raise ValueError(f"path escapes the sandbox workspace: {path!r}")
+        return candidate
+
+    async def write(self, path: str, content: str) -> None:
+        if len(content.encode("utf-8")) > _MAX_FILE_BYTES:
+            raise ValueError(f"file exceeds {_MAX_FILE_BYTES} byte cap: {path!r}")
+        target = self._resolve(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+
+    async def read(self, path: str) -> str:
+        target = self._resolve(path)
+        if not target.is_file():
+            raise FileNotFoundError(path)
+        return target.read_text(encoding="utf-8")
+
+    async def list(self, directory: str = ".") -> builtins.list[str]:
+        base = self._resolve(directory)
+        if not base.exists():
+            return []
+        return sorted(str(p.relative_to(self.root)) for p in base.rglob("*") if p.is_file())
+
+    async def exec(  # pragma: no cover - exercised in Task A3
+        self, cmd: builtins.list[str], timeout: float = 30.0
+    ) -> ExecResult:
+        timeout = min(timeout, _MAX_EXEC_TIMEOUT)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                cwd=str(self.root),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError as exc:
+            return ExecResult(stdout="", stderr=str(exc), exit_code=127)
+        try:
+            out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return ExecResult(stdout="", stderr="timed out", exit_code=124, timed_out=True)
+        return ExecResult(
+            stdout=out.decode("utf-8", "replace"),
+            stderr=err.decode("utf-8", "replace"),
+            exit_code=proc.returncode if proc.returncode is not None else -1,
+        )
+
+    async def snapshot(self) -> bytes:  # pragma: no cover - exercised in Task A3
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            for path in sorted(self.root.rglob("*")):
+                if path.is_file():
+                    zf.write(path, arcname=str(path.relative_to(self.root)))
+        return buf.getvalue()
+
+    async def close(self) -> None:
+        shutil.rmtree(self.root, ignore_errors=True)

--- a/engine/sandbox/local.py
+++ b/engine/sandbox/local.py
@@ -59,9 +59,7 @@ class LocalSandbox:
             return []
         return sorted(str(p.relative_to(self.root)) for p in base.rglob("*") if p.is_file())
 
-    async def exec(  # pragma: no cover - exercised in Task A3
-        self, cmd: builtins.list[str], timeout: float = 30.0
-    ) -> ExecResult:
+    async def exec(self, cmd: builtins.list[str], timeout: float = 30.0) -> ExecResult:
         timeout = min(timeout, _MAX_EXEC_TIMEOUT)
         try:
             proc = await asyncio.create_subprocess_exec(
@@ -84,7 +82,7 @@ class LocalSandbox:
             exit_code=proc.returncode if proc.returncode is not None else -1,
         )
 
-    async def snapshot(self) -> bytes:  # pragma: no cover - exercised in Task A3
+    async def snapshot(self) -> bytes:
         buf = io.BytesIO()
         with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
             for path in sorted(self.root.rglob("*")):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,10 @@ pdf = [
     # Without it the service falls back to a regex BT/ET parser.
     "PyPDF2>=3.0.0",
 ]
+cloud = [
+    # W4: e2b managed microVM backend for CloudSandbox (multi-tenant builder).
+    "e2b>=1.0,<2.0",
+]
 all-clouds = [
     "boto3>=1.34.0",
     "azure-identity>=1.16.0",

--- a/tests/e2e/test_builder_eject_codex_e2e.py
+++ b/tests/e2e/test_builder_eject_codex_e2e.py
@@ -1,0 +1,45 @@
+"""Gated e2e: the Codex engine writes real code against a live OpenAI model.
+
+Skipped unless AGENTBREEDER_E2E_OPENAI_KEY is set (BYO key, costs tokens).
+Mirrors test_builder_eject_e2e.py (the Claude path) for engine parity.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from engine.coding_agent.base import AgentBounds
+from engine.coding_agent.engines import engine_for
+from engine.providers.models import ProviderConfig, ProviderType
+from engine.providers.openai_provider import OpenAIProvider
+from engine.sandbox.local import LocalSandbox
+
+_KEY = os.environ.get("AGENTBREEDER_E2E_OPENAI_KEY")
+
+pytestmark = pytest.mark.skipif(not _KEY, reason="AGENTBREEDER_E2E_OPENAI_KEY not set")
+
+
+@pytest.mark.asyncio
+async def test_eject_writes_agent_py_against_live_codex():
+    provider = OpenAIProvider(ProviderConfig(provider_type=ProviderType.openai, api_key=_KEY))
+    sandbox = LocalSandbox()
+    try:
+        engine = engine_for("codex", provider=provider)
+        instruction = (
+            "Create a minimal Python agent project for this spec:\n"
+            "name: hello-agent\nframework: custom\n"
+            "Write agent.py with a `run(input: str) -> str` function that echoes "
+            "the input, and tools/__init__.py. Use write_file for each file, then stop."
+        )
+        file_changes: list[str] = []
+        async for evt in engine.run(instruction, [], sandbox, AgentBounds(max_turns=6)):
+            if evt.type == "file_change":
+                file_changes.append(evt.path)
+        assert any(p.endswith("agent.py") for p in file_changes), file_changes
+        files = await sandbox.list(".")
+        assert any(p.endswith("agent.py") for p in files), files
+    finally:
+        await sandbox.close()
+        await provider.close()

--- a/tests/e2e/test_builder_eject_e2e.py
+++ b/tests/e2e/test_builder_eject_e2e.py
@@ -20,9 +20,7 @@ from engine.sandbox.local import LocalSandbox
 
 _KEY = os.environ.get("AGENTBREEDER_E2E_ANTHROPIC_KEY")
 
-pytestmark = pytest.mark.skipif(
-    not _KEY, reason="AGENTBREEDER_E2E_ANTHROPIC_KEY not set"
-)
+pytestmark = pytest.mark.skipif(not _KEY, reason="AGENTBREEDER_E2E_ANTHROPIC_KEY not set")
 
 
 @pytest.mark.asyncio

--- a/tests/e2e/test_builder_eject_e2e.py
+++ b/tests/e2e/test_builder_eject_e2e.py
@@ -1,0 +1,51 @@
+"""Gated end-to-end test: the coding agent writes real code against a live model.
+
+Skipped unless AGENTBREEDER_E2E_ANTHROPIC_KEY is set (BYO key, costs tokens).
+Proves the provider-loop (B0-B3) genuinely produces files end-to-end, not just
+against fakes. One transcript per engine could be added later (Codex needs an
+OpenAI key); this covers the Claude path.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from engine.coding_agent.base import AgentBounds
+from engine.coding_agent.engines import engine_for
+from engine.providers.anthropic_provider import AnthropicProvider
+from engine.providers.models import ProviderConfig, ProviderType
+from engine.sandbox.local import LocalSandbox
+
+_KEY = os.environ.get("AGENTBREEDER_E2E_ANTHROPIC_KEY")
+
+pytestmark = pytest.mark.skipif(
+    not _KEY, reason="AGENTBREEDER_E2E_ANTHROPIC_KEY not set"
+)
+
+
+@pytest.mark.asyncio
+async def test_eject_writes_agent_py_against_live_claude():
+    provider = AnthropicProvider(
+        ProviderConfig(provider_type=ProviderType.anthropic, api_key=_KEY)
+    )
+    sandbox = LocalSandbox()
+    try:
+        engine = engine_for("claude", provider=provider)
+        instruction = (
+            "Create a minimal Python agent project for this spec:\n"
+            "name: hello-agent\nframework: custom\n"
+            "Write agent.py with a `run(input: str) -> str` function that echoes "
+            "the input, and tools/__init__.py. Use write_file for each file, then stop."
+        )
+        file_changes: list[str] = []
+        async for evt in engine.run(instruction, [], sandbox, AgentBounds(max_turns=6)):
+            if evt.type == "file_change":
+                file_changes.append(evt.path)
+        assert any(p.endswith("agent.py") for p in file_changes), file_changes
+        files = await sandbox.list(".")
+        assert any(p.endswith("agent.py") for p in files), files
+    finally:
+        await sandbox.close()
+        await provider.close()

--- a/tests/integration/test_analytics.py
+++ b/tests/integration/test_analytics.py
@@ -13,9 +13,24 @@ def client() -> TestClient:
     return TestClient(app)
 
 
-def test_ingest_rejects_unknown_event(client):
+def test_ingest_rejects_overlong_event(client):
     # Body validation (event too long) fails before the route body / DB.
     r = client.post("/api/v1/analytics/events", json={"event": "x" * 100})
+    assert r.status_code == 422
+
+
+def test_ingest_rejects_unknown_event(client):
+    # Well-formed but not on the server-side allowlist -> 422 before DB.
+    r = client.post("/api/v1/analytics/events", json={"event": "totally_made_up"})
+    assert r.status_code == 422
+
+
+def test_ingest_rejects_bad_session_id(client):
+    # Malformed UUID is rejected by pydantic (422) rather than 500 in the route.
+    r = client.post(
+        "/api/v1/analytics/events",
+        json={"event": "spec_validated", "session_id": "not-a-uuid"},
+    )
     assert r.status_code == 422
 
 

--- a/tests/integration/test_analytics.py
+++ b/tests/integration/test_analytics.py
@@ -1,0 +1,26 @@
+"""Analytics ingest + funnel aggregation."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def test_ingest_rejects_unknown_event(client):
+    # Body validation (event too long) fails before the route body / DB.
+    r = client.post("/api/v1/analytics/events", json={"event": "x" * 100})
+    assert r.status_code == 422
+
+
+@pytest.mark.no_auto_auth
+def test_funnel_requires_auth(client):
+    # Real auth runs (autouse mock disabled); no token -> 401/403 before DB.
+    r = client.get("/api/v1/analytics/funnel?period=7d")
+    assert r.status_code in (401, 403)

--- a/tests/integration/test_builder_sessions.py
+++ b/tests/integration/test_builder_sessions.py
@@ -1,4 +1,29 @@
+import pytest
+
+from api.services.builder_session_service import (  # noqa: F401  (service used in C3)
+    BuilderSessionService,
+    SessionEventBus,
+)
+
+
 def test_builder_session_model_importable():
     from api.models.database import BuilderSession
 
     assert BuilderSession.__tablename__ == "builder_sessions"
+
+
+@pytest.mark.asyncio
+async def test_event_bus_publish_subscribe():
+    bus = SessionEventBus()
+    async with bus.subscribe("s1") as q:
+        await bus.publish("s1", {"event": "token", "data": "{}"})
+        evt = await q.get()
+        assert evt["event"] == "token"
+
+
+@pytest.mark.asyncio
+async def test_event_bus_isolated_per_session():
+    bus = SessionEventBus()
+    async with bus.subscribe("s1") as q1:
+        await bus.publish("s2", {"event": "x", "data": "{}"})
+        assert q1.empty()

--- a/tests/integration/test_builder_sessions.py
+++ b/tests/integration/test_builder_sessions.py
@@ -393,16 +393,29 @@ async def test_stream_subscribes_and_relays_published_events(monkeypatch):
 
 def test_deploy_invalid_yaml_returns_404(client, _override_db, monkeypatch):
     from unittest.mock import AsyncMock
+
     sess = _fake_session()
-    sess.state = {"history": [], "agent_yaml": "name: x\nteam: engineering\n",
-                  "files": {}, "deploy_job_id": None, "satisfied": []}
-    monkeypatch.setattr("api.routes.builder_sessions._resolve_deploy_team",
-                        AsyncMock(return_value=("engineering", None)))
-    monkeypatch.setattr("api.routes.builder_sessions.enforce_team_role", AsyncMock(return_value=None))
-    monkeypatch.setattr("api.routes.builder_sessions.DeployService.create_agent_and_deploy",
-                        AsyncMock(side_effect=ValueError("bad config")))
-    with patch("api.routes.builder_sessions.BuilderSessionService.get",
-               new=AsyncMock(return_value=sess)):
+    sess.state = {
+        "history": [],
+        "agent_yaml": "name: x\nteam: engineering\n",
+        "files": {},
+        "deploy_job_id": None,
+        "satisfied": [],
+    }
+    monkeypatch.setattr(
+        "api.routes.builder_sessions._resolve_deploy_team",
+        AsyncMock(return_value=("engineering", None)),
+    )
+    monkeypatch.setattr(
+        "api.routes.builder_sessions.enforce_team_role", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(
+        "api.routes.builder_sessions.DeployService.create_agent_and_deploy",
+        AsyncMock(side_effect=ValueError("bad config")),
+    )
+    with patch(
+        "api.routes.builder_sessions.BuilderSessionService.get", new=AsyncMock(return_value=sess)
+    ):
         r = client.post("/api/v1/builder/sessions/11111111-1111-1111-1111-111111111111/deploy")
     assert r.status_code == 404
 

--- a/tests/integration/test_builder_sessions.py
+++ b/tests/integration/test_builder_sessions.py
@@ -27,3 +27,87 @@ async def test_event_bus_isolated_per_session():
     async with bus.subscribe("s1") as q1:
         await bus.publish("s2", {"event": "x", "data": "{}"})
         assert q1.empty()
+
+
+# --- C3: create / get / list route tests -----------------------------------
+
+from unittest.mock import AsyncMock, patch  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from api.main import app  # noqa: E402
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture
+def _override_db():
+    from api.database import get_db
+
+    app.dependency_overrides[get_db] = lambda: AsyncMock()
+    yield
+    app.dependency_overrides.pop(get_db, None)
+
+
+def _fake_session(sid="11111111-1111-1111-1111-111111111111", team="engineering"):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        id=sid,
+        team=team,
+        engine="claude",
+        state={
+            "history": [],
+            "agent_yaml": None,
+            "files": {},
+            "deploy_job_id": None,
+            "satisfied": [],
+        },
+    )
+
+
+def test_create_session_returns_id(client, _override_db):
+    with patch(
+        "api.routes.builder_sessions.BuilderSessionService.create",
+        new=AsyncMock(return_value=_fake_session()),
+    ):
+        r = client.post("/api/v1/builder/sessions", json={"engine": "claude"})
+    assert r.status_code == 200
+    assert r.json()["data"]["engine"] == "claude"
+
+
+def test_create_rejects_bad_engine(client, _override_db):
+    r = client.post("/api/v1/builder/sessions", json={"engine": "bard"})
+    assert r.status_code == 400
+
+
+def test_get_session_found(client, _override_db):
+    with patch(
+        "api.routes.builder_sessions.BuilderSessionService.get",
+        new=AsyncMock(return_value=_fake_session()),
+    ):
+        r = client.get("/api/v1/builder/sessions/11111111-1111-1111-1111-111111111111")
+    assert r.status_code == 200
+    assert r.json()["data"]["id"] == "11111111-1111-1111-1111-111111111111"
+
+
+def test_get_session_not_found(client, _override_db):
+    with patch(
+        "api.routes.builder_sessions.BuilderSessionService.get",
+        new=AsyncMock(return_value=None),
+    ):
+        r = client.get("/api/v1/builder/sessions/11111111-1111-1111-1111-111111111111")
+    assert r.status_code == 404
+
+
+def test_list_sessions(client, _override_db):
+    with patch(
+        "api.routes.builder_sessions.BuilderSessionService.list_for_team",
+        new=AsyncMock(return_value=[_fake_session()]),
+    ):
+        r = client.get("/api/v1/builder/sessions")
+    assert r.status_code == 200
+    assert len(r.json()["data"]) == 1

--- a/tests/integration/test_builder_sessions.py
+++ b/tests/integration/test_builder_sessions.py
@@ -1,0 +1,4 @@
+def test_builder_session_model_importable():
+    from api.models.database import BuilderSession
+
+    assert BuilderSession.__tablename__ == "builder_sessions"

--- a/tests/integration/test_builder_sessions.py
+++ b/tests/integration/test_builder_sessions.py
@@ -391,6 +391,22 @@ async def test_stream_subscribes_and_relays_published_events(monkeypatch):
     await gen.aclose()
 
 
+def test_deploy_invalid_yaml_returns_404(client, _override_db, monkeypatch):
+    from unittest.mock import AsyncMock
+    sess = _fake_session()
+    sess.state = {"history": [], "agent_yaml": "name: x\nteam: engineering\n",
+                  "files": {}, "deploy_job_id": None, "satisfied": []}
+    monkeypatch.setattr("api.routes.builder_sessions._resolve_deploy_team",
+                        AsyncMock(return_value=("engineering", None)))
+    monkeypatch.setattr("api.routes.builder_sessions.enforce_team_role", AsyncMock(return_value=None))
+    monkeypatch.setattr("api.routes.builder_sessions.DeployService.create_agent_and_deploy",
+                        AsyncMock(side_effect=ValueError("bad config")))
+    with patch("api.routes.builder_sessions.BuilderSessionService.get",
+               new=AsyncMock(return_value=sess)):
+        r = client.post("/api/v1/builder/sessions/11111111-1111-1111-1111-111111111111/deploy")
+    assert r.status_code == 404
+
+
 def test_stream_not_found_returns_404(client, _override_db):
     with patch(
         "api.routes.builder_sessions.BuilderSessionService.get", new=AsyncMock(return_value=None)

--- a/tests/integration/test_builder_sessions.py
+++ b/tests/integration/test_builder_sessions.py
@@ -123,13 +123,14 @@ def test_messages_turn_streams_and_persists(client, _override_db, monkeypatch):
     )
 
     sess = _fake_session()
+
     # ensure save_state can mutate without DB
     async def _fake_save_state(self, s, state):
         s.state = state
 
     async def _fake_stream(self, session, provider, user_text):
-        yield {"event": "token", "data": "{\"text\": \"Hello\"}"}
-        yield {"event": "done", "data": "{\"assistant_message\": \"Hello\"}"}
+        yield {"event": "token", "data": '{"text": "Hello"}'}
+        yield {"event": "done", "data": '{"assistant_message": "Hello"}'}
 
     class _Backend:
         async def get(self, _name):
@@ -142,15 +143,22 @@ def test_messages_turn_streams_and_persists(client, _override_db, monkeypatch):
     class _Provider:
         def __init__(self, *a, **k):
             pass
+
         async def close(self):
             pass
 
     monkeypatch.setattr("api.routes.builder_sessions.AnthropicProvider", _Provider)
 
-    with patch("api.routes.builder_sessions.BuilderSessionService.get",
-               new=AsyncMock(return_value=sess)), \
-         patch("api.routes.builder_sessions.BuilderSessionService.run_interview_turn",
-               new=_fake_stream):
+    with (
+        patch(
+            "api.routes.builder_sessions.BuilderSessionService.get",
+            new=AsyncMock(return_value=sess),
+        ),
+        patch(
+            "api.routes.builder_sessions.BuilderSessionService.run_interview_turn",
+            new=_fake_stream,
+        ),
+    ):
         r = client.post(
             "/api/v1/builder/sessions/11111111-1111-1111-1111-111111111111/messages",
             json={"content": "build a support agent"},
@@ -164,11 +172,14 @@ def test_messages_requires_key(client, _override_db, monkeypatch):
     class _Backend:
         async def get(self, _name):
             return None
+
     monkeypatch.setattr(
         "api.routes.builder_sessions.get_workspace_backend", lambda: (_Backend(), None)
     )
-    with patch("api.routes.builder_sessions.BuilderSessionService.get",
-               new=AsyncMock(return_value=_fake_session())):
+    with patch(
+        "api.routes.builder_sessions.BuilderSessionService.get",
+        new=AsyncMock(return_value=_fake_session()),
+    ):
         r = client.post(
             "/api/v1/builder/sessions/11111111-1111-1111-1111-111111111111/messages",
             json={"content": "hi"},
@@ -187,6 +198,7 @@ def test_eject_streams_file_change_with_content(client, _override_db, monkeypatc
 
     class _FakeEngine:
         name = "claude"
+
         async def run(self, instruction, history, sandbox, bounds=None):
             await sandbox.write("agent.py", "print('hi')\n")
             yield AgentEvent(type="file_change", path="agent.py", diff="+print('hi')")
@@ -199,30 +211,35 @@ def test_eject_streams_file_change_with_content(client, _override_db, monkeypatc
     monkeypatch.setattr(
         "api.services.builder_session_service.select_sandbox_mode", lambda: "local"
     )
-    monkeypatch.setattr(
-        "api.routes.builder_sessions.select_sandbox_mode", lambda: "local"
-    )
+    monkeypatch.setattr("api.routes.builder_sessions.select_sandbox_mode", lambda: "local")
 
     class _Backend:
         async def get(self, _name):
             return "sk-ant-test"
+
     monkeypatch.setattr(
         "api.routes.builder_sessions.get_workspace_backend", lambda: (_Backend(), None)
     )
 
     class _Provider:
-        def __init__(self, *a, **k): pass
-        async def close(self): pass
+        def __init__(self, *a, **k):
+            pass
+
+        async def close(self):
+            pass
+
     monkeypatch.setattr("api.routes.builder_sessions.AnthropicProvider", _Provider)
 
     async def _fake_save_state(self, s, state):
         s.state = state
+
     monkeypatch.setattr(
         "api.services.builder_session_service.BuilderSessionService.save_state", _fake_save_state
     )
 
-    with patch("api.routes.builder_sessions.BuilderSessionService.get",
-               new=AsyncMock(return_value=sess)):
+    with patch(
+        "api.routes.builder_sessions.BuilderSessionService.get", new=AsyncMock(return_value=sess)
+    ):
         r = client.post(
             "/api/v1/builder/sessions/11111111-1111-1111-1111-111111111111/eject",
             json={"instruction": "add a custom tool"},
@@ -233,11 +250,11 @@ def test_eject_streams_file_change_with_content(client, _override_db, monkeypatc
 
 
 def test_eject_blocked_when_sandbox_cloud(client, _override_db, monkeypatch):
-    monkeypatch.setattr(
-        "api.routes.builder_sessions.select_sandbox_mode", lambda: "cloud"
-    )
-    with patch("api.routes.builder_sessions.BuilderSessionService.get",
-               new=AsyncMock(return_value=_fake_session())):
+    monkeypatch.setattr("api.routes.builder_sessions.select_sandbox_mode", lambda: "cloud")
+    with patch(
+        "api.routes.builder_sessions.BuilderSessionService.get",
+        new=AsyncMock(return_value=_fake_session()),
+    ):
         r = client.post(
             "/api/v1/builder/sessions/11111111-1111-1111-1111-111111111111/eject",
             json={"instruction": "x"},
@@ -247,15 +264,136 @@ def test_eject_blocked_when_sandbox_cloud(client, _override_db, monkeypatch):
 
 def test_eject_requires_key(client, _override_db, monkeypatch):
     monkeypatch.setattr("api.routes.builder_sessions.select_sandbox_mode", lambda: "local")
+
     class _Backend:
-        async def get(self, _name): return None
+        async def get(self, _name):
+            return None
+
     monkeypatch.setattr(
         "api.routes.builder_sessions.get_workspace_backend", lambda: (_Backend(), None)
     )
-    with patch("api.routes.builder_sessions.BuilderSessionService.get",
-               new=AsyncMock(return_value=_fake_session())):
+    with patch(
+        "api.routes.builder_sessions.BuilderSessionService.get",
+        new=AsyncMock(return_value=_fake_session()),
+    ):
         r = client.post(
             "/api/v1/builder/sessions/11111111-1111-1111-1111-111111111111/eject",
             json={"instruction": "x"},
         )
     assert r.status_code == 400
+
+
+# --- C6: /deploy (governed) + /stream (aggregate SSE) route tests ----------
+
+
+def test_deploy_from_session_uses_governed_path(client, _override_db, monkeypatch):
+    from types import SimpleNamespace
+
+    sess = _fake_session()
+    sess.state = {
+        "history": [],
+        "agent_yaml": "name: x\nteam: engineering\n",
+        "files": {},
+        "deploy_job_id": None,
+        "satisfied": [],
+    }
+    fake_job = SimpleNamespace(id="job-123", agent_id="agent-1")
+
+    monkeypatch.setattr(
+        "api.routes.builder_sessions._resolve_deploy_team",
+        AsyncMock(return_value=("engineering", None)),
+    )
+    monkeypatch.setattr(
+        "api.routes.builder_sessions.enforce_team_role", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(
+        "api.routes.builder_sessions.DeployService.create_agent_and_deploy",
+        AsyncMock(return_value=(SimpleNamespace(id="agent-1"), fake_job)),
+    )
+    monkeypatch.setattr(
+        "api.routes.builder_sessions.AuditService.log_event", AsyncMock(return_value=None)
+    )
+
+    saved = {}
+
+    async def _fake_save_state(self, s, state):
+        s.state = state
+        saved.update(state)
+
+    monkeypatch.setattr(
+        "api.services.builder_session_service.BuilderSessionService.save_state", _fake_save_state
+    )
+    # commit is on the AsyncMock db already (no-op)
+
+    with patch(
+        "api.routes.builder_sessions.BuilderSessionService.get", new=AsyncMock(return_value=sess)
+    ):
+        r = client.post("/api/v1/builder/sessions/11111111-1111-1111-1111-111111111111/deploy")
+    assert r.status_code == 200
+    assert r.json()["data"]["deploy_job_id"] == "job-123"
+    assert saved.get("deploy_job_id") == "job-123"
+
+
+def test_deploy_without_spec_returns_400(client, _override_db, monkeypatch):
+    sess = _fake_session()
+    sess.state = {
+        "history": [],
+        "agent_yaml": None,
+        "files": {},
+        "deploy_job_id": None,
+        "satisfied": [],
+    }
+    with patch(
+        "api.routes.builder_sessions.BuilderSessionService.get", new=AsyncMock(return_value=sess)
+    ):
+        r = client.post("/api/v1/builder/sessions/11111111-1111-1111-1111-111111111111/deploy")
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_stream_subscribes_and_relays_published_events(monkeypatch):
+    # An infinite SSE generator deadlocks the synchronous TestClient (it blocks
+    # reading the never-ending body), so we drive the route's async generator
+    # directly. This still exercises the real behavior: the endpoint returns an
+    # EventSourceResponse, the generator subscribes to the session's bus topic,
+    # flushes an immediate `ready` frame, then relays published events verbatim.
+    import uuid as _uuid
+    from types import SimpleNamespace
+
+    from sse_starlette.sse import EventSourceResponse
+
+    from api.routes.builder_sessions import stream_session
+
+    sid = _uuid.UUID("11111111-1111-1111-1111-111111111111")
+    bus = SessionEventBus()
+    fake_request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(builder_event_bus=bus)),
+        is_disconnected=AsyncMock(return_value=False),
+    )
+    user = SimpleNamespace(team="engineering")
+
+    with patch(
+        "api.routes.builder_sessions.BuilderSessionService.get",
+        new=AsyncMock(return_value=_fake_session()),
+    ):
+        resp = await stream_session(sid, fake_request, user=user, db=AsyncMock())
+
+    assert isinstance(resp, EventSourceResponse)
+
+    gen = resp.body_iterator
+    first = await gen.__anext__()
+    assert first["event"] == "ready"
+
+    # A frame published to the session topic is relayed to the subscriber.
+    await bus.publish(str(sid), {"event": "deploy.progress", "data": "{}"})
+    relayed = await gen.__anext__()
+    assert relayed["event"] == "deploy.progress"
+    await gen.aclose()
+
+
+def test_stream_not_found_returns_404(client, _override_db):
+    with patch(
+        "api.routes.builder_sessions.BuilderSessionService.get", new=AsyncMock(return_value=None)
+    ):
+        r = client.get("/api/v1/builder/sessions/11111111-1111-1111-1111-111111111111/stream")
+    assert r.status_code == 404

--- a/tests/integration/test_builder_sessions.py
+++ b/tests/integration/test_builder_sessions.py
@@ -111,3 +111,66 @@ def test_list_sessions(client, _override_db):
         r = client.get("/api/v1/builder/sessions")
     assert r.status_code == 200
     assert len(r.json()["data"]) == 1
+
+
+# --- C4: /messages interview-turn route tests ------------------------------
+
+
+def test_messages_turn_streams_and_persists(client, _override_db, monkeypatch):
+    from engine.agent_chat_builder import (  # noqa: F401  (verifies symbols exist)
+        ChatStreamEvent,
+        ChatTurnResult,
+    )
+
+    sess = _fake_session()
+    # ensure save_state can mutate without DB
+    async def _fake_save_state(self, s, state):
+        s.state = state
+
+    async def _fake_stream(self, session, provider, user_text):
+        yield {"event": "token", "data": "{\"text\": \"Hello\"}"}
+        yield {"event": "done", "data": "{\"assistant_message\": \"Hello\"}"}
+
+    class _Backend:
+        async def get(self, _name):
+            return "sk-ant-test"
+
+    monkeypatch.setattr(
+        "api.routes.builder_sessions.get_workspace_backend", lambda: (_Backend(), None)
+    )
+
+    class _Provider:
+        def __init__(self, *a, **k):
+            pass
+        async def close(self):
+            pass
+
+    monkeypatch.setattr("api.routes.builder_sessions.AnthropicProvider", _Provider)
+
+    with patch("api.routes.builder_sessions.BuilderSessionService.get",
+               new=AsyncMock(return_value=sess)), \
+         patch("api.routes.builder_sessions.BuilderSessionService.run_interview_turn",
+               new=_fake_stream):
+        r = client.post(
+            "/api/v1/builder/sessions/11111111-1111-1111-1111-111111111111/messages",
+            json={"content": "build a support agent"},
+        )
+    assert r.status_code == 200
+    assert "event: token" in r.text
+    assert "event: done" in r.text
+
+
+def test_messages_requires_key(client, _override_db, monkeypatch):
+    class _Backend:
+        async def get(self, _name):
+            return None
+    monkeypatch.setattr(
+        "api.routes.builder_sessions.get_workspace_backend", lambda: (_Backend(), None)
+    )
+    with patch("api.routes.builder_sessions.BuilderSessionService.get",
+               new=AsyncMock(return_value=_fake_session())):
+        r = client.post(
+            "/api/v1/builder/sessions/11111111-1111-1111-1111-111111111111/messages",
+            json={"content": "hi"},
+        )
+    assert r.status_code == 400

--- a/tests/integration/test_builder_sessions.py
+++ b/tests/integration/test_builder_sessions.py
@@ -174,3 +174,88 @@ def test_messages_requires_key(client, _override_db, monkeypatch):
             json={"content": "hi"},
         )
     assert r.status_code == 400
+
+
+# --- C5: /eject coding-agent route tests -----------------------------------
+
+
+def test_eject_streams_file_change_with_content(client, _override_db, monkeypatch):
+    from engine.coding_agent.base import AgentEvent
+
+    sess = _fake_session()
+    sess.engine = "claude"
+
+    class _FakeEngine:
+        name = "claude"
+        async def run(self, instruction, history, sandbox, bounds=None):
+            await sandbox.write("agent.py", "print('hi')\n")
+            yield AgentEvent(type="file_change", path="agent.py", diff="+print('hi')")
+            yield AgentEvent(type="done", text="done")
+
+    monkeypatch.setattr(
+        "api.services.builder_session_service.engine_for",
+        lambda name, provider: _FakeEngine(),
+    )
+    monkeypatch.setattr(
+        "api.services.builder_session_service.select_sandbox_mode", lambda: "local"
+    )
+    monkeypatch.setattr(
+        "api.routes.builder_sessions.select_sandbox_mode", lambda: "local"
+    )
+
+    class _Backend:
+        async def get(self, _name):
+            return "sk-ant-test"
+    monkeypatch.setattr(
+        "api.routes.builder_sessions.get_workspace_backend", lambda: (_Backend(), None)
+    )
+
+    class _Provider:
+        def __init__(self, *a, **k): pass
+        async def close(self): pass
+    monkeypatch.setattr("api.routes.builder_sessions.AnthropicProvider", _Provider)
+
+    async def _fake_save_state(self, s, state):
+        s.state = state
+    monkeypatch.setattr(
+        "api.services.builder_session_service.BuilderSessionService.save_state", _fake_save_state
+    )
+
+    with patch("api.routes.builder_sessions.BuilderSessionService.get",
+               new=AsyncMock(return_value=sess)):
+        r = client.post(
+            "/api/v1/builder/sessions/11111111-1111-1111-1111-111111111111/eject",
+            json={"instruction": "add a custom tool"},
+        )
+    assert r.status_code == 200
+    assert "event: file_change" in r.text
+    assert "print('hi')" in r.text  # content present in the frame
+
+
+def test_eject_blocked_when_sandbox_cloud(client, _override_db, monkeypatch):
+    monkeypatch.setattr(
+        "api.routes.builder_sessions.select_sandbox_mode", lambda: "cloud"
+    )
+    with patch("api.routes.builder_sessions.BuilderSessionService.get",
+               new=AsyncMock(return_value=_fake_session())):
+        r = client.post(
+            "/api/v1/builder/sessions/11111111-1111-1111-1111-111111111111/eject",
+            json={"instruction": "x"},
+        )
+    assert r.status_code == 409
+
+
+def test_eject_requires_key(client, _override_db, monkeypatch):
+    monkeypatch.setattr("api.routes.builder_sessions.select_sandbox_mode", lambda: "local")
+    class _Backend:
+        async def get(self, _name): return None
+    monkeypatch.setattr(
+        "api.routes.builder_sessions.get_workspace_backend", lambda: (_Backend(), None)
+    )
+    with patch("api.routes.builder_sessions.BuilderSessionService.get",
+               new=AsyncMock(return_value=_fake_session())):
+        r = client.post(
+            "/api/v1/builder/sessions/11111111-1111-1111-1111-111111111111/eject",
+            json={"instruction": "x"},
+        )
+    assert r.status_code == 400

--- a/tests/integration/test_builders_chat_stream.py
+++ b/tests/integration/test_builders_chat_stream.py
@@ -1,4 +1,5 @@
 """Integration tests for POST /api/v1/builders/chat/stream."""
+
 from __future__ import annotations
 
 import pytest
@@ -21,9 +22,7 @@ def test_chat_stream_requires_key(client: TestClient, monkeypatch: pytest.Monkey
         async def get(self, _name: str) -> None:
             return None
 
-    monkeypatch.setattr(
-        "api.routes.builders.get_workspace_backend", lambda: (_Backend(), None)
-    )
+    monkeypatch.setattr("api.routes.builders.get_workspace_backend", lambda: (_Backend(), None))
 
     resp = client.post(
         "/api/v1/builders/chat/stream",
@@ -42,9 +41,7 @@ def test_chat_stream_emits_token_and_done_events(
         async def get(self, _name: str) -> str:
             return "sk-ant-test"
 
-    monkeypatch.setattr(
-        "api.routes.builders.get_workspace_backend", lambda: (_Backend(), None)
-    )
+    monkeypatch.setattr("api.routes.builders.get_workspace_backend", lambda: (_Backend(), None))
 
     class _Provider:
         def __init__(self, *_a: object, **_k: object) -> None:
@@ -55,9 +52,7 @@ def test_chat_stream_emits_token_and_done_events(
 
     monkeypatch.setattr("api.routes.builders.AnthropicProvider", _Provider)
 
-    async def _fake_stream(
-        _provider: object, _history: list[dict[str, str]]
-    ):  # type: ignore[return]
+    async def _fake_stream(_provider: object, _history: list[dict[str, str]]):  # type: ignore[return]
         yield ChatStreamEvent(type="token", text="Hello")
         yield ChatStreamEvent(
             type="done",
@@ -89,9 +84,7 @@ def test_chat_stream_emits_setup_request_event(
         async def get(self, _name: str) -> str:
             return "sk-ant-test"
 
-    monkeypatch.setattr(
-        "api.routes.builders.get_workspace_backend", lambda: (_Backend(), None)
-    )
+    monkeypatch.setattr("api.routes.builders.get_workspace_backend", lambda: (_Backend(), None))
 
     class _Provider:
         def __init__(self, *_a: object, **_k: object) -> None:
@@ -102,9 +95,7 @@ def test_chat_stream_emits_setup_request_event(
 
     monkeypatch.setattr("api.routes.builders.AnthropicProvider", _Provider)
 
-    async def _fake_stream(
-        _provider: object, _history: list[dict[str, str]]
-    ):  # type: ignore[return]
+    async def _fake_stream(_provider: object, _history: list[dict[str, str]]):  # type: ignore[return]
         yield ChatStreamEvent(
             type="setup_request",
             setup=SetupRequest(kind="mcp", name="zendesk", reason="read tickets"),
@@ -144,9 +135,7 @@ def test_chat_stream_auth_error_yields_sse_error_event(
         async def get(self, _name: str) -> str:
             return "sk-ant-test"
 
-    monkeypatch.setattr(
-        "api.routes.builders.get_workspace_backend", lambda: (_Backend(), None)
-    )
+    monkeypatch.setattr("api.routes.builders.get_workspace_backend", lambda: (_Backend(), None))
 
     class _Provider:
         def __init__(self, *_a: object, **_k: object) -> None:
@@ -162,9 +151,7 @@ def test_chat_stream_auth_error_yields_sse_error_event(
     # NOT forwarded to the client in any form.
     _LEAK_CANARY = "secret-canary-token-must-not-appear-in-response"
 
-    async def _raise_auth(
-        _provider: object, _history: list[dict[str, str]]
-    ):  # type: ignore[return]
+    async def _raise_auth(_provider: object, _history: list[dict[str, str]]):  # type: ignore[return]
         raise AuthenticationError(f"401 Unauthorized — {_LEAK_CANARY}")
         yield  # make this an async generator
 
@@ -197,9 +184,7 @@ def test_chat_stream_provider_error_yields_sse_error_event(
         async def get(self, _name: str) -> str:
             return "sk-ant-test"
 
-    monkeypatch.setattr(
-        "api.routes.builders.get_workspace_backend", lambda: (_Backend(), None)
-    )
+    monkeypatch.setattr("api.routes.builders.get_workspace_backend", lambda: (_Backend(), None))
 
     class _Provider:
         def __init__(self, *_a: object, **_k: object) -> None:
@@ -213,9 +198,7 @@ def test_chat_stream_provider_error_yields_sse_error_event(
     # The canary text must not be forwarded to the client in any form.
     _LEAK_CANARY = "raw-upstream-detail-must-not-appear-CANARY"
 
-    async def _raise_provider(
-        _provider: object, _history: list[dict[str, str]]
-    ):  # type: ignore[return]
+    async def _raise_provider(_provider: object, _history: list[dict[str, str]]):  # type: ignore[return]
         raise ProviderError(f"503 Service Unavailable — {_LEAK_CANARY}")
         yield  # make this an async generator
 

--- a/tests/integration/test_builders_chat_stream.py
+++ b/tests/integration/test_builders_chat_stream.py
@@ -1,0 +1,238 @@
+"""Integration tests for POST /api/v1/builders/chat/stream."""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from engine.agent_chat_builder import ChatStreamEvent, ChatTurnResult, SetupRequest
+from engine.providers.base import AuthenticationError, ProviderError
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def test_chat_stream_requires_key(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no BYO key stored, the endpoint returns 400 before constructing a provider."""
+
+    class _Backend:
+        async def get(self, _name: str) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "api.routes.builders.get_workspace_backend", lambda: (_Backend(), None)
+    )
+
+    resp = client.post(
+        "/api/v1/builders/chat/stream",
+        json={"messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 400
+    assert "key" in resp.text.lower()
+
+
+def test_chat_stream_emits_token_and_done_events(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SSE stream emits token and done events with correct content-type."""
+
+    class _Backend:
+        async def get(self, _name: str) -> str:
+            return "sk-ant-test"
+
+    monkeypatch.setattr(
+        "api.routes.builders.get_workspace_backend", lambda: (_Backend(), None)
+    )
+
+    class _Provider:
+        def __init__(self, *_a: object, **_k: object) -> None:
+            pass
+
+        async def close(self) -> None:
+            pass
+
+    monkeypatch.setattr("api.routes.builders.AnthropicProvider", _Provider)
+
+    async def _fake_stream(
+        _provider: object, _history: list[dict[str, str]]
+    ):  # type: ignore[return]
+        yield ChatStreamEvent(type="token", text="Hello")
+        yield ChatStreamEvent(
+            type="done",
+            result=ChatTurnResult(
+                assistant_message="Hello", agent_yaml=None, valid=False, errors=[]
+            ),
+        )
+
+    monkeypatch.setattr("api.routes.builders.run_chat_turn_stream", _fake_stream)
+
+    resp = client.post(
+        "/api/v1/builders/chat/stream",
+        json={"messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 200
+    assert "text/event-stream" in resp.headers["content-type"]
+    body = resp.text
+    assert "event: token" in body
+    assert "event: done" in body
+    assert "Hello" in body
+
+
+def test_chat_stream_emits_setup_request_event(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The stream forwards a setup_request event with kind/name to the client."""
+
+    class _Backend:
+        async def get(self, _name: str) -> str:
+            return "sk-ant-test"
+
+    monkeypatch.setattr(
+        "api.routes.builders.get_workspace_backend", lambda: (_Backend(), None)
+    )
+
+    class _Provider:
+        def __init__(self, *_a: object, **_k: object) -> None:
+            pass
+
+        async def close(self) -> None:
+            pass
+
+    monkeypatch.setattr("api.routes.builders.AnthropicProvider", _Provider)
+
+    async def _fake_stream(
+        _provider: object, _history: list[dict[str, str]]
+    ):  # type: ignore[return]
+        yield ChatStreamEvent(
+            type="setup_request",
+            setup=SetupRequest(kind="mcp", name="zendesk", reason="read tickets"),
+        )
+        yield ChatStreamEvent(
+            type="done",
+            result=ChatTurnResult(
+                assistant_message="",
+                agent_yaml=None,
+                valid=False,
+                errors=[],
+                setup_request=SetupRequest(kind="mcp", name="zendesk", reason="read tickets"),
+            ),
+        )
+
+    monkeypatch.setattr("api.routes.builders.run_chat_turn_stream", _fake_stream)
+
+    resp = client.post(
+        "/api/v1/builders/chat/stream",
+        json={"messages": [{"role": "user", "content": "support agent"}]},
+    )
+    assert resp.status_code == 200
+    body = resp.text
+    assert "event: setup_request" in body
+    assert "zendesk" in body
+    assert '"kind": "mcp"' in body or '"kind":"mcp"' in body
+
+
+def test_chat_stream_auth_error_yields_sse_error_event(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When run_chat_turn_stream raises AuthenticationError, the stream emits
+    an SSE error event with a sanitised detail and does NOT leak the exception
+    text or any raw key material."""
+
+    class _Backend:
+        async def get(self, _name: str) -> str:
+            return "sk-ant-test"
+
+    monkeypatch.setattr(
+        "api.routes.builders.get_workspace_backend", lambda: (_Backend(), None)
+    )
+
+    class _Provider:
+        def __init__(self, *_a: object, **_k: object) -> None:
+            pass
+
+        async def close(self) -> None:
+            pass
+
+    monkeypatch.setattr("api.routes.builders.AnthropicProvider", _Provider)
+
+    # Simulate an AuthenticationError raised from within the streaming generator.
+    # The error message contains a canary string — the test verifies it is
+    # NOT forwarded to the client in any form.
+    _LEAK_CANARY = "secret-canary-token-must-not-appear-in-response"
+
+    async def _raise_auth(
+        _provider: object, _history: list[dict[str, str]]
+    ):  # type: ignore[return]
+        raise AuthenticationError(f"401 Unauthorized — {_LEAK_CANARY}")
+        yield  # make this an async generator
+
+    monkeypatch.setattr("api.routes.builders.run_chat_turn_stream", _raise_auth)
+
+    resp = client.post(
+        "/api/v1/builders/chat/stream",
+        json={"messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 200
+    body = resp.text
+    # Must contain an SSE error event
+    assert "event: error" in body
+    # The detail must be the sanitised message (case-insensitive match)
+    assert "authentication failed" in body.lower()
+    # The code field must identify the error category for the frontend
+    assert "auth_error" in body
+    # The raw exception message (including any canary text) must NOT appear
+    assert _LEAK_CANARY not in body
+    assert "401 Unauthorized" not in body
+
+
+def test_chat_stream_provider_error_yields_sse_error_event(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When run_chat_turn_stream raises ProviderError, the stream emits an SSE
+    error event with 'upstream_error' code and does NOT leak the raw exception text."""
+
+    class _Backend:
+        async def get(self, _name: str) -> str:
+            return "sk-ant-test"
+
+    monkeypatch.setattr(
+        "api.routes.builders.get_workspace_backend", lambda: (_Backend(), None)
+    )
+
+    class _Provider:
+        def __init__(self, *_a: object, **_k: object) -> None:
+            pass
+
+        async def close(self) -> None:
+            pass
+
+    monkeypatch.setattr("api.routes.builders.AnthropicProvider", _Provider)
+
+    # The canary text must not be forwarded to the client in any form.
+    _LEAK_CANARY = "raw-upstream-detail-must-not-appear-CANARY"
+
+    async def _raise_provider(
+        _provider: object, _history: list[dict[str, str]]
+    ):  # type: ignore[return]
+        raise ProviderError(f"503 Service Unavailable — {_LEAK_CANARY}")
+        yield  # make this an async generator
+
+    monkeypatch.setattr("api.routes.builders.run_chat_turn_stream", _raise_provider)
+
+    resp = client.post(
+        "/api/v1/builders/chat/stream",
+        json={"messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 200
+    body = resp.text
+    # Must contain an SSE error event
+    assert "event: error" in body
+    # The sanitised detail must mention 'upstream' (case-insensitive)
+    assert "upstream" in body.lower()
+    # The code field must identify the error category
+    assert "upstream_error" in body
+    # The raw exception message must NOT appear
+    assert _LEAK_CANARY not in body
+    assert "503 Service Unavailable" not in body

--- a/tests/integration/test_e2b_backend.py
+++ b/tests/integration/test_e2b_backend.py
@@ -1,0 +1,25 @@
+"""Gated integration test for E2BBackend. Skipped unless E2B_API_KEY is set."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+_KEY = os.environ.get("E2B_API_KEY")
+pytestmark = pytest.mark.skipif(not _KEY, reason="E2B_API_KEY not set")
+
+
+@pytest.mark.asyncio
+async def test_e2b_write_read_exec_roundtrip():
+    from engine.sandbox.backends.e2b import E2BBackend
+
+    backend = E2BBackend()
+    try:
+        await backend.start()
+        await backend.write_file("hello.txt", "world")
+        assert await backend.read_file("hello.txt") == "world"
+        res = await backend.run(["echo", "ok"], timeout=30.0)
+        assert res.exit_code == 0
+    finally:
+        await backend.destroy()

--- a/tests/unit/fakes/fake_provider.py
+++ b/tests/unit/fakes/fake_provider.py
@@ -1,0 +1,45 @@
+"""Scripted streaming provider double.
+
+Each entry in ``script`` is a list of StreamChunk objects representing one
+generate_stream() turn. Successive generate_stream() calls pop the next turn.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from engine.providers.models import StreamChunk, ToolCall
+
+
+class FakeProvider:
+    def __init__(self, script: list[list[StreamChunk]]) -> None:
+        self._script = list(script)
+        self.calls: list[list[dict[str, Any]]] = []
+        self.closed = False
+
+    async def generate_stream(
+        self,
+        messages: list[dict[str, Any]],
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        tools: Any = None,
+    ) -> AsyncIterator[StreamChunk]:
+        self.calls.append(list(messages))
+        turn = self._script.pop(0) if self._script else []
+        for chunk in turn:
+            yield chunk
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def text(s: str) -> StreamChunk:
+    return StreamChunk(content=s)
+
+
+def call(tool_id: str, name: str, args_json: str) -> StreamChunk:
+    return StreamChunk(
+        tool_calls=[ToolCall(id=tool_id, function_name=name, function_arguments=args_json)]
+    )

--- a/tests/unit/fakes/fake_sandbox.py
+++ b/tests/unit/fakes/fake_sandbox.py
@@ -1,0 +1,39 @@
+"""In-memory Sandbox double for engine + service tests (no subprocess)."""
+
+from __future__ import annotations
+
+import builtins
+
+from engine.sandbox.base import ExecResult
+
+
+class FakeSandbox:
+    """Deterministic in-memory sandbox. exec() returns scripted results."""
+
+    def __init__(self) -> None:
+        self.files: dict[str, str] = {}
+        self.exec_calls: builtins.list[builtins.list[str]] = []
+        self.exec_results: dict[str, ExecResult] = {}
+        self.closed = False
+
+    async def write(self, path: str, content: str) -> None:
+        self.files[path] = content
+
+    async def read(self, path: str) -> str:
+        if path not in self.files:
+            raise FileNotFoundError(path)
+        return self.files[path]
+
+    async def list(self, directory: str = ".") -> builtins.list[str]:
+        return sorted(self.files)
+
+    async def exec(self, cmd: builtins.list[str], timeout: float = 30.0) -> ExecResult:
+        self.exec_calls.append(cmd)
+        key = " ".join(cmd)
+        return self.exec_results.get(key, ExecResult(stdout="", stderr="", exit_code=0))
+
+    async def snapshot(self) -> bytes:
+        return repr(self.files).encode("utf-8")
+
+    async def close(self) -> None:
+        self.closed = True

--- a/tests/unit/test_agent_chat_builder.py
+++ b/tests/unit/test_agent_chat_builder.py
@@ -156,7 +156,7 @@ class TestRunChatTurnTextTurn:
 
     @pytest.mark.asyncio
     async def test_provider_called_with_tools(self) -> None:
-        """generate() must be called with the submit_agent_spec tool."""
+        """generate() must be called with both builder tools (submit + request_setup)."""
         provider = _make_provider(_text_result("Ok!"))
         history = [{"role": "user", "content": "hello"}]
 
@@ -166,8 +166,10 @@ class TestRunChatTurnTextTurn:
         call_kwargs = provider.generate.call_args
         passed_tools = call_kwargs.kwargs.get("tools")
         assert passed_tools is not None, "tools must be passed to generate()"
-        assert len(passed_tools) == 1
-        assert passed_tools[0].function.name == SUBMIT_TOOL_NAME
+        tool_names = {t.function.name for t in passed_tools}
+        # Wave 2 added request_setup alongside submit_agent_spec.
+        assert SUBMIT_TOOL_NAME in tool_names
+        assert "request_setup" in tool_names
 
     @pytest.mark.asyncio
     async def test_system_prompt_included(self) -> None:

--- a/tests/unit/test_agent_chat_builder_setup.py
+++ b/tests/unit/test_agent_chat_builder_setup.py
@@ -1,0 +1,152 @@
+"""Unit tests for Wave 2 inline-setup support in the agent-builder driver.
+
+The interviewer can call a `request_setup` tool to ask the user for a dependency
+(secret | mcp | provider) before finishing the spec. The streaming driver emits a
+dedicated `setup_request` event; the non-streaming path sets `ChatTurnResult.setup_request`.
+A real spec submission always wins over a setup request in the same turn.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from engine.agent_chat_builder import (
+    REQUEST_SETUP_TOOL_NAME,
+    SUBMIT_TOOL_NAME,
+    ChatStreamEvent,
+    SetupRequest,
+    run_chat_turn,
+    run_chat_turn_stream,
+)
+from engine.providers.models import GenerateResult, StreamChunk, ToolCall
+
+_VALID_SPEC = (
+    '{"name":"my-agent","version":"1.0.0","team":"default",'
+    '"owner":"owner@example.com","framework":"langgraph",'
+    '"model":{"primary":"claude-sonnet-4-6"},"deploy":{"cloud":"local"}}'
+)
+
+
+class FakeStreamingProvider:
+    """Yields a scripted sequence of StreamChunks from generate_stream()."""
+
+    def __init__(self, chunks: list[StreamChunk]) -> None:
+        self._chunks = chunks
+
+    async def generate_stream(self, **_kwargs):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class FakeProvider:
+    """Returns a scripted GenerateResult from generate()."""
+
+    def __init__(self, result: GenerateResult) -> None:
+        self._result = result
+
+    async def generate(self, **_kwargs) -> GenerateResult:
+        return self._result
+
+
+def _setup_call(kind: str, name: str, reason: str = "") -> ToolCall:
+    return ToolCall(
+        id="s1",
+        function_name=REQUEST_SETUP_TOOL_NAME,
+        function_arguments=json.dumps({"kind": kind, "name": name, "reason": reason}),
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_emits_setup_request_then_done():
+    provider = FakeStreamingProvider(
+        [
+            StreamChunk(content="You'll need Zendesk. "),
+            StreamChunk(tool_calls=[_setup_call("mcp", "zendesk", "read tickets")]),
+            StreamChunk(finish_reason="tool_calls"),
+        ]
+    )
+    events = [
+        e async for e in run_chat_turn_stream(provider, [{"role": "user", "content": "support agent"}])
+    ]
+
+    setups = [e for e in events if e.type == "setup_request"]
+    done = [e for e in events if e.type == "done"]
+
+    assert len(setups) == 1
+    assert isinstance(setups[0].setup, SetupRequest)
+    assert setups[0].setup.kind == "mcp"
+    assert setups[0].setup.name == "zendesk"
+
+    assert len(done) == 1
+    assert done[0].result is not None
+    assert done[0].result.agent_yaml is None
+    assert done[0].result.setup_request is not None
+    assert done[0].result.setup_request.name == "zendesk"
+
+
+@pytest.mark.asyncio
+async def test_stream_spec_submission_wins_over_setup_request():
+    provider = FakeStreamingProvider(
+        [
+            StreamChunk(tool_calls=[_setup_call("secret", "ZENDESK_API_KEY")]),
+            StreamChunk(
+                tool_calls=[
+                    ToolCall(id="t1", function_name=SUBMIT_TOOL_NAME, function_arguments=_VALID_SPEC)
+                ]
+            ),
+            StreamChunk(finish_reason="tool_calls"),
+        ]
+    )
+    events = [e async for e in run_chat_turn_stream(provider, [{"role": "user", "content": "go"}])]
+
+    assert not [e for e in events if e.type == "setup_request"]
+    done = [e for e in events if e.type == "done"]
+    assert len(done) == 1
+    assert done[0].result is not None
+    assert done[0].result.agent_yaml is not None
+    assert done[0].result.valid is True
+
+
+@pytest.mark.asyncio
+async def test_stream_malformed_setup_args_degrade_to_text_reply():
+    provider = FakeStreamingProvider(
+        [
+            StreamChunk(content="Hmm."),
+            StreamChunk(
+                tool_calls=[
+                    ToolCall(id="s1", function_name=REQUEST_SETUP_TOOL_NAME, function_arguments="{not json")
+                ]
+            ),
+            StreamChunk(finish_reason="tool_calls"),
+        ]
+    )
+    events = [e async for e in run_chat_turn_stream(provider, [{"role": "user", "content": "hi"}])]
+
+    assert not [e for e in events if e.type == "setup_request"]
+    done = [e for e in events if e.type == "done"]
+    assert len(done) == 1
+    assert done[0].result is not None
+    assert done[0].result.setup_request is None
+    assert done[0].result.agent_yaml is None
+    assert done[0].result.assistant_message == "Hmm."
+
+
+@pytest.mark.asyncio
+async def test_non_stream_sets_setup_request_field():
+    provider = FakeProvider(
+        GenerateResult(content="One thing first.", tool_calls=[_setup_call("provider", "openai")])
+    )
+    result = await run_chat_turn(provider, [{"role": "user", "content": "use gpt-4o"}])
+
+    assert result.agent_yaml is None
+    assert result.setup_request is not None
+    assert result.setup_request.kind == "provider"
+    assert result.setup_request.name == "openai"
+    assert result.assistant_message == "One thing first."
+
+
+def test_stream_event_supports_setup_type():
+    evt = ChatStreamEvent(type="setup_request", setup=SetupRequest(kind="secret", name="X"))
+    assert evt.type == "setup_request"
+    assert evt.setup is not None and evt.setup.name == "X"

--- a/tests/unit/test_agent_chat_builder_setup.py
+++ b/tests/unit/test_agent_chat_builder_setup.py
@@ -5,6 +5,7 @@ The interviewer can call a `request_setup` tool to ask the user for a dependency
 dedicated `setup_request` event; the non-streaming path sets `ChatTurnResult.setup_request`.
 A real spec submission always wins over a setup request in the same turn.
 """
+
 from __future__ import annotations
 
 import json
@@ -67,7 +68,10 @@ async def test_stream_emits_setup_request_then_done():
         ]
     )
     events = [
-        e async for e in run_chat_turn_stream(provider, [{"role": "user", "content": "support agent"}])
+        e
+        async for e in run_chat_turn_stream(
+            provider, [{"role": "user", "content": "support agent"}]
+        )
     ]
 
     setups = [e for e in events if e.type == "setup_request"]
@@ -92,7 +96,9 @@ async def test_stream_spec_submission_wins_over_setup_request():
             StreamChunk(tool_calls=[_setup_call("secret", "ZENDESK_API_KEY")]),
             StreamChunk(
                 tool_calls=[
-                    ToolCall(id="t1", function_name=SUBMIT_TOOL_NAME, function_arguments=_VALID_SPEC)
+                    ToolCall(
+                        id="t1", function_name=SUBMIT_TOOL_NAME, function_arguments=_VALID_SPEC
+                    )
                 ]
             ),
             StreamChunk(finish_reason="tool_calls"),
@@ -115,7 +121,11 @@ async def test_stream_malformed_setup_args_degrade_to_text_reply():
             StreamChunk(content="Hmm."),
             StreamChunk(
                 tool_calls=[
-                    ToolCall(id="s1", function_name=REQUEST_SETUP_TOOL_NAME, function_arguments="{not json")
+                    ToolCall(
+                        id="s1",
+                        function_name=REQUEST_SETUP_TOOL_NAME,
+                        function_arguments="{not json",
+                    )
                 ]
             ),
             StreamChunk(finish_reason="tool_calls"),
@@ -149,4 +159,5 @@ async def test_non_stream_sets_setup_request_field():
 def test_stream_event_supports_setup_type():
     evt = ChatStreamEvent(type="setup_request", setup=SetupRequest(kind="secret", name="X"))
     assert evt.type == "setup_request"
-    assert evt.setup is not None and evt.setup.name == "X"
+    assert evt.setup is not None
+    assert evt.setup.name == "X"

--- a/tests/unit/test_agent_chat_builder_stream.py
+++ b/tests/unit/test_agent_chat_builder_stream.py
@@ -1,9 +1,10 @@
 """Unit tests for the streaming agent-builder driver."""
+
 from __future__ import annotations
 
 import pytest
 
-from engine.agent_chat_builder import ChatStreamEvent, run_chat_turn_stream
+from engine.agent_chat_builder import run_chat_turn_stream
 from engine.providers.models import StreamChunk, ToolCall
 
 
@@ -31,7 +32,9 @@ async def test_stream_emits_text_tokens_then_done():
             StreamChunk(finish_reason="stop"),
         ]
     )
-    events = [e async for e in run_chat_turn_stream(provider, [{"role": "user", "content": "hello"}])]
+    events = [
+        e async for e in run_chat_turn_stream(provider, [{"role": "user", "content": "hello"}])
+    ]
 
     tokens = [e.text for e in events if e.type == "token"]
     done = [e for e in events if e.type == "done"]
@@ -51,11 +54,17 @@ async def test_stream_handles_spec_submission():
     )
     provider = FakeStreamingProvider(
         [
-            StreamChunk(tool_calls=[ToolCall(id="t1", function_name="submit_agent_spec", function_arguments=spec)]),
+            StreamChunk(
+                tool_calls=[
+                    ToolCall(id="t1", function_name="submit_agent_spec", function_arguments=spec)
+                ]
+            ),
             StreamChunk(finish_reason="tool_calls"),
         ]
     )
-    events = [e async for e in run_chat_turn_stream(provider, [{"role": "user", "content": "build it"}])]
+    events = [
+        e async for e in run_chat_turn_stream(provider, [{"role": "user", "content": "build it"}])
+    ]
 
     done = [e for e in events if e.type == "done"]
     assert len(done) == 1

--- a/tests/unit/test_agent_chat_builder_stream.py
+++ b/tests/unit/test_agent_chat_builder_stream.py
@@ -1,0 +1,63 @@
+"""Unit tests for the streaming agent-builder driver."""
+from __future__ import annotations
+
+import pytest
+
+from engine.agent_chat_builder import ChatStreamEvent, run_chat_turn_stream
+from engine.providers.models import StreamChunk, ToolCall
+
+
+class FakeStreamingProvider:
+    """Yields a scripted sequence of StreamChunks from generate_stream()."""
+
+    def __init__(self, chunks: list[StreamChunk]) -> None:
+        self._chunks = chunks
+        self.closed = False
+
+    async def generate_stream(self, **_kwargs):
+        for chunk in self._chunks:
+            yield chunk
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_stream_emits_text_tokens_then_done():
+    provider = FakeStreamingProvider(
+        [
+            StreamChunk(content="Hi! "),
+            StreamChunk(content="What should it do?"),
+            StreamChunk(finish_reason="stop"),
+        ]
+    )
+    events = [e async for e in run_chat_turn_stream(provider, [{"role": "user", "content": "hello"}])]
+
+    tokens = [e.text for e in events if e.type == "token"]
+    done = [e for e in events if e.type == "done"]
+
+    assert "".join(tokens) == "Hi! What should it do?"
+    assert len(done) == 1
+    assert done[0].result.agent_yaml is None
+    assert done[0].result.valid is False
+
+
+@pytest.mark.asyncio
+async def test_stream_handles_spec_submission():
+    spec = (
+        '{"name":"my-agent","version":"1.0.0","team":"default",'
+        '"owner":"owner@example.com","framework":"langgraph",'
+        '"model":{"primary":"claude-sonnet-4-6"},"deploy":{"cloud":"local"}}'
+    )
+    provider = FakeStreamingProvider(
+        [
+            StreamChunk(tool_calls=[ToolCall(id="t1", function_name="submit_agent_spec", function_arguments=spec)]),
+            StreamChunk(finish_reason="tool_calls"),
+        ]
+    )
+    events = [e async for e in run_chat_turn_stream(provider, [{"role": "user", "content": "build it"}])]
+
+    done = [e for e in events if e.type == "done"]
+    assert len(done) == 1
+    assert done[0].result.agent_yaml is not None
+    assert done[0].result.valid is True

--- a/tests/unit/test_analytics_model.py
+++ b/tests/unit/test_analytics_model.py
@@ -1,0 +1,5 @@
+from api.models.database import AnalyticsEvent
+
+
+def test_analytics_event_table_name():
+    assert AnalyticsEvent.__tablename__ == "analytics_events"

--- a/tests/unit/test_anthropic_provider_stream_tools.py
+++ b/tests/unit/test_anthropic_provider_stream_tools.py
@@ -1,0 +1,337 @@
+"""Tests for AnthropicProvider streaming tool-use event handling.
+
+Verifies that generate_stream() correctly accumulates tool_use content blocks
+across the multi-event Anthropic SSE sequence and yields StreamChunk(tool_calls=[...])
+with fully-assembled function_arguments JSON.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from engine.providers.anthropic_provider import AnthropicProvider
+from engine.providers.models import ProviderConfig, ProviderType, StreamChunk, ToolCall
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _config() -> ProviderConfig:
+    return ProviderConfig(
+        provider_type=ProviderType.anthropic,
+        api_key="sk-ant-test",
+        default_model="claude-sonnet-4-6",
+    )
+
+
+def _make_stream_ctx(sse_lines: list[str]) -> AsyncMock:
+    """Build a mock streaming context manager that yields the given SSE lines."""
+
+    async def _fake_lines():
+        for line in sse_lines:
+            yield line
+
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=ctx)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    ctx.status_code = 200
+    ctx.aiter_lines = _fake_lines
+    return ctx
+
+
+def _sse(event: dict) -> str:
+    return f"data: {json.dumps(event)}"
+
+
+# ── SSE event builders (matching Anthropic wire format exactly) ──────────────
+
+
+def _message_start(model: str = "claude-sonnet-4-6") -> str:
+    return _sse({"type": "message_start", "message": {"model": model, "usage": {}}})
+
+
+def _content_block_start_tool(index: int, tool_id: str, tool_name: str) -> str:
+    return _sse(
+        {
+            "type": "content_block_start",
+            "index": index,
+            "content_block": {
+                "type": "tool_use",
+                "id": tool_id,
+                "name": tool_name,
+                "input": {},
+            },
+        }
+    )
+
+
+def _content_block_start_text(index: int) -> str:
+    return _sse(
+        {
+            "type": "content_block_start",
+            "index": index,
+            "content_block": {"type": "text", "text": ""},
+        }
+    )
+
+
+def _input_json_delta(index: int, partial_json: str) -> str:
+    return _sse(
+        {
+            "type": "content_block_delta",
+            "index": index,
+            "delta": {"type": "input_json_delta", "partial_json": partial_json},
+        }
+    )
+
+
+def _text_delta(index: int, text: str) -> str:
+    return _sse(
+        {
+            "type": "content_block_delta",
+            "index": index,
+            "delta": {"type": "text_delta", "text": text},
+        }
+    )
+
+
+def _content_block_stop(index: int) -> str:
+    return _sse({"type": "content_block_stop", "index": index})
+
+
+def _message_delta(stop_reason: str) -> str:
+    return _sse({"type": "message_delta", "delta": {"stop_reason": stop_reason}})
+
+
+def _message_stop() -> str:
+    return _sse({"type": "message_stop"})
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+
+class TestStreamToolUse:
+    """generate_stream() assembles tool_use blocks from partial_json fragments."""
+
+    @pytest.mark.asyncio
+    async def test_single_tool_call_assembled_from_fragments(self) -> None:
+        """Core test: fragments are concatenated and a ToolCall chunk is yielded."""
+        provider = AnthropicProvider(_config())
+
+        # The tool input JSON arrives in 3 fragments
+        fragment_1 = '{"name": "My'
+        fragment_2 = " Agent"
+        fragment_3 = '", "framework": "langgraph"}'
+        full_json = fragment_1 + fragment_2 + fragment_3
+
+        sse_lines = [
+            _message_start(),
+            _content_block_start_tool(0, "toolu_01abc", "submit_agent_spec"),
+            _input_json_delta(0, fragment_1),
+            _input_json_delta(0, fragment_2),
+            _input_json_delta(0, fragment_3),
+            _content_block_stop(0),
+            _message_delta("tool_use"),
+            _message_stop(),
+        ]
+
+        provider._client.stream = MagicMock(return_value=_make_stream_ctx(sse_lines))
+
+        chunks: list[StreamChunk] = []
+        async for chunk in provider.generate_stream(messages=[{"role": "user", "content": "go"}]):
+            chunks.append(chunk)
+
+        tool_chunks = [c for c in chunks if c.tool_calls]
+        assert len(tool_chunks) == 1, "Expected exactly one chunk carrying tool_calls"
+
+        tool_call = tool_chunks[0].tool_calls[0]
+        assert isinstance(tool_call, ToolCall)
+        assert tool_call.id == "toolu_01abc"
+        assert tool_call.function_name == "submit_agent_spec"
+
+        # function_arguments must be the full concatenated JSON string
+        assert tool_call.function_arguments == full_json
+        parsed = json.loads(tool_call.function_arguments)
+        assert parsed == {"name": "My Agent", "framework": "langgraph"}
+
+    @pytest.mark.asyncio
+    async def test_tool_call_finish_reason_is_tool_calls(self) -> None:
+        """finish_reason should map 'tool_use' -> 'tool_calls'."""
+        provider = AnthropicProvider(_config())
+
+        sse_lines = [
+            _message_start(),
+            _content_block_start_tool(0, "toolu_xyz", "get_weather"),
+            _input_json_delta(0, '{"city": "London"}'),
+            _content_block_stop(0),
+            _message_delta("tool_use"),
+            _message_stop(),
+        ]
+
+        provider._client.stream = MagicMock(return_value=_make_stream_ctx(sse_lines))
+
+        chunks: list[StreamChunk] = []
+        async for chunk in provider.generate_stream(messages=[{"role": "user", "content": "go"}]):
+            chunks.append(chunk)
+
+        finish_chunks = [c for c in chunks if c.finish_reason]
+        assert finish_chunks, "Expected at least one chunk with finish_reason"
+        assert finish_chunks[-1].finish_reason == "tool_calls"
+
+    @pytest.mark.asyncio
+    async def test_multiple_tool_calls(self) -> None:
+        """Two tool blocks at different indices both produce ToolCall entries."""
+        provider = AnthropicProvider(_config())
+
+        sse_lines = [
+            _message_start(),
+            # Block 0: search tool
+            _content_block_start_tool(0, "toolu_aaa", "search"),
+            _input_json_delta(0, '{"query": "AI frameworks"}'),
+            _content_block_stop(0),
+            # Block 1: weather tool
+            _content_block_start_tool(1, "toolu_bbb", "get_weather"),
+            _input_json_delta(1, '{"city": "SF"}'),
+            _content_block_stop(1),
+            _message_delta("tool_use"),
+            _message_stop(),
+        ]
+
+        provider._client.stream = MagicMock(return_value=_make_stream_ctx(sse_lines))
+
+        chunks: list[StreamChunk] = []
+        async for chunk in provider.generate_stream(messages=[{"role": "user", "content": "go"}]):
+            chunks.append(chunk)
+
+        tool_chunks = [c for c in chunks if c.tool_calls]
+        # Either one chunk with two ToolCalls or two chunks each with one — collect all calls
+        all_tool_calls = [tc for c in tool_chunks for tc in c.tool_calls]
+        assert len(all_tool_calls) == 2
+
+        by_name = {tc.function_name: tc for tc in all_tool_calls}
+        assert "search" in by_name
+        assert "get_weather" in by_name
+        assert json.loads(by_name["search"].function_arguments) == {"query": "AI frameworks"}
+        assert json.loads(by_name["get_weather"].function_arguments) == {"city": "SF"}
+        assert by_name["search"].id == "toolu_aaa"
+        assert by_name["get_weather"].id == "toolu_bbb"
+
+    @pytest.mark.asyncio
+    async def test_tool_call_with_empty_input(self) -> None:
+        """Tool blocks that send zero input_json_delta fragments produce empty-string arguments."""
+        provider = AnthropicProvider(_config())
+
+        sse_lines = [
+            _message_start(),
+            _content_block_start_tool(0, "toolu_no_input", "ping"),
+            # no input_json_delta events at all
+            _content_block_stop(0),
+            _message_delta("tool_use"),
+            _message_stop(),
+        ]
+
+        provider._client.stream = MagicMock(return_value=_make_stream_ctx(sse_lines))
+
+        chunks: list[StreamChunk] = []
+        async for chunk in provider.generate_stream(messages=[{"role": "user", "content": "go"}]):
+            chunks.append(chunk)
+
+        tool_chunks = [c for c in chunks if c.tool_calls]
+        assert len(tool_chunks) == 1
+        tc = tool_chunks[0].tool_calls[0]
+        assert tc.function_name == "ping"
+        assert tc.function_arguments == ""
+
+
+class TestStreamTextNoRegression:
+    """Existing plain-text streaming must still work correctly after the refactor."""
+
+    @pytest.mark.asyncio
+    async def test_plain_text_streaming_unchanged(self) -> None:
+        provider = AnthropicProvider(_config())
+
+        sse_lines = [
+            _message_start(),
+            _content_block_start_text(0),
+            _text_delta(0, "Hello"),
+            _text_delta(0, " world"),
+            _content_block_stop(0),
+            _message_delta("end_turn"),
+            _message_stop(),
+        ]
+
+        provider._client.stream = MagicMock(return_value=_make_stream_ctx(sse_lines))
+
+        chunks: list[StreamChunk] = []
+        async for chunk in provider.generate_stream(messages=[{"role": "user", "content": "Hi"}]):
+            chunks.append(chunk)
+
+        text_chunks = [c for c in chunks if c.content]
+        assert [c.content for c in text_chunks] == ["Hello", " world"]
+
+        finish_chunks = [c for c in chunks if c.finish_reason]
+        assert finish_chunks[-1].finish_reason == "stop"
+
+        # No spurious tool_calls on a text-only response
+        assert not any(c.tool_calls for c in chunks)
+
+    @pytest.mark.asyncio
+    async def test_text_and_tool_in_same_response(self) -> None:
+        """A response with both a text block and a tool block works correctly."""
+        provider = AnthropicProvider(_config())
+
+        sse_lines = [
+            _message_start(),
+            # Text block first
+            _content_block_start_text(0),
+            _text_delta(0, "Thinking..."),
+            _content_block_stop(0),
+            # Then tool block
+            _content_block_start_tool(1, "toolu_mixed", "do_thing"),
+            _input_json_delta(1, '{"key": "val"}'),
+            _content_block_stop(1),
+            _message_delta("tool_use"),
+            _message_stop(),
+        ]
+
+        provider._client.stream = MagicMock(return_value=_make_stream_ctx(sse_lines))
+
+        chunks: list[StreamChunk] = []
+        async for chunk in provider.generate_stream(messages=[{"role": "user", "content": "go"}]):
+            chunks.append(chunk)
+
+        text_chunks = [c for c in chunks if c.content]
+        assert any(c.content == "Thinking..." for c in text_chunks)
+
+        tool_chunks = [c for c in chunks if c.tool_calls]
+        assert len(tool_chunks) == 1
+        assert tool_chunks[0].tool_calls[0].function_name == "do_thing"
+        assert json.loads(tool_chunks[0].tool_calls[0].function_arguments) == {"key": "val"}
+
+    @pytest.mark.asyncio
+    async def test_input_json_delta_without_prior_block_start_is_ignored(self) -> None:
+        """Orphaned input_json_delta events (no matching block start) do not crash."""
+        provider = AnthropicProvider(_config())
+
+        sse_lines = [
+            _message_start(),
+            # input_json_delta for index 5 but no content_block_start for it
+            _input_json_delta(5, '{"orphan": true}'),
+            _text_delta(0, "safe"),
+            _message_delta("end_turn"),
+            _message_stop(),
+        ]
+
+        provider._client.stream = MagicMock(return_value=_make_stream_ctx(sse_lines))
+
+        chunks: list[StreamChunk] = []
+        async for chunk in provider.generate_stream(messages=[{"role": "user", "content": "Hi"}]):
+            chunks.append(chunk)
+
+        # Should not raise; text still comes through
+        assert any(c.content == "safe" for c in chunks)
+        # No tool chunks for the orphaned delta
+        assert not any(c.tool_calls for c in chunks)

--- a/tests/unit/test_anthropic_provider_stream_tools.py
+++ b/tests/unit/test_anthropic_provider_stream_tools.py
@@ -15,7 +15,6 @@ import pytest
 from engine.providers.anthropic_provider import AnthropicProvider
 from engine.providers.models import ProviderConfig, ProviderType, StreamChunk, ToolCall
 
-
 # ── Helpers ─────────────────────────────────────────────────────────────────
 
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -9,6 +9,31 @@ from api.main import app
 client = TestClient(app)
 
 
+def _route_paths(application) -> list[str]:
+    """Collect every route path, flattening included routers.
+
+    Starlette >=1.3 wraps ``include_router()`` results in an ``_IncludedRouter``
+    object that has no ``.path`` (the real routes live on ``original_router``),
+    so a flat ``[r.path for r in app.routes]`` raises AttributeError. This walks
+    plain routes, mounts, and included routers uniformly.
+    """
+    paths: list[str] = []
+    stack = list(getattr(application, "routes", []))
+    guard = 0
+    while stack and guard < 20000:
+        guard += 1
+        route = stack.pop()
+        path = getattr(route, "path", None)
+        if isinstance(path, str):
+            paths.append(path)
+        original = getattr(route, "original_router", None)
+        if original is not None:
+            stack.extend(getattr(original, "routes", []))
+        elif getattr(route, "routes", None):
+            stack.extend(route.routes)
+    return paths
+
+
 class TestHealthEndpoint:
     def test_health_returns_200(self) -> None:
         response = client.get("/health")
@@ -24,12 +49,12 @@ class TestAPIConfig:
         assert app.title == "AgentBreeder API"
 
     def test_api_has_agent_routes(self) -> None:
-        routes = [r.path for r in app.routes]
-        assert "/api/v1/agents" in routes or any("/api/v1/agents" in r for r in routes)
+        routes = _route_paths(app)
+        assert any("/api/v1/agents" in r for r in routes)
 
     def test_api_has_registry_routes(self) -> None:
-        routes = [r.path for r in app.routes]
-        assert any("/api/v1/registry" in str(r) for r in routes)
+        routes = _route_paths(app)
+        assert any("/api/v1/registry" in r for r in routes)
 
     def test_api_has_cors(self) -> None:
         response = client.options("/health", headers={"Origin": "http://localhost:3000"})

--- a/tests/unit/test_builder_session_service.py
+++ b/tests/unit/test_builder_session_service.py
@@ -1,0 +1,49 @@
+"""Unit tests for BuilderSessionService.run_interview_turn (Wave 3 C4).
+
+Drives the interview turn directly with a fake provider and a monkeypatched
+run_chat_turn_stream so the real frame-emission + history-threading +
+durable-commit logic is exercised without a database or Claude API.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from api.services.builder_session_service import BuilderSessionService, SessionEventBus
+
+
+@pytest.mark.asyncio
+async def test_run_interview_turn_threads_history_and_persists(monkeypatch):
+    from engine.agent_chat_builder import ChatStreamEvent, ChatTurnResult
+
+    async def _fake_stream(provider, history):
+        yield ChatStreamEvent(type="token", text="Hi")
+        yield ChatStreamEvent(
+            type="done",
+            result=ChatTurnResult(
+                assistant_message="Hi there",
+                agent_yaml="name: x",
+                valid=True,
+                errors=[],
+            ),
+        )
+
+    monkeypatch.setattr("api.services.builder_session_service.run_chat_turn_stream", _fake_stream)
+
+    db = AsyncMock()
+    svc = BuilderSessionService(db, SessionEventBus())
+    sess = SimpleNamespace(state={"history": [], "agent_yaml": None, "files": {}})
+
+    frames = [f async for f in svc.run_interview_turn(sess, object(), "build a bot")]
+
+    events = [f["event"] for f in frames]
+    assert "token" in events
+    assert "spec_update" in events  # agent_yaml present
+    assert events[-1] == "done"
+    # history threaded: user first, assistant last
+    assert sess.state["history"][0] == {"role": "user", "content": "build a bot"}
+    assert sess.state["history"][-1]["role"] == "assistant"
+    assert sess.state["history"][-1]["content"] == "Hi there"
+    assert sess.state["agent_yaml"] == "name: x"
+    db.commit.assert_awaited()  # Fix 1: durable commit

--- a/tests/unit/test_builder_session_service_sandbox.py
+++ b/tests/unit/test_builder_session_service_sandbox.py
@@ -1,0 +1,63 @@
+"""_make_sandbox selection + eject frame contract (W4)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api.services import builder_session_service as svc
+from engine.coding_agent.base import AgentEvent
+from engine.sandbox.cloud import CloudSandbox
+from engine.sandbox.local import LocalSandbox
+
+
+def test_make_sandbox_local(monkeypatch):
+    monkeypatch.setenv("AGENTBREEDER_SANDBOX", "local")
+    sb = svc._make_sandbox()
+    assert isinstance(sb, LocalSandbox)
+
+
+def test_make_sandbox_cloud_returns_cloud_sandbox(monkeypatch):
+    monkeypatch.setenv("AGENTBREEDER_SANDBOX", "cloud")
+    monkeypatch.setenv("AGENTBREEDER_SANDBOX_BACKEND", "fake")
+    sb = svc._make_sandbox()
+    assert isinstance(sb, CloudSandbox)
+
+
+def test_make_sandbox_disabled_raises(monkeypatch):
+    monkeypatch.setenv("AGENTBREEDER_SANDBOX", "disabled")
+    with pytest.raises(svc.CloudSandboxUnavailable):
+        svc._make_sandbox()
+
+
+class _FakeEngine:
+    name = "claude"
+
+    async def run(self, instruction, history, sandbox, bounds=None):
+        yield AgentEvent(type="done", text="built it")
+
+
+@pytest.mark.asyncio
+async def test_eject_complete_frame_has_code_and_sandbox_seconds(monkeypatch):
+    monkeypatch.setenv("AGENTBREEDER_SANDBOX", "cloud")
+    monkeypatch.setenv("AGENTBREEDER_SANDBOX_BACKEND", "fake")
+    monkeypatch.setattr(svc, "engine_for", lambda name, provider: _FakeEngine())
+
+    db = AsyncMock()
+    service = svc.BuilderSessionService(db, svc.SessionEventBus())
+    sess = MagicMock()
+    sess.state = {"history": [], "files": {}, "agent_yaml": None}
+
+    frames = [
+        f
+        async for f in service.run_eject(
+            sess, provider=None, instruction="x", engine_name="claude"
+        )
+    ]
+    complete = [f for f in frames if f["event"] == "complete"][0]
+    payload = json.loads(complete["data"])
+    assert payload["code"] == "ok"
+    assert "sandbox_seconds" in payload
+    assert payload["sandbox_seconds"] >= 0.0

--- a/tests/unit/test_cli_coverage_boost.py
+++ b/tests/unit/test_cli_coverage_boost.py
@@ -2371,7 +2371,9 @@ class TestEjectRemainingBranches:
 
     def test_eject_unsupported_sdk(self) -> None:
         """eject command with unsupported --sdk value."""
-        from click.exceptions import Exit as ClickExit
+        # The command raises typer.Exit; catch that directly. typer >=0.26
+        # bundles its own click, so typer.Exit is no longer click.exceptions.Exit.
+        from typer import Exit as TyperExit
 
         from cli.commands.eject import eject as eject_fn
 
@@ -2379,7 +2381,7 @@ class TestEjectRemainingBranches:
         f.write(VALID_YAML)
         f.close()
 
-        with pytest.raises(ClickExit) as exc_info:
+        with pytest.raises(TyperExit) as exc_info:
             eject_fn(
                 config_path=Path(f.name),
                 sdk="ruby",

--- a/tests/unit/test_cloud_sandbox.py
+++ b/tests/unit/test_cloud_sandbox.py
@@ -2,9 +2,53 @@
 
 from __future__ import annotations
 
+import pytest
+
 from engine.sandbox.backends.base import SandboxBackend
 from engine.sandbox.backends.fake import FakeBackend
+from engine.sandbox.base import Sandbox
+from engine.sandbox.cloud import _MAX_FILE_BYTES, CloudSandbox, _safe_relpath
 
 
 def test_fake_backend_satisfies_protocol():
     assert isinstance(FakeBackend(), SandboxBackend)
+
+
+def test_cloud_sandbox_satisfies_protocol():
+    assert isinstance(CloudSandbox(FakeBackend()), Sandbox)
+
+
+@pytest.mark.parametrize("bad", ["/etc/passwd", "../escape", "a/../../b", "\\abs"])
+def test_safe_relpath_rejects_escapes(bad):
+    with pytest.raises(ValueError):
+        _safe_relpath(bad)
+
+
+def test_safe_relpath_normalizes():
+    assert _safe_relpath("./a/b.py") == "a/b.py"
+
+
+@pytest.mark.asyncio
+async def test_cloud_sandbox_write_read_roundtrip_starts_backend():
+    backend = FakeBackend()
+    sb = CloudSandbox(backend)
+    await sb.write("agent.py", "print('hi')")
+    assert backend.started is True
+    assert await sb.read("agent.py") == "print('hi')"
+
+
+@pytest.mark.asyncio
+async def test_cloud_sandbox_write_rejects_oversize():
+    sb = CloudSandbox(FakeBackend())
+    with pytest.raises(ValueError):
+        await sb.write("big.txt", "x" * (_MAX_FILE_BYTES + 1))
+
+
+@pytest.mark.asyncio
+async def test_cloud_sandbox_close_records_elapsed_and_destroys():
+    backend = FakeBackend()
+    sb = CloudSandbox(backend)
+    await sb.write("a.py", "1")  # starts backend
+    await sb.close()
+    assert backend.destroyed is True
+    assert sb.elapsed_seconds >= 0.0

--- a/tests/unit/test_cloud_sandbox.py
+++ b/tests/unit/test_cloud_sandbox.py
@@ -1,0 +1,10 @@
+"""Unit tests for CloudSandbox + the SandboxBackend abstraction (no network)."""
+
+from __future__ import annotations
+
+from engine.sandbox.backends.base import SandboxBackend
+from engine.sandbox.backends.fake import FakeBackend
+
+
+def test_fake_backend_satisfies_protocol():
+    assert isinstance(FakeBackend(), SandboxBackend)

--- a/tests/unit/test_coding_agent_base.py
+++ b/tests/unit/test_coding_agent_base.py
@@ -1,0 +1,25 @@
+from engine.coding_agent.base import (
+    CODING_TOOLS,
+    TOOL_NAMES,
+    AgentBounds,
+    AgentEvent,
+)
+
+
+def test_agent_event_token_defaults():
+    e = AgentEvent(type="token", text="hi")
+    assert e.path == ""
+    assert e.diff == ""
+    assert e.error == ""
+
+
+def test_coding_tools_cover_fs_surface():
+    assert TOOL_NAMES == {"write_file", "read_file", "list_files", "run_command"}
+    assert all(t.function.name in TOOL_NAMES for t in CODING_TOOLS)
+
+
+def test_bounds_defaults_are_sane():
+    b = AgentBounds()
+    assert b.max_turns >= 1
+    assert b.wall_clock_s > 0
+    assert b.max_tokens > 0

--- a/tests/unit/test_coding_engines.py
+++ b/tests/unit/test_coding_engines.py
@@ -1,0 +1,30 @@
+import pytest
+
+from engine.coding_agent.engines import ClaudeAgentEngine, CodexEngine, engine_for
+from tests.unit.fakes.fake_provider import FakeProvider, text
+from tests.unit.fakes.fake_sandbox import FakeSandbox
+
+
+def test_engine_for_claude():
+    e = engine_for("claude", provider=FakeProvider([]))
+    assert isinstance(e, ClaudeAgentEngine)
+    assert e.name == "claude"
+
+
+def test_engine_for_codex():
+    e = engine_for("codex", provider=FakeProvider([]))
+    assert isinstance(e, CodexEngine)
+    assert e.name == "codex"
+
+
+def test_engine_for_unknown_raises():
+    with pytest.raises(ValueError):
+        engine_for("bard", provider=FakeProvider([]))
+
+
+@pytest.mark.asyncio
+async def test_engine_run_streams_done():
+    provider = FakeProvider([[text("hi")]])
+    engine = engine_for("claude", provider=provider)
+    events = [e async for e in engine.run("build", [], FakeSandbox())]
+    assert events[-1].type == "done"

--- a/tests/unit/test_coding_loop.py
+++ b/tests/unit/test_coding_loop.py
@@ -1,0 +1,284 @@
+import json
+
+import pytest
+
+from engine.coding_agent.base import AgentBounds
+from engine.coding_agent.loop import _apply_tool, run_coding_loop
+from engine.providers.models import ToolCall
+from tests.unit.fakes.fake_provider import FakeProvider, call, text
+from tests.unit.fakes.fake_sandbox import FakeSandbox
+
+
+@pytest.mark.asyncio
+async def test_apply_tool_unknown_name_returns_error():
+    sandbox = FakeSandbox()
+    tc = ToolCall(id="x", function_name="mystery", function_arguments="{}")
+    result, event = await _apply_tool(sandbox, tc)
+    assert "unknown tool mystery" in result
+    assert event is None
+
+
+@pytest.mark.asyncio
+async def test_loop_writes_file_and_emits_diff():
+    sandbox = FakeSandbox()
+    provider = FakeProvider(
+        [
+            [
+                text("Creating agent.py"),
+                call(
+                    "c1",
+                    "write_file",
+                    json.dumps({"path": "agent.py", "content": "print(1)\n"}),
+                ),
+            ],
+            [text("Done.")],
+        ]
+    )
+
+    events = [
+        e
+        async for e in run_coding_loop(
+            provider=provider,
+            model="m",
+            system_prompt="sys",
+            instruction="build it",
+            history=[],
+            sandbox=sandbox,
+            bounds=AgentBounds(max_turns=5),
+        )
+    ]
+
+    types = [e.type for e in events]
+    assert "token" in types
+    assert "file_change" in types
+    assert types[-1] == "done"
+    fc = next(e for e in events if e.type == "file_change")
+    assert fc.path == "agent.py"
+    assert "+print(1)" in fc.diff
+    assert sandbox.files["agent.py"] == "print(1)\n"
+
+
+@pytest.mark.asyncio
+async def test_loop_respects_max_turns():
+    sandbox = FakeSandbox()
+    provider = FakeProvider([[call(f"c{i}", "list_files", "{}")] for i in range(20)])
+    events = [
+        e
+        async for e in run_coding_loop(
+            provider=provider,
+            model="m",
+            system_prompt="s",
+            instruction="x",
+            history=[],
+            sandbox=sandbox,
+            bounds=AgentBounds(max_turns=3),
+        )
+    ]
+    assert events[-1].type == "done"
+    assert len([e for e in events if e.type == "tool_call"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_loop_run_command_feeds_result_back():
+    sandbox = FakeSandbox()
+    provider = FakeProvider(
+        [
+            [call("c1", "run_command", json.dumps({"cmd": ["pytest"], "timeout": 5}))],
+            [text("tests pass")],
+        ]
+    )
+    events = [
+        e
+        async for e in run_coding_loop(
+            provider=provider,
+            model="m",
+            system_prompt="s",
+            instruction="run tests",
+            history=[],
+            sandbox=sandbox,
+        )
+    ]
+    assert sandbox.exec_calls == [["pytest"]]
+    assert events[-1].type == "done"
+    assert any(m.get("role") == "tool" for m in provider.calls[1])
+
+
+@pytest.mark.asyncio
+async def test_loop_malformed_tool_args_feed_error_back():
+    sandbox = FakeSandbox()
+    provider = FakeProvider(
+        [
+            [call("c1", "write_file", "{not json")],
+            [text("ok")],
+        ]
+    )
+    events = [
+        e
+        async for e in run_coding_loop(
+            provider=provider,
+            model="m",
+            system_prompt="s",
+            instruction="x",
+            history=[],
+            sandbox=sandbox,
+        )
+    ]
+    assert events[-1].type == "done"
+    tool_msg = next(m for m in provider.calls[1] if m.get("role") == "tool")
+    assert "malformed" in tool_msg["content"]
+    assert sandbox.files == {}
+
+
+@pytest.mark.asyncio
+async def test_loop_read_missing_file_feeds_error_back():
+    sandbox = FakeSandbox()
+    provider = FakeProvider(
+        [
+            [call("c1", "read_file", json.dumps({"path": "nope.py"}))],
+            [text("done")],
+        ]
+    )
+    events = [
+        e
+        async for e in run_coding_loop(
+            provider=provider,
+            model="m",
+            system_prompt="s",
+            instruction="x",
+            history=[],
+            sandbox=sandbox,
+        )
+    ]
+    assert events[-1].type == "done"
+    tool_msg = next(m for m in provider.calls[1] if m.get("role") == "tool")
+    assert "file not found" in tool_msg["content"]
+
+
+@pytest.mark.asyncio
+async def test_loop_read_existing_file_returns_content():
+    sandbox = FakeSandbox()
+    sandbox.files["a.py"] = "x = 1\n"
+    provider = FakeProvider(
+        [
+            [call("c1", "read_file", json.dumps({"path": "a.py"}))],
+            [text("done")],
+        ]
+    )
+    events = [
+        e
+        async for e in run_coding_loop(
+            provider=provider,
+            model="m",
+            system_prompt="s",
+            instruction="x",
+            history=[],
+            sandbox=sandbox,
+        )
+    ]
+    assert events[-1].type == "done"
+    tool_msg = next(m for m in provider.calls[1] if m.get("role") == "tool")
+    assert tool_msg["content"] == "x = 1\n"
+
+
+@pytest.mark.asyncio
+async def test_loop_list_files_returns_listing():
+    sandbox = FakeSandbox()
+    sandbox.files["a.py"] = ""
+    sandbox.files["b.py"] = ""
+    provider = FakeProvider(
+        [
+            [call("c1", "list_files", "{}")],
+            [text("done")],
+        ]
+    )
+    events = [
+        e
+        async for e in run_coding_loop(
+            provider=provider,
+            model="m",
+            system_prompt="s",
+            instruction="x",
+            history=[],
+            sandbox=sandbox,
+        )
+    ]
+    assert events[-1].type == "done"
+    tool_msg = next(m for m in provider.calls[1] if m.get("role") == "tool")
+    assert "a.py" in tool_msg["content"]
+    assert "b.py" in tool_msg["content"]
+
+
+@pytest.mark.asyncio
+async def test_loop_unavailable_tool_feeds_error_without_executing():
+    sandbox = FakeSandbox()
+    provider = FakeProvider(
+        [
+            [call("c1", "delete_everything", "{}")],
+            [text("done")],
+        ]
+    )
+    events = [
+        e
+        async for e in run_coding_loop(
+            provider=provider,
+            model="m",
+            system_prompt="s",
+            instruction="x",
+            history=[],
+            sandbox=sandbox,
+        )
+    ]
+    assert events[-1].type == "done"
+    assert not any(e.type == "tool_call" for e in events)
+    tool_msg = next(m for m in provider.calls[1] if m.get("role") == "tool")
+    assert "not available" in tool_msg["content"]
+
+
+@pytest.mark.asyncio
+async def test_loop_stops_on_wall_clock_bound():
+    sandbox = FakeSandbox()
+    provider = FakeProvider([[call("c1", "list_files", "{}")]])
+    events = [
+        e
+        async for e in run_coding_loop(
+            provider=provider,
+            model="m",
+            system_prompt="s",
+            instruction="x",
+            history=[],
+            sandbox=sandbox,
+            bounds=AgentBounds(wall_clock_s=-1.0),
+        )
+    ]
+    assert events[-1].type == "done"
+    assert "wall-clock" in events[-1].text
+    assert provider.calls == []
+
+
+@pytest.mark.asyncio
+async def test_loop_stops_on_token_bound():
+    sandbox = FakeSandbox()
+    provider = FakeProvider(
+        [
+            [
+                text("a lot of tokens here"),
+                call("c1", "list_files", "{}"),
+            ],
+            [text("should not reach")],
+        ]
+    )
+    events = [
+        e
+        async for e in run_coding_loop(
+            provider=provider,
+            model="m",
+            system_prompt="s",
+            instruction="x",
+            history=[],
+            sandbox=sandbox,
+            bounds=AgentBounds(max_tokens=1),
+        )
+    ]
+    assert events[-1].type == "done"
+    assert "token bound" in events[-1].text
+    assert len(provider.calls) == 1

--- a/tests/unit/test_funnel_metrics.py
+++ b/tests/unit/test_funnel_metrics.py
@@ -1,0 +1,24 @@
+from api.routes.analytics import _percentile, _scorecard_from_rows
+
+
+def test_percentile_p50_p90():
+    data = [10.0, 20.0, 30.0, 40.0, 50.0]
+    assert _percentile(data, 50) == 30.0
+    # Linear interpolation (numpy 'linear' default): p90 of this set is 46.0,
+    # not the max. k = (5-1)*0.9 = 3.6 -> 40 + (50-40)*0.6.
+    assert _percentile(data, 90) == 46.0
+
+
+def test_percentile_empty_is_none():
+    assert _percentile([], 50) is None
+
+
+def test_scorecard_rates():
+    # 4 sessions: 3 valid specs, 2 deploy successes, avg 5 turns, 1 hallucination
+    sc = _scorecard_from_rows(
+        engine="claude", samples=4, valid=3, deployed=2, total_turns=20, hallucinated=1
+    )
+    assert sc.spec_validity_rate == 0.75
+    assert sc.deploy_success_rate == 0.5
+    assert sc.turns_to_spec == 5.0
+    assert sc.hallucinated_field_rate == 0.25

--- a/tests/unit/test_provider_tool_roundtrip.py
+++ b/tests/unit/test_provider_tool_roundtrip.py
@@ -1,0 +1,58 @@
+import json
+
+from engine.providers.anthropic_provider import AnthropicProvider
+from engine.providers.models import ProviderConfig, ProviderType
+from engine.providers.openai_provider import OpenAIProvider
+
+
+def _messages():
+    return [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "build it"},
+        {
+            "role": "assistant",
+            "content": "Creating agent.py",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function_name": "write_file",
+                    "function_arguments": json.dumps({"path": "agent.py", "content": "x=1\n"}),
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "wrote agent.py (4 bytes)"},
+    ]
+
+
+def test_anthropic_builds_tool_use_and_tool_result_blocks():
+    p = AnthropicProvider(ProviderConfig(provider_type=ProviderType.anthropic, api_key="sk-x"))
+    payload = p._build_payload(_messages(), "claude-sonnet-4-6", None, 1024, None)
+    msgs = payload["messages"]
+    asst = next(m for m in msgs if m["role"] == "assistant")
+    tu = [b for b in asst["content"] if isinstance(b, dict) and b.get("type") == "tool_use"]
+    assert tu
+    assert tu[0]["id"] == "call_1"
+    assert tu[0]["name"] == "write_file"
+    assert tu[0]["input"] == {"path": "agent.py", "content": "x=1\n"}
+    tr_turns = [
+        m
+        for m in msgs
+        if m["role"] == "user"
+        and isinstance(m["content"], list)
+        and any(b.get("type") == "tool_result" for b in m["content"])
+    ]
+    assert tr_turns
+    block = next(b for b in tr_turns[-1]["content"] if b.get("type") == "tool_result")
+    assert block["tool_use_id"] == "call_1"
+
+
+def test_openai_translates_toolcall_shape():
+    p = OpenAIProvider(ProviderConfig(provider_type=ProviderType.openai, api_key="sk-x"))
+    payload = p._build_payload(_messages(), "gpt-4o", None, None, None, False)
+    asst = next(m for m in payload["messages"] if m["role"] == "assistant")
+    fn = asst["tool_calls"][0]["function"]
+    assert fn["name"] == "write_file"
+    assert json.loads(fn["arguments"])["path"] == "agent.py"
+    tool_msg = next(m for m in payload["messages"] if m["role"] == "tool")
+    assert tool_msg["tool_call_id"] == "call_1"

--- a/tests/unit/test_rbac_system.py
+++ b/tests/unit/test_rbac_system.py
@@ -1004,7 +1004,22 @@ class TestRBACRoutes:
 
     def test_rbac_router_registered(self, client: TestClient) -> None:
         """The /api/v1/rbac prefix must be reachable (even if auth-gated)."""
-        routes = [str(r.path) for r in client.app.routes]
+        # Starlette >=1.3 wraps include_router() results in _IncludedRouter
+        # (no .path); flatten via original_router so this survives the bump.
+        routes: list[str] = []
+        stack = list(client.app.routes)
+        guard = 0
+        while stack and guard < 20000:
+            guard += 1
+            route = stack.pop()
+            path = getattr(route, "path", None)
+            if isinstance(path, str):
+                routes.append(path)
+            original = getattr(route, "original_router", None)
+            if original is not None:
+                stack.extend(getattr(original, "routes", []))
+            elif getattr(route, "routes", None):
+                stack.extend(route.routes)
         rbac_routes = [r for r in routes if r.startswith("/api/v1/rbac")]
         assert len(rbac_routes) > 0, "RBAC routes must be registered in the app"
 

--- a/tests/unit/test_sandbox_base.py
+++ b/tests/unit/test_sandbox_base.py
@@ -1,0 +1,33 @@
+import pytest
+
+from engine.sandbox.base import (
+    ExecResult,
+    SandboxDisabledError,
+    select_sandbox_mode,
+)
+
+
+def test_exec_result_defaults():
+    r = ExecResult(stdout="hi", stderr="", exit_code=0)
+    assert r.timed_out is False
+    assert r.ok is True
+
+
+def test_exec_result_nonzero_not_ok():
+    assert ExecResult(stdout="", stderr="boom", exit_code=1).ok is False
+
+
+def test_select_sandbox_mode_defaults_local(monkeypatch):
+    monkeypatch.delenv("AGENTBREEDER_SANDBOX", raising=False)
+    assert select_sandbox_mode() == "local"
+
+
+def test_select_sandbox_mode_reads_env(monkeypatch):
+    monkeypatch.setenv("AGENTBREEDER_SANDBOX", "cloud")
+    assert select_sandbox_mode() == "cloud"
+
+
+def test_select_sandbox_mode_rejects_unknown(monkeypatch):
+    monkeypatch.setenv("AGENTBREEDER_SANDBOX", "bogus")
+    with pytest.raises(SandboxDisabledError):
+        select_sandbox_mode()

--- a/tests/unit/test_sandbox_local.py
+++ b/tests/unit/test_sandbox_local.py
@@ -1,0 +1,73 @@
+import pytest
+
+from engine.sandbox.local import LocalSandbox
+
+
+@pytest.mark.asyncio
+async def test_write_then_read_roundtrip():
+    sb = LocalSandbox()
+    try:
+        await sb.write("agent.py", "print('hi')\n")
+        assert await sb.read("agent.py") == "print('hi')\n"
+    finally:
+        await sb.close()
+
+
+@pytest.mark.asyncio
+async def test_write_creates_nested_dirs():
+    sb = LocalSandbox()
+    try:
+        await sb.write("tools/search.py", "x = 1\n")
+        assert "tools/search.py" in await sb.list(".")
+    finally:
+        await sb.close()
+
+
+@pytest.mark.asyncio
+async def test_read_missing_raises_filenotfound():
+    sb = LocalSandbox()
+    try:
+        with pytest.raises(FileNotFoundError):
+            await sb.read("nope.py")
+    finally:
+        await sb.close()
+
+
+@pytest.mark.asyncio
+async def test_path_traversal_is_rejected():
+    sb = LocalSandbox()
+    try:
+        with pytest.raises(ValueError):
+            await sb.write("../escape.py", "danger")
+        with pytest.raises(ValueError):
+            await sb.read("/etc/passwd")
+    finally:
+        await sb.close()
+
+
+@pytest.mark.asyncio
+async def test_write_rejects_oversized_file():
+    sb = LocalSandbox()
+    try:
+        with pytest.raises(ValueError):
+            await sb.write("big.txt", "x" * 1_000_001)
+    finally:
+        await sb.close()
+
+
+@pytest.mark.asyncio
+async def test_list_missing_directory_returns_empty():
+    sb = LocalSandbox()
+    try:
+        assert await sb.list("does-not-exist") == []
+    finally:
+        await sb.close()
+
+
+@pytest.mark.asyncio
+async def test_close_removes_workspace():
+    sb = LocalSandbox()
+    root = sb.root
+    await sb.write("a.txt", "1")
+    await sb.close()
+    assert not root.exists()

--- a/tests/unit/test_sandbox_local.py
+++ b/tests/unit/test_sandbox_local.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from engine.sandbox.local import LocalSandbox
@@ -71,3 +73,53 @@ async def test_close_removes_workspace():
     await sb.write("a.txt", "1")
     await sb.close()
     assert not root.exists()
+
+
+@pytest.mark.asyncio
+async def test_exec_runs_and_captures_stdout():
+    sb = LocalSandbox()
+    try:
+        await sb.write("hello.py", "print('from sandbox')\n")
+        res = await sb.exec([sys.executable, "hello.py"], timeout=10)
+        assert res.ok
+        assert "from sandbox" in res.stdout
+    finally:
+        await sb.close()
+
+
+@pytest.mark.asyncio
+async def test_exec_timeout_is_flagged():
+    sb = LocalSandbox()
+    try:
+        res = await sb.exec([sys.executable, "-c", "import time; time.sleep(5)"], timeout=0.5)
+        assert res.timed_out is True
+        assert res.exit_code == 124
+    finally:
+        await sb.close()
+
+
+@pytest.mark.asyncio
+async def test_exec_missing_command_returns_127():
+    sb = LocalSandbox()
+    try:
+        res = await sb.exec(["this-binary-does-not-exist-xyz"], timeout=5)
+        assert res.exit_code == 127
+        assert res.ok is False
+    finally:
+        await sb.close()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_contains_written_files():
+    import io
+    import zipfile
+
+    sb = LocalSandbox()
+    try:
+        await sb.write("agent.py", "x = 1\n")
+        await sb.write("tools/t.py", "y = 2\n")
+        data = await sb.snapshot()
+        names = set(zipfile.ZipFile(io.BytesIO(data)).namelist())
+        assert {"agent.py", "tools/t.py"} <= names
+    finally:
+        await sb.close()

--- a/website/content/docs/how-to.mdx
+++ b/website/content/docs/how-to.mdx
@@ -152,9 +152,17 @@ Once the chat has produced a validated `agent.yaml`, an **Eject to code** button
 - **Watch the code stream in.** The coding agent writes files into a sandbox workspace and you see live file diffs land in a new **Code** tab in the chat. It can run the generated tests in the sandbox and iterate on failures before handing back.
 - **Deploy from the same thread.** When the code is ready, deploy it straight from the conversation. This is the same governed deploy as everywhere else — RBAC, audit trail, and registry registration all apply.
 
-<Callout type="warning" title="Code generation runs in a local sandbox">
-  Eject-to-code executes in a **local** sandbox on the machine running Studio — `AGENTBREEDER_SANDBOX=local` is the default. In cloud / multi-tenant mode this is gated off: the eject endpoint returns **HTTP 409** until the managed cloud sandbox ships in a later release. Self-hosted users with `AGENTBREEDER_SANDBOX=local` get the full flow today; on [console.agentbreeder.io](https://console.agentbreeder.io) the **Eject to code** button is disabled for now.
+<Callout type="info" title="Where code generation runs">
+  Eject-to-code runs in a sandbox selected by `AGENTBREEDER_SANDBOX`:
+
+  - **`local`** (default) — runs on the machine running Studio. Right for self-hosted, single-user setups.
+  - **`cloud`** — runs in a managed microVM, isolated per session, so multi-tenant deployments never execute user code in-process. Pick the backend with `AGENTBREEDER_SANDBOX_BACKEND` (default `e2b`; `fake` is for tests). The cloud backend enforces path containment, per-file size and exec-timeout caps, and a default-deny egress allowlist.
+  - **`disabled`** — the eject endpoint is turned off entirely.
+
+  On [console.agentbreeder.io](https://console.agentbreeder.io) the cloud sandbox is metered: each eject is charged actual **sandbox-minutes** against your plan's daily quota (a pre-check returns **HTTP 429** when the cap is already met), on top of the per-turn quota the chat builder uses.
 </Callout>
+
+**Builder analytics.** Studio › **Builder** shows the conversational-builder funnel for your team — Converse → Spec validated → Eject → Deploy → Live — with the drop-off at each step, a north-star "time to first deployed agent" (p50/p90), and per-engine scorecards. Events are structural and PII-free (no message or prompt bodies are ever recorded), and the view is scoped to your own team.
 
 ---
 

--- a/website/content/docs/how-to.mdx
+++ b/website/content/docs/how-to.mdx
@@ -105,23 +105,44 @@ agentbreeder chat
 
 ### Chat to build (BYO Claude key)
 
-AgentBreeder Studio includes a **Chat to build** tab at `/agents/new` that lets you describe your agent in plain language and have Claude generate a ready-to-deploy `agent.yaml` for you.
+AgentBreeder Studio's home page greets you with a conversational front door — **"What do you want to build today?"** — whenever you have no agents yet, and is also reachable any time at **Studio → Agents → New agent** (`/agents/new`). Type what you want or pick an example starter and the builder takes it from there.
+
+**One-time setup — add your Claude API key:**
+
+Go to **Settings → Secrets** and paste your key under **Claude API Key**. It is stored in the workspace secrets backend under `AGENTBREEDER_CLAUDE_BUILDER_KEY` — never in the database, never returned to the browser, never logged. Get a key at [console.anthropic.com](https://console.anthropic.com).
+
+<Callout type="info" title="Key stored once, used server-side">
+  Your Claude API key is read on the server for every builder request. It is never sent from the browser to the chat endpoint. If the key is absent or invalid, the endpoint returns HTTP 400 with a clear message — the provider is never constructed.
+</Callout>
 
 **How it works:**
 
-1. Go to **Studio → Agents → New agent** (`/agents/new`).
-2. Click the **Chat to build** toggle (top-right of the page header).
-3. On first use, connect your Claude API key — it is stored in your workspace secrets backend under the key name `AGENTBREEDER_CLAUDE_BUILDER_KEY` (never in the database, never returned to the browser, never logged).  Get a key at [console.anthropic.com](https://console.anthropic.com).
-4. Describe what you want your agent to do.  Claude asks a few focused questions (framework, model, deploy target) and then calls the `submit_agent_spec` tool to emit a structured spec.
-5. The backend validates the spec against the `agent.yaml` JSON schema before showing it to you.  A "Create agent" button appears only when the spec is valid.
-6. Clicking **Create agent** runs the spec through the same `POST /api/v1/agents/from-yaml` path used by the form wizard — no shortcuts or schema bypasses.
+1. Land on Studio's home page or go to **Agents → New agent** (`/agents/new`). If you have no agents the empty-state prompt is already focused — just start typing.
+2. Describe what you want your agent to do. The builder's responses stream back token-by-token as Claude writes them — no waiting for the full reply.
+3. Claude asks 3–5 focused follow-up questions (framework, model, deploy target, any tools or integrations you need) and then emits a structured spec.
+4. The backend validates the spec against the `agent.yaml` JSON schema before surfacing it to you. A **Deploy now** button appears only when the spec is valid.
+5. Click **Deploy now**. Live deploy logs stream directly in the conversation thread — you can watch each of the 8 pipeline steps (parse → RBAC → resolve → build → provision → health check → register → endpoint) as they run.
+6. When the pipeline finishes, the endpoint URL is posted in the thread. Click it to open the agent, or copy it into `agentbreeder chat` or your app.
 
-**Security notes:**
+**Inline setup — credentials, providers, and MCP servers without leaving the thread:**
 
-- Your Claude API key is read server-side on every request from the workspace secrets backend.  It is never sent from the browser to the chat endpoint.
+When the agent you describe needs something the builder can't supply on its own — an API key or secret, a model-provider key, or an MCP server — a secure **setup card** appears right in the conversation. You never get bounced to a settings page.
+
+- **Secret** (e.g. `ZENDESK_API_KEY`): a password field stores the value straight into your workspace secrets backend (masked, server-side). The spec records only the **name** under `secrets:` — never the value.
+- **Provider key** (e.g. `openai`): the key is stored as a workspace secret (`{provider}/api-key`) so the chosen model can authenticate at deploy time.
+- **MCP server** (e.g. `zendesk`): supply the endpoint and transport; the builder registers it via `POST /mcp-servers` and runs tool discovery, then the agent can reference its tools.
+
+Once you connect (or **Skip**) the card, the conversation continues automatically and Claude references the new dependency by name in the final spec — which is re-validated by `validate_config_yaml()` like everything else. Captured values are never kept in browser state and never appear in the generated `agent.yaml`.
+
+**Security and limits:**
+
+- Your Claude API key is read server-side on every request from the workspace secrets backend. It is never sent from the browser to the chat endpoint.
 - If the key is absent or invalid, the endpoint returns HTTP 400 with a clear "add your key" message — the provider is never constructed.
 - The conversation is bounded: maximum 40 turns and 100 000 total characters.
-- Claude's output (the agent spec) is always re-validated by `validate_config_yaml()` on the backend before `valid: true` is returned.  Untrusted model output cannot bypass the schema.
+- Claude's output (the agent spec) is always re-validated by `validate_config_yaml()` on the backend before `valid: true` is returned. Untrusted model output cannot bypass the schema.
+- Clicking **Deploy now** runs the spec through the same `POST /api/v1/agents/from-yaml` path used by the form wizard — no shortcuts or schema bypasses.
+
+**On AgentBreeder cloud:** The chat builder works identically at [console.agentbreeder.io](https://console.agentbreeder.io). The cloud control plane proxies requests to the OSS builder and meters each conversational turn against your plan's daily quota.
 
 ---
 

--- a/website/content/docs/how-to.mdx
+++ b/website/content/docs/how-to.mdx
@@ -144,6 +144,18 @@ Once you connect (or **Skip**) the card, the conversation continues automaticall
 
 **On AgentBreeder cloud:** The chat builder works identically at [console.agentbreeder.io](https://console.agentbreeder.io). The cloud control plane proxies requests to the OSS builder and meters each conversational turn against your plan's daily quota.
 
+**Eject to code — when YAML isn't enough:**
+
+Once the chat has produced a validated `agent.yaml`, an **Eject to code** button appears in the thread. Clicking it hands the project to a coding agent that writes real code — `agent.py`, a `tools/` directory, and tests — for when you need custom logic beyond what YAML config can express. This is tier mobility in the builder itself: **No Code → Low Code (YAML) → Full Code**, without leaving the conversation.
+
+- **Pick your engine.** Choose **Claude** (a Claude Agent SDK-style agentic loop) or **Codex** (OpenAI), selectable per session. Claude uses the same BYO key the chat builder already reads from your workspace secrets backend; Codex uses a separate OpenAI key stored alongside it.
+- **Watch the code stream in.** The coding agent writes files into a sandbox workspace and you see live file diffs land in a new **Code** tab in the chat. It can run the generated tests in the sandbox and iterate on failures before handing back.
+- **Deploy from the same thread.** When the code is ready, deploy it straight from the conversation. This is the same governed deploy as everywhere else — RBAC, audit trail, and registry registration all apply.
+
+<Callout type="warning" title="Code generation runs in a local sandbox">
+  Eject-to-code executes in a **local** sandbox on the machine running Studio — `AGENTBREEDER_SANDBOX=local` is the default. In cloud / multi-tenant mode this is gated off: the eject endpoint returns **HTTP 409** until the managed cloud sandbox ships in a later release. Self-hosted users with `AGENTBREEDER_SANDBOX=local` get the full flow today; on [console.agentbreeder.io](https://console.agentbreeder.io) the **Eject to code** button is disabled for now.
+</Callout>
+
 ---
 
 ## Deploy to different targets

--- a/website/content/docs/quickstart.mdx
+++ b/website/content/docs/quickstart.mdx
@@ -117,6 +117,23 @@ agentbreeder quickstart --cloud aws    # also: gcp | azure
 
 ---
 
+## Build from a conversation
+
+The fastest way to create and deploy an agent is through the conversational builder in Studio. No `agent.yaml` editing required.
+
+1. Open Studio at [http://localhost:3001](http://localhost:3001) and go to the **Agents** page. If you have no agents yet, the empty-state prompt "What do you want to build today?" is already waiting — type there or pick one of the example starters.
+2. The builder interviews you with 3–5 focused questions (framework, model, deploy target, any tools you need) — answers stream back token-by-token as you type.
+3. When it has enough information it generates a complete `agent.yaml`, shown inline in the thread for you to review or tweak.
+4. Click **Deploy now**. Live deploy logs stream directly in the conversation thread. When the pipeline finishes you get a live endpoint link — paste it straight into `agentbreeder chat` or your app.
+
+<Callout type="info" title="Claude API key required">
+  The chat builder drives a Claude model to generate your `agent.yaml`. You need to add your Claude API key once: go to **Settings → Secrets** and paste the key under **Claude API Key**. It is stored securely in the workspace secrets backend — it is never written to the database, never returned to the browser, and never logged. Get a key at [console.anthropic.com](https://console.anthropic.com).
+
+  The builder works identically whether you are running locally or on AgentBreeder cloud at [console.agentbreeder.io](https://console.agentbreeder.io).
+</Callout>
+
+---
+
 ## Build your own agent
 
 ```bash
@@ -172,5 +189,6 @@ The 8-step deploy pipeline (parse → RBAC → resolve deps → build container 
 | Deploy to AWS / GCP / Azure / Kubernetes | [How-To: Deploy →](how-to#deploy-to-different-targets) |
 | Add knowledge bases (RAG / GraphRAG) | [RAG →](rag) · [GraphRAG →](graphrag) |
 | Add tools / MCP servers | [MCP servers →](mcp-servers) |
+| Chat to build (conversational) | [How-To: Chat to build →](how-to#chat-to-build-byo-claude-key) |
 | Visual builder | [No Code →](no-code) |
 | Python / TypeScript SDK | [Full Code →](full-code) |


### PR DESCRIPTION
## Studio Conversational Builder (Waves 1–4)

A Lovable-style chat agent-builder for AgentBreeder Studio: converse to a validated `agent.yaml`, eject to real code in a sandbox, and deploy through the governed pipeline — all from one thread. This PR lands the full epic (W1–W4).

### What's in it

**W1–W2 — Conversational builder** (`3d67880`)
- Streaming interview that produces a validated `agent.yaml`, deploy-from-chat, and inline setup (secret / MCP / provider) requests mid-conversation.

**W3 — Eject-to-code**
- `Sandbox` interface + `LocalSandbox` with path containment and per-file/exec caps; env-gated mode selection (`AGENTBREEDER_SANDBOX`).
- Provider-loop coding driver (no vendor SDK deps) with bounds + diffs; Claude and Codex coding-engine strategies.
- `BuilderSession` table + service + SSE event bus; session routes (`/messages` interview, `/eject`, `/deploy` via the governed pipeline, aggregate `/stream`).
- Frontend: `ChatBuildPanel` Code artifact tab + file tree/viewer; gated eject e2e.

**W4 — Cloud sandbox, analytics, parity**
- **CloudSandbox** over a pluggable `SandboxBackend` (`A2`) with an `E2BBackend` managed-microVM adapter behind the optional `[cloud]` extra (`A3`); `_make_sandbox` now serves the cloud microVM when `AGENTBREEDER_SANDBOX=cloud` and emits `sandbox_seconds`/`code` telemetry frames (`A4`).
- **Analytics funnel**: PII-free `AnalyticsEvent` model + migration `025` (`C1`); ingest + funnel endpoint with p50/p90 time-to-first-deploy and engine-scorecard helpers (`C2/C3`); frontend analytics seam + api client (`C4`); **Studio › Builder** funnel view using the house CSS-bar idiom — no new chart dep (`C5`).
- **Codex eject gated e2e** for engine parity (`D1`).
- **Security hardening** (from automated review): team-scoped funnel queries (tenant isolation), defensive numeric coercion against poisoned aggregation input, server-side event allowlist, and typed-UUID validation (`1ca52de`).

### Security & privacy
- Cloud code generation runs in an isolated per-session microVM; client-side guards (path containment, byte/exec caps, default-deny egress) apply before the backend runs anything. No long-lived secrets in the workspace.
- Analytics events are structural and PII-free (no message/prompt bodies) and the funnel view is team-scoped.

### Testing
- Full backend suite green: **5657 passed, 10 skipped** (e2b + Codex e2e skip without keys).
- Frontend: vitest + typecheck + `vite build` clean.
- Docs synced: `website/content/docs/how-to.mdx` (sandbox env vars, sandbox-minute metering, Builder analytics).

### Companion
Cloud sandbox-minute metering ships in a stacked `agentbreeder-cloud` PR (`feat/w4-sandbox-metering`): quota scopes + migration, `charge_sandbox_minutes`, and eject metering (429 pre-check + frame-sniff + post-stream charge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
