### PR TITLE
fix(packaging): ship examples/quickstart/*.yaml in wheel

### DIFF
--- a/.github/workflows/smoke-quickstart.yml
+++ b/.github/workflows/smoke-quickstart.yml
@@ -112,9 +112,14 @@ jobs:
           import zipfile, sys
           names = zipfile.ZipFile('$WHEEL').namelist()
           deploy_files = [n for n in names if n.startswith('deploy/') and n.endswith('.yml')]
+          example_yamls = [n for n in names if n.startswith('examples/quickstart/') and n.endswith('.yaml')]
           print('deploy/*.yml in wheel:', deploy_files)
+          print('examples/quickstart/*.yaml in wheel:', example_yamls)
           if not deploy_files:
               print('FAIL: no deploy/*.yml files in wheel — Bug #1 has regressed')
+              sys.exit(1)
+          if not example_yamls:
+              print('FAIL: no examples/quickstart/*.yaml files in wheel — quickstart Step 7 would no-op')
               sys.exit(1)
           "
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 ## [Unreleased]
 
 ### Fixed
+- **Packaging follow-up to issue #560.** `examples/quickstart/*.yaml` now ships
+  in the published wheel via hatch `force-include`; `Dockerfile` COPYs
+  `examples/quickstart/` so in-container wheel builds work. Discovered while
+  testing the freshly-published `agentbreeder==2.7.1`: `quickstart` Step 7
+  (Deploying Sample Agents) silently no-op'd on a pipx install because the
+  examples dir didn't exist in site-packages. Also makes `_register_agents()`
+  emit an explicit warning if `EXAMPLES_QS` is empty so the silent no-op can't
+  hide again, and extends the smoke workflow with an
+  `examples/quickstart/*.yaml` guard alongside the existing `deploy/*.yml` one.
+
+### Fixed
 - **Quickstart + how-to happy-path bundle (issue #560).** Resolves 15 bugs and
   6 doc errors uncovered by the docs-vs-reality audit:
   - PyPI wheel now ships `deploy/` (hatchling `force-include`); `Dockerfile`

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY sdk/ sdk/
 COPY alembic/ alembic/
 COPY alembic.ini ./
 COPY deploy/ deploy/
+COPY examples/quickstart/ examples/quickstart/
 
 # Install Python dependencies
 RUN pip install --no-cache-dir .

--- a/cli/commands/quickstart.py
+++ b/cli/commands/quickstart.py
@@ -970,6 +970,17 @@ def _register_agents() -> list[dict]:
     """Register sample agents in the platform registry."""
     agents = []
     yamls = sorted(EXAMPLES_QS.glob("*.yaml"))
+    if not yamls:
+        # The wheel ships examples/quickstart/ via hatch force-include; if the
+        # dir is empty here we're on a broken install. Surface explicitly so
+        # the silent no-op doesn't hide the registration miss.
+        _warn(
+            f"No sample agent YAMLs found at {EXAMPLES_QS} — "
+            "the wheel may be missing examples/quickstart/. "
+            "Reinstall agentbreeder or report this at "
+            "https://github.com/agentbreeder/agentbreeder/issues."
+        )
+        return []
     for yaml_path in yamls:
         try:
             content = yaml_path.read_text()

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -7429,9 +7429,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,12 @@ packages = ["engine", "api", "cli", "registry", "connectors"]
 # FileNotFoundError on docker-compose.quickstart.yml.
 [tool.hatch.build.targets.wheel.force-include]
 "deploy" = "deploy"
+# examples/quickstart/ ships with the wheel because cli/commands/quickstart.py
+# resolves EXAMPLES_QS = REPO_ROOT / "examples" / "quickstart" at runtime to
+# register + deploy the sample agents (assistant, search-agent, a2a-orchestrator,
+# etc.). Without this, Step 7 of `agentbreeder quickstart` silently no-ops on a
+# pipx install — the dir doesn't exist in site-packages.
+"examples/quickstart" = "examples/quickstart"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Follow-up to #561. Discovered while testing the freshly-published
`agentbreeder==2.7.1` from PyPI: `agentbreeder quickstart` Step 7
(Deploying Sample Agents) silently no-ops on a pipx install because
\`EXAMPLES_QS = REPO_ROOT / "examples" / "quickstart"\` resolves to a
non-existent path in site-packages.

The wheel only ships \`deploy/\` (force-included for Bug #1 in #560),
not \`examples/\`. This was a pre-existing bug (every wheel back through
2.6.0 has it), but the Bug #1 fix unblocked install enough that the
quickstart now reaches Step 7 to expose the silent registration miss.

Repro on `agentbreeder==2.7.1`:
- \`pipx install agentbreeder==2.7.1\`
- \`agentbreeder quickstart --yes --no-browser --no-ollama\`
- Step 7 logs: \`⚠ Agent registration via API failed — agents listed in examples/quickstart/\`
- \`agentbreeder list agents\` → \`No agents found.\`

## Changes

- **\`pyproject.toml\`**: force-include \`examples/quickstart\` so the 6
  sample yamls ship in the wheel.
- **\`cli/commands/quickstart.py\`**: surface an explicit warning when
  \`EXAMPLES_QS\` is empty so the silent no-op can't hide again.
- **\`.github/workflows/smoke-quickstart.yml\`**: assert
  \`examples/quickstart/*.yaml\` presence alongside the existing
  \`deploy/*.yml\` guard.

## Verification

Locally rebuilt wheel includes all 6 sample yamls:
\`a2a-orchestrator.yaml\`, \`assistant-agent.yaml\`, \`search-agent.yaml\`,
plus 3 nested agent bundles (graph-agent, rag-agent, search-agent).

## Test plan

- [ ] CI: smoke-quickstart job asserts \`examples/quickstart/*.yaml\` in wheel
- [ ] Manual: \`pipx install <wheel>\` → \`agentbreeder quickstart\` reaches "Quickstart Complete" with "✓ Registered 3 agent(s)"
- [ ] \`agentbreeder list agents\` shows the 3 quickstart agents

Generated with [Claude Code](https://claude.com/claude-code)